### PR TITLE
fix: 🐛 Allow for space after , when passing mnemonics and dids

### DIFF
--- a/src/relayer-accounts/config/relayer-accounts.config.ts
+++ b/src/relayer-accounts/config/relayer-accounts.config.ts
@@ -5,10 +5,8 @@ import { registerAs } from '@nestjs/config';
 export default registerAs('relayer-accounts', () => {
   const { RELAYER_DIDS, RELAYER_MNEMONICS } = process.env;
 
-  /* eslint-disable @typescript-eslint/no-non-null-assertion */
-  const dids = RELAYER_DIDS?.split(',') || [];
-  const mnemonics = RELAYER_MNEMONICS?.split(',') || [];
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+  const dids = RELAYER_DIDS?.split(',').map(d => d.trim()) || [];
+  const mnemonics = RELAYER_MNEMONICS?.split(',').map(m => m.trim()) || [];
 
   const accounts: Record<string, string> = {};
 


### PR DESCRIPTION
### JIRA Link 

Small issue I found when working in polymesh-local, but it stops the services from starting when passing an argument that looks right.

https://github.com/PolymathNetwork/polymesh-local/pull/29#discussion_r796631108

### Changelog / Description 

Trim RELAYER_DIDS + RELAYER_MNEMONIC args so people can use spaces after `,` in lists

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
