### PR TITLE
docs: ✏️ use false investor uniqueness for create asset example

### DIFF
--- a/src/assets/dto/create-asset.dto.ts
+++ b/src/assets/dto/create-asset.dto.ts
@@ -55,7 +55,7 @@ export class CreateAssetDto extends TransactionBaseDto {
   @ApiProperty({
     description:
       'Specifies whether Identities must have an Investor Uniqueness Claim in order to be able to hold this Asset. More info [here](https://developers.polymesh.live/introduction/identity#polymesh-unique-identity-system-puis)',
-    example: true,
+    example: false,
   })
   @IsBoolean()
   readonly requireInvestorUniqueness: boolean;

--- a/src/settlements/dto/create-venue.dto.ts
+++ b/src/settlements/dto/create-venue.dto.ts
@@ -9,7 +9,7 @@ import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 export class CreateVenueDto extends TransactionBaseDto {
   @ApiProperty({
     description: 'Description of the Venue',
-    example: 'A place to exchange commodity Assets',
+    example: 'A place to exchange Assets',
   })
   @IsString()
   readonly description: string;


### PR DESCRIPTION
### JIRA Link 

N/A  

### Changelog / Description 

Default create asset to not require investor uniqueness. If enabled claims have to be made before settlements succeed, and it can be difficult to debug why they fail. 

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
