### PR TITLE
chore: 🤖 publish to association docker hub account

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.ASSOCIATION_DOCKER_USERNAME }}
+          password: ${{ secrets.ASSOCIATION_DOCKER_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ secrets.DOCKER_HUB_REPO }}
+          images: ${{ secrets.ASSOCIATION_DOCKER_HUB_REPO }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
### JIRA Link 

[DA-413](https://polymesh.atlassian.net/browse/DA-413)

### Changelog / Description 

migrate images to be published to the new polymesh association docker hub instead of the deprecated polymathnet one

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
