### PR TITLE
fix: 🐛 Build assets in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN yarn --frozen-lockfile
 COPY --chown=node:node . /home/node
 
 USER node
+RUN yarn build
 ENTRYPOINT ["/bin/bash", "./docker-entrypoint.sh"]


### PR DESCRIPTION
Container would complain about missing /dist directory

### Changelog / Description 

Add `yarn build` to dockerfile

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
