### PR TITLE
feat: 🎸 Endpoint to get account subsidy

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@golevelup/ts-jest": "^0.3.3",
     "@nestjs/axios": "^0.0.8",
     "@nestjs/common": "^8.4.6",
     "@nestjs/config": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@golevelup/ts-jest": "^0.3.3",
     "@nestjs/axios": "^0.0.8",
     "@nestjs/common": "^8.4.6",
     "@nestjs/config": "^2.1.0",
@@ -50,6 +49,7 @@
     "@babel/plugin-transform-modules-commonjs": "7.15.0",
     "@commitlint/cli": "12.1.4",
     "@commitlint/config-conventional": "12.1.4",
+    "@golevelup/ts-jest": "^0.3.3",
     "@nestjs/cli": "^8.2.6",
     "@nestjs/schematics": "^8.0.11",
     "@nestjs/testing": "^8.4.6",

--- a/src/accounts/accounts.controller.spec.ts
+++ b/src/accounts/accounts.controller.spec.ts
@@ -11,7 +11,12 @@ import { AccountsService } from '~/accounts/accounts.service';
 import { ExtrinsicModel } from '~/common/models/extrinsic.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { AccountModel } from '~/identities/models/account.model';
-import { MockAsset, MockPortfolio, mockResponseObject, MockSubsidy } from '~/test-utils/mocks';
+import {
+  createMockResponseObject,
+  MockAsset,
+  MockPortfolio,
+  MockSubsidy,
+} from '~/test-utils/mocks';
 import { MockAccountsService } from '~/test-utils/service-mocks';
 
 describe('AccountsController', () => {
@@ -162,7 +167,7 @@ describe('AccountsController', () => {
     let mockResponse: DeepMocked<Response>;
 
     beforeEach(() => {
-      mockResponse = mockResponseObject();
+      mockResponse = createMockResponseObject();
     });
     it(`should return the ${HttpStatus.NO_CONTENT} if the Account has no subsidy`, async () => {
       mockAccountsService.getSubsidy.mockResolvedValue(null);

--- a/src/accounts/accounts.controller.spec.ts
+++ b/src/accounts/accounts.controller.spec.ts
@@ -1,13 +1,17 @@
+import { DeepMocked } from '@golevelup/ts-jest';
+import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { Order, TransactionOrderFields } from '@polymeshassociation/polymesh-sdk/middleware/types';
 import { PermissionType, TxGroup, TxTags } from '@polymeshassociation/polymesh-sdk/types';
+import { Response } from 'express';
 
 import { AccountsController } from '~/accounts/accounts.controller';
 import { AccountsService } from '~/accounts/accounts.service';
 import { ExtrinsicModel } from '~/common/models/extrinsic.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
-import { MockAsset, MockPortfolio } from '~/test-utils/mocks';
+import { AccountModel } from '~/identities/models/account.model';
+import { MockAsset, MockPortfolio, mockResponseObject, MockSubsidy } from '~/test-utils/mocks';
 import { MockAccountsService } from '~/test-utils/service-mocks';
 
 describe('AccountsController', () => {
@@ -150,6 +154,38 @@ describe('AccountsController', () => {
           values: [TxTags.asset.AddDocuments],
         },
         transactionGroups: [TxGroup.Issuance, TxGroup.StoManagement],
+      });
+    });
+  });
+
+  describe('getSubsidy', () => {
+    let mockResponse: DeepMocked<Response>;
+
+    beforeEach(() => {
+      mockResponse = mockResponseObject();
+    });
+    it(`should return the ${HttpStatus.NO_CONTENT} if the Account has no subsidy`, async () => {
+      mockAccountsService.getSubsidy.mockResolvedValue(null);
+
+      await controller.getSubsidy({ account: 'someAccount' }, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NO_CONTENT);
+    });
+
+    it('should return the Account Subsidy', async () => {
+      const subsidyWithAllowance = {
+        subsidy: new MockSubsidy(),
+        allowance: new BigNumber(10),
+      };
+      mockAccountsService.getSubsidy.mockResolvedValue(subsidyWithAllowance);
+
+      await controller.getSubsidy({ account: 'someAccount' }, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        beneficiary: new AccountModel({ address: 'beneficiary' }),
+        subsidizer: new AccountModel({ address: 'subsidizer' }),
+        allowance: new BigNumber(10),
       });
     });
   });

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, HttpStatus, Param, Post, Query, Res } from '@nestjs/common';
 import {
+  ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -7,13 +8,15 @@ import {
   ApiTags,
   ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
+import { Response } from 'express';
 
 import { AccountsService } from '~/accounts/accounts.service';
-import { createPermissionsModel } from '~/accounts/accounts.util';
+import { createPermissionsModel, createSubsidyModel } from '~/accounts/accounts.util';
 import { AccountParamsDto } from '~/accounts/dto/account-params.dto';
 import { TransactionHistoryFiltersDto } from '~/accounts/dto/transaction-history-filters.dto';
 import { TransferPolyxDto } from '~/accounts/dto/transfer-polyx.dto';
 import { PermissionsModel } from '~/accounts/models/permissions.model';
+import { SubsidyModel } from '~/accounts/models/subsidy.model';
 import { BalanceModel } from '~/assets/models/balance.model';
 import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
 import { ExtrinsicModel } from '~/common/models/extrinsic.model';
@@ -121,5 +124,37 @@ export class AccountsController {
   async getPermissions(@Param() { account }: AccountParamsDto): Promise<PermissionsModel> {
     const permissions = await this.accountsService.getPermissions(account);
     return createPermissionsModel(permissions);
+  }
+
+  @ApiOperation({
+    summary: 'Get Account Subsidy',
+    description:
+      'The endpoint retrieves the subsidized balance of this Account and the subsidizer Account',
+  })
+  @ApiParam({
+    name: 'account',
+    description: 'The Account address whose subsidy is to be fetched',
+    type: 'string',
+    example: '5GwwYnwCYcJ1Rkop35y7SDHAzbxrCkNUDD4YuCUJRPPXbvyV',
+  })
+  @ApiOkResponse({
+    description: 'Subsidy details for the Account',
+    type: SubsidyModel,
+  })
+  @ApiNoContentResponse({
+    description: 'Account is not being subsidized',
+  })
+  @ApiNotFoundResponse({
+    description: 'Account is not associated with any Identity',
+  })
+  @Get(':account/subsidy')
+  async getSubsidy(@Param() { account }: AccountParamsDto, @Res() res: Response): Promise<void> {
+    const result = await this.accountsService.getSubsidy(account);
+
+    if (result) {
+      res.status(HttpStatus.OK).json(createSubsidyModel(result));
+    } else {
+      res.status(HttpStatus.NO_CONTENT).send({});
+    }
   }
 }

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -144,9 +144,6 @@ export class AccountsController {
   @ApiNoContentResponse({
     description: 'Account is not being subsidized',
   })
-  @ApiNotFoundResponse({
-    description: 'Account is not associated with any Identity',
-  })
   @Get(':account/subsidy')
   async getSubsidy(@Param() { account }: AccountParamsDto, @Res() res: Response): Promise<void> {
     const result = await this.accountsService.getSubsidy(account);

--- a/src/accounts/accounts.service.spec.ts
+++ b/src/accounts/accounts.service.spec.ts
@@ -18,7 +18,13 @@ import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { SigningModule } from '~/signing/signing.module';
-import { MockAccount, MockAsset, MockPolymesh, MockTransaction } from '~/test-utils/mocks';
+import {
+  MockAccount,
+  MockAsset,
+  MockPolymesh,
+  MockSubsidy,
+  MockTransaction,
+} from '~/test-utils/mocks';
 import { mockTransactionsProvider, MockTransactionsService } from '~/test-utils/service-mocks';
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
@@ -281,6 +287,33 @@ describe('AccountsService', () => {
 
         findOneSpy.mockRestore();
       });
+    });
+  });
+
+  describe('getSubsidy', () => {
+    const mockSubsidyWithAllowance = {
+      subsidy: new MockSubsidy(),
+      allowance: new BigNumber(10),
+    };
+
+    let findOneSpy: jest.SpyInstance;
+    let mockAccount: MockAccount;
+
+    beforeEach(() => {
+      mockAccount = new MockAccount();
+      findOneSpy = jest.spyOn(service, 'findOne');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findOneSpy.mockResolvedValue(mockAccount as any);
+    });
+
+    it('should return the Account Subsidy', async () => {
+      mockAccount.getSubsidy.mockResolvedValue(mockSubsidyWithAllowance);
+
+      const result = await service.getSubsidy('address');
+
+      expect(result).toEqual(mockSubsidyWithAllowance);
+
+      findOneSpy.mockRestore();
     });
   });
 });

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -28,7 +28,7 @@ export class AccountsService {
       polymeshService: { polymeshApi },
     } = this;
     try {
-      return polymeshApi.accountManagement.getAccount({ address });
+      return await polymeshApi.accountManagement.getAccount({ address });
     } catch (err: unknown) {
       if (isPolymeshError(err)) {
         const { code } = err;

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -6,6 +6,7 @@ import {
   ExtrinsicData,
   Permissions,
   ResultSet,
+  SubsidyWithAllowance,
 } from '@polymeshassociation/polymesh-sdk/types';
 import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
@@ -88,5 +89,10 @@ export class AccountsService {
       }
       throw err;
     }
+  }
+
+  public async getSubsidy(address: string): Promise<SubsidyWithAllowance | null> {
+    const account = await this.findOne(address);
+    return account.getSubsidy();
   }
 }

--- a/src/accounts/accounts.util.spec.ts
+++ b/src/accounts/accounts.util.spec.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
   Account,
   Asset,
@@ -5,11 +6,16 @@ import {
   PermissionedAccount,
   Permissions,
   PermissionType,
+  SubsidyWithAllowance,
   TxGroup,
   TxTags,
 } from '@polymeshassociation/polymesh-sdk/types';
 
-import { createPermissionedAccountModel, createPermissionsModel } from '~/accounts/accounts.util';
+import {
+  createPermissionedAccountModel,
+  createPermissionsModel,
+  createSubsidyModel,
+} from '~/accounts/accounts.util';
 import { AssetPermissionsModel } from '~/accounts/models/asset-permissions.model';
 import { PermissionsModel } from '~/accounts/models/permissions.model';
 import { PortfolioPermissionsModel } from '~/accounts/models/portfolio-permissions.model';
@@ -97,6 +103,28 @@ describe('createPermissionedAccountModel', () => {
     expect(result).toEqual({
       account: new AccountModel({ address }),
       permissions: new PermissionsModel(permissions),
+    });
+  });
+});
+
+describe('createSubsidyModel', () => {
+  it('should transform SubsidyWithAllowance to SubsidyModel', () => {
+    const subsidyWithAllowance = {
+      beneficiary: {
+        address: 'beneficiary',
+      },
+      subsidizer: {
+        address: 'subsidizer',
+      },
+      allowance: new BigNumber(10),
+    } as unknown as SubsidyWithAllowance;
+
+    const result = createSubsidyModel(subsidyWithAllowance);
+
+    expect(result).toEqual({
+      beneficiary: new AccountModel({ address: 'beneficiary' }),
+      subsidizer: new AccountModel({ address: 'subsidizer' }),
+      allowance: new BigNumber(10),
     });
   });
 });

--- a/src/accounts/accounts.util.spec.ts
+++ b/src/accounts/accounts.util.spec.ts
@@ -22,7 +22,7 @@ import { PortfolioPermissionsModel } from '~/accounts/models/portfolio-permissio
 import { TransactionPermissionsModel } from '~/accounts/models/transaction-permissions.model';
 import { AccountModel } from '~/identities/models/account.model';
 import { PortfolioIdentifierModel } from '~/portfolios/models/portfolio-identifier.model';
-import { MockAccount, MockAsset, MockPortfolio } from '~/test-utils/mocks';
+import { MockAccount, MockAsset, MockPortfolio, MockSubsidy } from '~/test-utils/mocks';
 
 describe('createPermissionsModel', () => {
   it('should transform Permissions to PermissionsModel', () => {
@@ -110,12 +110,7 @@ describe('createPermissionedAccountModel', () => {
 describe('createSubsidyModel', () => {
   it('should transform SubsidyWithAllowance to SubsidyModel', () => {
     const subsidyWithAllowance = {
-      beneficiary: {
-        address: 'beneficiary',
-      },
-      subsidizer: {
-        address: 'subsidizer',
-      },
+      subsidy: new MockSubsidy(),
       allowance: new BigNumber(10),
     } as unknown as SubsidyWithAllowance;
 

--- a/src/accounts/accounts.util.ts
+++ b/src/accounts/accounts.util.ts
@@ -1,9 +1,14 @@
-import { PermissionedAccount, Permissions } from '@polymeshassociation/polymesh-sdk/types';
+import {
+  PermissionedAccount,
+  Permissions,
+  SubsidyWithAllowance,
+} from '@polymeshassociation/polymesh-sdk/types';
 
 import { AssetPermissionsModel } from '~/accounts/models/asset-permissions.model';
 import { PermissionedAccountModel } from '~/accounts/models/permissioned-account.model';
 import { PermissionsModel } from '~/accounts/models/permissions.model';
 import { PortfolioPermissionsModel } from '~/accounts/models/portfolio-permissions.model';
+import { SubsidyModel } from '~/accounts/models/subsidy.model';
 import { TransactionPermissionsModel } from '~/accounts/models/transaction-permissions.model';
 import { AccountModel } from '~/identities/models/account.model';
 import { createPortfolioIdentifierModel } from '~/portfolios/portfolios.util';
@@ -56,5 +61,21 @@ export function createPermissionedAccountModel(
   return new PermissionedAccountModel({
     account: new AccountModel({ address }),
     permissions: createPermissionsModel(permissions),
+  });
+}
+
+export function createSubsidyModel(subsidy: SubsidyWithAllowance): SubsidyModel {
+  const {
+    subsidy: {
+      beneficiary: { address: beneficiaryAddress },
+      subsidizer: { address: subsidizerAddress },
+    },
+    allowance,
+  } = subsidy;
+
+  return new SubsidyModel({
+    beneficiary: new AccountModel({ address: beneficiaryAddress }),
+    subsidizer: new AccountModel({ address: subsidizerAddress }),
+    allowance,
   });
 }

--- a/src/accounts/models/subsidy.model.ts
+++ b/src/accounts/models/subsidy.model.ts
@@ -1,0 +1,36 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+import { Type } from 'class-transformer';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+import { AccountModel } from '~/identities/models/account.model';
+
+export class SubsidyModel {
+  @ApiProperty({
+    description: 'Account whose transactions are being paid for',
+    type: AccountModel,
+  })
+  @Type(() => AccountModel)
+  readonly beneficiary: AccountModel;
+
+  @ApiProperty({
+    description: 'Account that is paying for the transactions',
+    type: AccountModel,
+  })
+  @Type(() => AccountModel)
+  readonly subsidizer: AccountModel;
+
+  @ApiProperty({
+    description: 'Amount of POLYX being subsidized',
+    type: 'string',
+    example: '12345',
+  })
+  @FromBigNumber()
+  readonly allowance: BigNumber;
+
+  constructor(model: SubsidyModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
   AuthorizationType,
@@ -8,6 +9,7 @@ import {
   TxTag,
   TxTags,
 } from '@polymeshassociation/polymesh-sdk/types';
+import { Response } from 'express';
 
 export type Mocked<T> = T &
   {
@@ -15,6 +17,13 @@ export type Mocked<T> = T &
       ? T[K] & jest.Mock<ReturnType<T[K]>, Args>
       : T[K];
   };
+
+export const mockResponseObject = (): DeepMocked<Response> => {
+  return createMock<Response>({
+    json: jest.fn().mockReturnThis(),
+    status: jest.fn().mockReturnThis(),
+  });
+};
 
 /* Polymesh SDK */
 
@@ -299,9 +308,19 @@ export class MockAuthorizations {
   getOne = jest.fn();
 }
 export class MockAccount {
-  address = 'address';
+  address: string;
   authorizations = new MockAuthorizations();
   getTransactionHistory = jest.fn();
   getPermissions = jest.fn();
   getIdentity = jest.fn();
+  getSubsidy = jest.fn();
+
+  constructor(address = 'address') {
+    this.address = address;
+  }
+}
+
+export class MockSubsidy {
+  beneficiary = new MockAccount('beneficiary');
+  subsidizer = new MockAccount('subsidizer');
 }

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -18,7 +18,7 @@ export type Mocked<T> = T &
       : T[K];
   };
 
-export const mockResponseObject = (): DeepMocked<Response> => {
+export const createMockResponseObject = (): DeepMocked<Response> => {
   return createMock<Response>({
     json: jest.fn().mockReturnThis(),
     status: jest.fn().mockReturnThis(),

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -61,6 +61,7 @@ export class MockAccountsService {
   getTransactionHistory = jest.fn();
   getPermissions = jest.fn();
   findOne = jest.fn();
+  getSubsidy = jest.fn();
 }
 
 export class MockEventsService {

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,6 +591,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@golevelup/ts-jest@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@golevelup/ts-jest/-/ts-jest-0.3.3.tgz#f9901f3eaaa7fd366d97538d2fc859ffc3052693"
+  integrity sha512-gut5EhD2S7W1p+C/IsUS1o0P5SHgxsN9TqHyRTjG+rfycniLNBfvIWZPEizpsTev/lR10/XOTpE0YicxPme2+Q==
+
 "@hapi/hoek@^9.0.0":
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"


### PR DESCRIPTION
### JIRA Link 

DA-6

### Changelog / Description 

Adds endpoint `/accounts/:account/subsidy` to fetch account subsidy

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
