### PR TITLE
fix: 🐛 Run husky install as prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "prepare": "husky install",
     "postinstall": "rimraf node_modules/@polymathnetwork/polymesh-sdk/node_modules/@polkadot/{util-crypto,wasm-crypto}",
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
Run `husky install` as prepare script. When a user runs `yarn` husky git
hooks will get configured.