### PR TITLE
chore: 🤖 Allow for empty strings for signer configuration

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,14 +26,14 @@ import { SigningModule } from '~/signing/signing.module';
         POLYMESH_NODE_URL: Joi.required(),
         POLYMESH_MIDDLEWARE_URL: Joi.string(),
         POLYMESH_MIDDLEWARE_API_KEY: Joi.string(),
-        LOCAL_SIGNERS: Joi.string(),
-        LOCAL_MNEMONICS: Joi.string(),
-        VAULT_TOKEN: Joi.string(),
-        VAULT_URL: Joi.string(),
+        LOCAL_SIGNERS: Joi.string().allow(''),
+        LOCAL_MNEMONICS: Joi.string().allow(''),
+        VAULT_TOKEN: Joi.string().allow(''),
+        VAULT_URL: Joi.string().allow(''),
       })
         .and('POLYMESH_MIDDLEWARE_URL', 'POLYMESH_MIDDLEWARE_API_KEY')
         .and('LOCAL_SIGNERS', 'LOCAL_MNEMONICS')
-        .nand('LOCAL_SIGNERS', 'VAULT_TOKEN'),
+        .and('VAULT_TOKEN', 'VAULT_URL'),
     }),
     AssetsModule,
     PolymeshModule,


### PR DESCRIPTION
In polymesh-local docker-compose makes it difficult to pass a non empty
string for VAULT_URL and VAULT_TOKEN when they are not set.

Ideally `nand` would be left but wouldn't error on empty string values.
