### PR TITLE
Fix/prepare husky install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "prepare": "husky install",
     "postinstall": "rimraf node_modules/@polymathnetwork/polymesh-sdk/node_modules/@polkadot/{util-crypto,wasm-crypto}",
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
`prepare` gets ran when a user runs `yarn`. This makes it so husky gets installed, which will help enforce good commit hygiene.

I didn't know about husky and wasn't running it. With this added it will make sure anyone committing to the project will have the husky checks ran.
