### PR TITLE
feat: 🎸 Allow optional `memo` field while creating instruction

### DIFF
--- a/src/settlements/dto/create-instruction.dto.ts
+++ b/src/settlements/dto/create-instruction.dto.ts
@@ -2,7 +2,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { Type } from 'class-transformer';
-import { IsDate, IsOptional, ValidateNested } from 'class-validator';
+import { IsByteLength, IsDate, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { ToBigNumber } from '~/common/decorators/transformation';
 import { IsBigNumber } from '~/common/decorators/validation';
@@ -40,4 +40,13 @@ export class CreateInstructionDto extends TransactionBaseDto {
   @IsBigNumber()
   @ToBigNumber()
   readonly endBlock?: BigNumber;
+
+  @ApiPropertyOptional({
+    description: 'Identifier string to help differentiate instructions. Maximum 32 bytes',
+    example: 'Transfer of GROWTH Asset',
+  })
+  @IsOptional()
+  @IsString()
+  @IsByteLength(0, 32)
+  readonly memo?: string;
 }

--- a/src/settlements/models/instruction.model.ts
+++ b/src/settlements/models/instruction.model.ts
@@ -72,6 +72,12 @@ export class InstructionModel {
   @Type(() => EventIdentifierModel)
   readonly eventIdentifier?: EventIdentifierModel;
 
+  @ApiPropertyOptional({
+    description: 'Identifier string provided while creating the Instruction',
+    example: 'Transfer of GROWTH Asset',
+  })
+  readonly memo?: string;
+
   @ApiProperty({
     description: 'List of Legs in the Instruction',
     type: LegModel,

--- a/src/settlements/settlements.util.ts
+++ b/src/settlements/settlements.util.ts
@@ -16,7 +16,7 @@ export async function createInstructionModel(instruction: Instruction): Promise<
     instruction.getStatus(),
   ]);
 
-  const { status, createdAt, tradeDate, valueDate, venue, type } = details;
+  const { status, createdAt, tradeDate, valueDate, venue, type, memo } = details;
 
   let instructionModelParams: ConstructorParameters<typeof InstructionModel>[0] = {
     status,
@@ -41,6 +41,10 @@ export async function createInstructionModel(instruction: Instruction): Promise<
 
   if (tradeDate !== null) {
     instructionModelParams = { ...instructionModelParams, tradeDate };
+  }
+
+  if (memo !== null) {
+    instructionModelParams = { ...instructionModelParams, memo };
   }
 
   if (details.type === InstructionType.SettleOnBlock) {


### PR DESCRIPTION
### JIRA Link 

DA-435

### Changelog / Description 

- Allow optional `memo` field while creating instruction
- Also, returns the `memo` value in `InstructionModel`

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
