### PR TITLE
refactor: 💡 use const for signer in tests

### DIFF
--- a/src/accounts/accounts.controller.spec.ts
+++ b/src/accounts/accounts.controller.spec.ts
@@ -13,7 +13,7 @@ import { ExtrinsicModel } from '~/common/models/extrinsic.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { PermissionsLikeDto } from '~/identities/dto/permissions-like.dto';
 import { AccountModel } from '~/identities/models/account.model';
-import { testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import {
   createMockResponseObject,
   MockAsset,
@@ -21,6 +21,8 @@ import {
   MockSubsidy,
 } from '~/test-utils/mocks';
 import { MockAccountsService } from '~/test-utils/service-mocks';
+
+const { signer } = testValues;
 
 describe('AccountsController', () => {
   let controller: AccountsController;

--- a/src/accounts/accounts.controller.spec.ts
+++ b/src/accounts/accounts.controller.spec.ts
@@ -13,6 +13,7 @@ import { ExtrinsicModel } from '~/common/models/extrinsic.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { PermissionsLikeDto } from '~/identities/dto/permissions-like.dto';
 import { AccountModel } from '~/identities/models/account.model';
+import { testSigner as signer } from '~/test-utils/consts';
 import {
   createMockResponseObject,
   MockAsset,
@@ -63,7 +64,7 @@ describe('AccountsController', () => {
       mockAccountsService.transferPolyx.mockResolvedValue({ transactions });
 
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
         to: 'address',
         amount: new BigNumber(10),
         memo: 'Sample memo',
@@ -202,7 +203,7 @@ describe('AccountsController', () => {
       const transactions = ['transaction'];
       mockAccountsService.freezeSecondaryAccounts.mockResolvedValue({ transactions });
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
       };
 
       const result = await controller.freezeSecondaryAccounts(body);
@@ -218,7 +219,7 @@ describe('AccountsController', () => {
       const transactions = ['transaction'];
       mockAccountsService.unfreezeSecondaryAccounts.mockResolvedValue({ transactions });
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
       };
 
       const result = await controller.unfreezeSecondaryAccounts(body);
@@ -235,7 +236,7 @@ describe('AccountsController', () => {
       mockAccountsService.revokePermissions.mockResolvedValue({ transactions });
 
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
         secondaryAccounts: ['someAddress'],
       };
 
@@ -253,7 +254,7 @@ describe('AccountsController', () => {
       mockAccountsService.modifyPermissions.mockResolvedValue({ transactions });
 
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
         secondaryAccounts: [
           new PermissionedAccountDto({
             secondaryAccount: 'someAddress',

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -236,7 +236,6 @@ export class AccountsController {
   })
   @Post('permissions/modify')
   async modifyPermissions(@Body() params: ModifyPermissionsDto): Promise<TransactionResponseModel> {
-    console.log(params);
     const result = await this.accountsService.modifyPermissions(params);
     return handleServiceResult(result);
   }

--- a/src/accounts/accounts.service.spec.ts
+++ b/src/accounts/accounts.service.spec.ts
@@ -20,7 +20,7 @@ import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { SigningModule } from '~/signing/signing.module';
-import { testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import {
   MockAccount,
   MockAsset,
@@ -35,6 +35,8 @@ jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
+
+const { signer } = testValues;
 
 describe('AccountsService', () => {
   let service: AccountsService;

--- a/src/accounts/accounts.service.spec.ts
+++ b/src/accounts/accounts.service.spec.ts
@@ -20,6 +20,7 @@ import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { SigningModule } from '~/signing/signing.module';
+import { testSigner as signer } from '~/test-utils/consts';
 import {
   MockAccount,
   MockAsset,
@@ -147,7 +148,6 @@ describe('AccountsService', () => {
       mockPolymeshApi.network.transferPolyx.mockResolvedValue(mockTransaction);
       mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-      const signer = '0x6'.padEnd(66, '0');
       const body = {
         signer,
         to: 'address',
@@ -329,7 +329,6 @@ describe('AccountsService', () => {
       mockPolymeshApi.accountManagement.freezeSecondaryAccounts.mockResolvedValue(mockTransaction);
       mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-      const signer = '0x6'.padEnd(66, '0');
       const body = {
         signer,
       };
@@ -361,7 +360,6 @@ describe('AccountsService', () => {
       );
       mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-      const signer = '0x6'.padEnd(66, '0');
       const body = {
         signer,
       };
@@ -391,7 +389,6 @@ describe('AccountsService', () => {
       mockPolymeshApi.accountManagement.revokePermissions.mockResolvedValue(mockTransaction);
       mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-      const signer = '0x6'.padEnd(66, '0');
       const secondaryAccounts = ['someAddress'];
       const body = {
         signer,
@@ -424,7 +421,6 @@ describe('AccountsService', () => {
       mockPolymeshApi.accountManagement.modifyPermissions.mockResolvedValue(mockTransaction);
       mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-      const signer = '0x6'.padEnd(66, '0');
       const account = 'someAddress';
       const permissions = {
         assets: null,

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -14,6 +14,7 @@ import { createAuthorizationRequestModel } from '~/authorizations/authorizations
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ComplianceRequirementsService } from '~/compliance/compliance-requirements.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
+import { testDid } from '~/test-utils/consts';
 import { MockAsset, MockAuthorizationRequest } from '~/test-utils/mocks';
 import { MockAssetService, MockComplianceRequirementsService } from '~/test-utils/service-mocks';
 
@@ -48,7 +49,7 @@ describe('AssetsController', () => {
         isDivisible: false,
         name: 'NAME',
         owner: {
-          did: '0x6'.padEnd(66, '0'),
+          did: testDid,
         },
         totalSupply: new BigNumber(1),
       };
@@ -86,7 +87,7 @@ describe('AssetsController', () => {
     const mockHolders = {
       data: [
         {
-          identity: { did: '0x6'.padEnd(66, '0') },
+          identity: { did: testDid },
           balance: new BigNumber(1),
         },
       ],

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -14,9 +14,11 @@ import { createAuthorizationRequestModel } from '~/authorizations/authorizations
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ComplianceRequirementsService } from '~/compliance/compliance-requirements.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
-import { testDid } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockAsset, MockAuthorizationRequest } from '~/test-utils/mocks';
 import { MockAssetService, MockComplianceRequirementsService } from '~/test-utils/service-mocks';
+
+const { signer, did } = testValues;
 
 describe('AssetsController', () => {
   let controller: AssetsController;
@@ -49,7 +51,7 @@ describe('AssetsController', () => {
         isDivisible: false,
         name: 'NAME',
         owner: {
-          did: testDid,
+          did,
         },
         totalSupply: new BigNumber(1),
       };
@@ -87,7 +89,7 @@ describe('AssetsController', () => {
     const mockHolders = {
       data: [
         {
-          identity: { did: testDid },
+          identity: { did },
           balance: new BigNumber(1),
         },
       ],
@@ -249,7 +251,6 @@ describe('AssetsController', () => {
 
   describe('issue', () => {
     it('should call the service and return the results', async () => {
-      const signer = '0x6000';
       const ticker = 'TICKER';
       const amount = new BigNumber(1000);
       mockAssetsService.issue.mockResolvedValue({ transactions: ['transaction'] });
@@ -285,7 +286,6 @@ describe('AssetsController', () => {
 
   describe('redeem', () => {
     it('should call the service and return the results', async () => {
-      const signer = '0x6000';
       const ticker = 'TICKER';
       const amount = new BigNumber(1000);
       const from = new BigNumber(1);
@@ -299,7 +299,6 @@ describe('AssetsController', () => {
 
   describe('freeze', () => {
     it('should call the service and return the results', async () => {
-      const signer = '0x6000';
       const ticker = 'TICKER';
       mockAssetsService.freeze.mockResolvedValue({ transactions: ['transaction'] });
 
@@ -311,7 +310,6 @@ describe('AssetsController', () => {
 
   describe('unfreeze', () => {
     it('should call the service and return the results', async () => {
-      const signer = '0x6000';
       const ticker = 'TICKER';
       mockAssetsService.unfreeze.mockResolvedValue({ transactions: ['transaction'] });
 
@@ -323,7 +321,6 @@ describe('AssetsController', () => {
 
   describe('controllerTransfer', () => {
     it('should call the service and return the results', async () => {
-      const signer = '0x6000';
       const ticker = 'TICKER';
       const amount = new BigNumber(1000);
       const origin = new PortfolioDto({ id: new BigNumber(1), did: '0x1000' });

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -15,6 +15,7 @@ import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
+import { testDid } from '~/test-utils/consts';
 import {
   MockAsset,
   MockAuthorizationRequest,
@@ -172,7 +173,7 @@ describe('AssetsService', () => {
     const mockHolders = {
       data: [
         {
-          identity: '0x6'.padEnd(66, '0'),
+          identity: testDid,
           balance: new BigNumber(1),
         },
       ],

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -15,7 +15,7 @@ import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
-import { testDid } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import {
   MockAsset,
   MockAuthorizationRequest,
@@ -23,6 +23,8 @@ import {
   MockTransaction,
 } from '~/test-utils/mocks';
 import { mockTransactionsProvider, MockTransactionsService } from '~/test-utils/service-mocks';
+
+const { did } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
@@ -173,7 +175,7 @@ describe('AssetsService', () => {
     const mockHolders = {
       data: [
         {
-          identity: testDid,
+          identity: did,
           balance: new BigNumber(1),
         },
       ],

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { AuthController } from '~/auth/auth.controller';
-import { testUser } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockAuthService, mockAuthServiceProvider } from '~/test-utils/service-mocks';
+
+const { user } = testValues;
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -25,7 +27,7 @@ describe('AuthController', () => {
   describe('createApiKey', () => {
     it('should call the service and return the result', async () => {
       const fakeResult = 'fake-result';
-      const userName = testUser.name;
+      const userName = user.name;
       mockAuthService.createApiKey.mockResolvedValue(fakeResult);
 
       const result = await controller.createApiKey({ userName });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -5,10 +5,12 @@ import { when } from 'jest-when';
 import { AuthService } from '~/auth/auth.service';
 import { ApiKeyRepo } from '~/auth/repos/api-key.repo';
 import { AppNotFoundError } from '~/common/errors';
-import { testUser } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { mockApiKeyRepoProvider, mockUserRepoProvider } from '~/test-utils/repo-mocks';
 import { mockUserServiceProvider } from '~/test-utils/service-mocks';
 import { UsersService } from '~/users/users.service';
+
+const { user } = testValues;
 
 describe('AuthService', () => {
   const testApiKey = 'authServiceSecret';
@@ -39,24 +41,24 @@ describe('AuthService', () => {
 
   describe('method: createApiKey', () => {
     it('should create an API key', async () => {
-      when(mockUsersService.getByName).calledWith(testUser.name).mockResolvedValue(testUser);
+      when(mockUsersService.getByName).calledWith(user.name).mockResolvedValue(user);
       when(mockApiKeyRepo.createApiKey)
-        .calledWith(testUser)
-        .mockResolvedValue({ userId: testUser.id, secret: testApiKey });
+        .calledWith(user)
+        .mockResolvedValue({ userId: user.id, secret: testApiKey });
 
-      const { userId, secret } = await service.createApiKey({ userName: testUser.name });
+      const { userId, secret } = await service.createApiKey({ userName: user.name });
 
-      expect(userId).toEqual(testUser.id);
+      expect(userId).toEqual(user.id);
       expect(secret.length).toBeGreaterThan(8);
     });
   });
 
   describe('method: validateApiKey', () => {
     it('should return the user when given a valid api key', async () => {
-      when(mockApiKeyRepo.getUserByApiKey).calledWith(testApiKey).mockResolvedValue(testUser);
+      when(mockApiKeyRepo.getUserByApiKey).calledWith(testApiKey).mockResolvedValue(user);
 
       const foundUser = await service.validateApiKey(testApiKey);
-      expect(foundUser).toEqual(testUser);
+      expect(foundUser).toEqual(user);
     });
 
     it('should throw a NotFoundError when given an unknown API key', () => {

--- a/src/auth/repos/api-key.repo.suite.ts
+++ b/src/auth/repos/api-key.repo.suite.ts
@@ -1,6 +1,8 @@
 import { ApiKeyRepo } from '~/auth/repos/api-key.repo';
 import { AppNotFoundError } from '~/common/errors';
-import { testUser } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
+
+const { user } = testValues;
 
 export const testApiKeyRepo = async (repo: ApiKeyRepo): Promise<void> => {
   let secret: string;
@@ -10,8 +12,8 @@ export const testApiKeyRepo = async (repo: ApiKeyRepo): Promise<void> => {
 
   describe('method: createApiKey', () => {
     it('should create an API key', async () => {
-      ({ secret, userId } = await repo.createApiKey(testUser));
-      expect(userId).toEqual(testUser.id);
+      ({ secret, userId } = await repo.createApiKey(user));
+      expect(userId).toEqual(user.id);
       expect(secret).toBeDefined();
     });
   });
@@ -19,7 +21,7 @@ export const testApiKeyRepo = async (repo: ApiKeyRepo): Promise<void> => {
   describe('method: getByApiKey', () => {
     it('should return the User associated to the API key', async () => {
       const foundUser = await repo.getUserByApiKey(secret);
-      expect(foundUser).toEqual(testUser);
+      expect(foundUser).toEqual(user);
     });
 
     it('should throw NotFoundError if the API key does not exist', () => {

--- a/src/auth/repos/api-key.repo.suite.ts
+++ b/src/auth/repos/api-key.repo.suite.ts
@@ -24,9 +24,9 @@ export const testApiKeyRepo = async (repo: ApiKeyRepo): Promise<void> => {
       expect(foundUser).toEqual(user);
     });
 
-    it('should throw NotFoundError if the API key does not exist', () => {
+    it('should throw NotFoundError if the API key does not exist', async () => {
       const unknownApiKey = 'unknownApiKey';
-      return expect(repo.getUserByApiKey(unknownApiKey)).rejects.toThrow(expectedNotFoundError);
+      await expect(repo.getUserByApiKey(unknownApiKey)).rejects.toThrow(expectedNotFoundError);
     });
   });
 
@@ -38,7 +38,7 @@ export const testApiKeyRepo = async (repo: ApiKeyRepo): Promise<void> => {
     });
 
     it('should be a no-op on if the API key is not found', () => {
-      expect(repo.deleteApiKey(secret)).resolves.not.toThrow();
+      return expect(repo.deleteApiKey(secret)).resolves.not.toThrow();
     });
   });
 };

--- a/src/authorizations/authorizations.service.spec.ts
+++ b/src/authorizations/authorizations.service.spec.ts
@@ -11,7 +11,7 @@ import { when } from 'jest-when';
 import { AccountsService } from '~/accounts/accounts.service';
 import { AuthorizationsService } from '~/authorizations/authorizations.service';
 import { IdentitiesService } from '~/identities/identities.service';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import {
   MockAccount,
   MockAuthorizationRequest,
@@ -30,6 +30,8 @@ jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
+
+const { signer, did } = testValues;
 
 describe('AuthorizationsService', () => {
   let service: AuthorizationsService;
@@ -70,7 +72,6 @@ describe('AuthorizationsService', () => {
 
   describe('findPendingByDid', () => {
     const mockIdentity = new MockIdentity();
-    const did = testDid;
     const mockAuthorizations = [
       {
         id: '1',
@@ -114,7 +115,6 @@ describe('AuthorizationsService', () => {
 
   describe('findIssuedByDid', () => {
     const mockIdentity = new MockIdentity();
-    const did = testDid;
     const mockIssuedAuthorizations = {
       data: [
         {

--- a/src/authorizations/authorizations.service.spec.ts
+++ b/src/authorizations/authorizations.service.spec.ts
@@ -11,6 +11,7 @@ import { when } from 'jest-when';
 import { AccountsService } from '~/accounts/accounts.service';
 import { AuthorizationsService } from '~/authorizations/authorizations.service';
 import { IdentitiesService } from '~/identities/identities.service';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 import {
   MockAccount,
   MockAuthorizationRequest,
@@ -69,7 +70,7 @@ describe('AuthorizationsService', () => {
 
   describe('findPendingByDid', () => {
     const mockIdentity = new MockIdentity();
-    const did = '0x6'.padEnd(66, '0');
+    const did = testDid;
     const mockAuthorizations = [
       {
         id: '1',
@@ -113,7 +114,7 @@ describe('AuthorizationsService', () => {
 
   describe('findIssuedByDid', () => {
     const mockIdentity = new MockIdentity();
-    const did = '0x6'.padEnd(66, '0');
+    const did = testDid;
     const mockIssuedAuthorizations = {
       data: [
         {
@@ -237,7 +238,7 @@ describe('AuthorizationsService', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       jest.spyOn(service, 'findOne').mockResolvedValue(mockAuthorization as any);
 
-      const result = await service.findOneByDid('0x6'.padEnd(66, '0'), new BigNumber(1));
+      const result = await service.findOneByDid(signer, new BigNumber(1));
       expect(result).toEqual(mockAuthorization);
     });
   });

--- a/src/checkpoints/checkpoints.controller.spec.ts
+++ b/src/checkpoints/checkpoints.controller.spec.ts
@@ -9,6 +9,7 @@ import { CheckpointDetailsModel } from '~/checkpoints/models/checkpoint-details.
 import { CheckpointScheduleModel } from '~/checkpoints/models/checkpoint-schedule.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ResultsModel } from '~/common/models/results.model';
+import { testSigner as signer } from '~/test-utils/consts';
 import { MockCheckpoint, MockCheckpointSchedule } from '~/test-utils/mocks';
 import { MockCheckpointsService } from '~/test-utils/service-mocks';
 
@@ -305,7 +306,7 @@ describe('CheckpointsController', () => {
 
       const result = await controller.deleteSchedule(
         { id: new BigNumber(1), ticker: 'TICKER' },
-        { signer: '0x6'.padEnd(66, '0') }
+        { signer }
       );
 
       expect(result).toEqual({

--- a/src/checkpoints/checkpoints.controller.spec.ts
+++ b/src/checkpoints/checkpoints.controller.spec.ts
@@ -9,9 +9,11 @@ import { CheckpointDetailsModel } from '~/checkpoints/models/checkpoint-details.
 import { CheckpointScheduleModel } from '~/checkpoints/models/checkpoint-schedule.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ResultsModel } from '~/common/models/results.model';
-import { testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockCheckpoint, MockCheckpointSchedule } from '~/test-utils/mocks';
 import { MockCheckpointsService } from '~/test-utils/service-mocks';
+
+const { did, signer } = testValues;
 
 describe('CheckpointsController', () => {
   let controller: CheckpointsController;
@@ -279,7 +281,6 @@ describe('CheckpointsController', () => {
     it('should return the balance of an Asset for an Identity at a given Checkpoint', async () => {
       const balance = new BigNumber(10);
       const ticker = 'TICKER';
-      const did = '0x0600';
       const id = new BigNumber(1);
 
       const balanceModel = new IdentityBalanceModel({ balance, identity: did });

--- a/src/checkpoints/checkpoints.service.spec.ts
+++ b/src/checkpoints/checkpoints.service.spec.ts
@@ -10,7 +10,7 @@ import { CalendarUnit, ErrorCode, TxTags } from '@polymeshassociation/polymesh-s
 import { AssetsService } from '~/assets/assets.service';
 import { CheckpointsService } from '~/checkpoints/checkpoints.service';
 import { mockPolymeshLoggerProvider } from '~/logger/mock-polymesh-logger';
-import { testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import {
   MockAsset,
   MockCheckpoint,
@@ -28,6 +28,8 @@ jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
+
+const { signer } = testValues;
 
 describe('CheckpointsService', () => {
   let service: CheckpointsService;

--- a/src/checkpoints/checkpoints.service.spec.ts
+++ b/src/checkpoints/checkpoints.service.spec.ts
@@ -10,6 +10,7 @@ import { CalendarUnit, ErrorCode, TxTags } from '@polymeshassociation/polymesh-s
 import { AssetsService } from '~/assets/assets.service';
 import { CheckpointsService } from '~/checkpoints/checkpoints.service';
 import { mockPolymeshLoggerProvider } from '~/logger/mock-polymesh-logger';
+import { testSigner as signer } from '~/test-utils/consts';
 import {
   MockAsset,
   MockCheckpoint,
@@ -258,8 +259,6 @@ describe('CheckpointsService', () => {
 
       mockAssetsService.findOne.mockReturnValue(mockAsset);
 
-      const signer = 'signer';
-
       const body = {
         signer,
       };
@@ -298,8 +297,6 @@ describe('CheckpointsService', () => {
       });
 
       mockAssetsService.findOne.mockReturnValue(mockAsset);
-
-      const signer = 'signer';
 
       const mockDate = new Date();
       const params = {
@@ -426,7 +423,6 @@ describe('CheckpointsService', () => {
         });
 
         mockAssetsService.findOne.mockResolvedValue(mockAsset);
-        const signer = '0x6'.padEnd(66, '0');
         const ticker = 'TICKER';
         const id = new BigNumber(1);
 

--- a/src/common/filters/app-error-to-http-response.filter.spec.ts
+++ b/src/common/filters/app-error-to-http-response.filter.spec.ts
@@ -4,7 +4,9 @@ import { HttpAdapterHost } from '@nestjs/core';
 
 import { AppConfigError, AppConflictError, AppError, AppNotFoundError } from '~/common/errors';
 import { AppErrorToHttpResponseFilter } from '~/common/filters/app-error-to-http-response.filter';
-import { testResource } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
+
+const { resource } = testValues;
 
 type ExpectedReplyArgs = [{ message: string; statusCode: number }, HttpStatus];
 type Case = [AppError, ExpectedReplyArgs];
@@ -16,8 +18,8 @@ describe('AppErrorToHttpResponseFilter', () => {
   const mockHost = createMock<ArgumentsHost>();
   const errorToHttpResponseFilter = new AppErrorToHttpResponseFilter(mockHttpAdaptorHost);
 
-  const notFoundError = new AppNotFoundError(testResource.id, testResource.type);
-  const conflictError = new AppConflictError(testResource.id, testResource.type);
+  const notFoundError = new AppNotFoundError(resource.id, resource.type);
+  const conflictError = new AppConflictError(resource.id, resource.type);
   const configError = new AppConfigError('TEST_CONFIG', 'is a test error');
 
   const cases: Case[] = [

--- a/src/common/filters/app-error-to-http-response.filter.spec.ts
+++ b/src/common/filters/app-error-to-http-response.filter.spec.ts
@@ -33,7 +33,7 @@ describe('AppErrorToHttpResponseFilter', () => {
 
   test.each(cases)('should transform %p into %p', async (error, expected) => {
     errorToHttpResponseFilter.catch(error, mockHost);
-    expect(mockReplyFn).toHaveBeenCalledWith({}, ...expected);
+    return expect(mockReplyFn).toHaveBeenCalledWith({}, ...expected);
   });
 
   it('should throw if an unknown Error is encountered', () => {

--- a/src/corporate-actions/corporate-actions.controller.spec.ts
+++ b/src/corporate-actions/corporate-actions.controller.spec.ts
@@ -12,6 +12,7 @@ import {
 import { MockCorporateActionDefaultConfig } from '~/corporate-actions/mocks/corporate-action-default-config.mock';
 import { MockDistributionWithDetails } from '~/corporate-actions/mocks/distribution-with-details.mock';
 import { MockDistribution } from '~/corporate-actions/mocks/dividend-distribution.mock';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 
 describe('CorporateActionsController', () => {
   let controller: CorporateActionsController;
@@ -67,7 +68,7 @@ describe('CorporateActionsController', () => {
       };
       mockCorporateActionsService.updateDefaultConfigByTicker.mockResolvedValue(response);
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
         defaultTaxWithholding: new BigNumber(25),
       };
 
@@ -128,7 +129,7 @@ describe('CorporateActionsController', () => {
       mockCorporateActionsService.createDividendDistribution.mockResolvedValue(response);
       const mockDate = new Date();
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
         description: 'Corporate Action description',
         checkpoint: mockDate,
         originPortfolio: new BigNumber(0),
@@ -161,7 +162,7 @@ describe('CorporateActionsController', () => {
 
       const result = await controller.deleteCorporateAction(
         { id: new BigNumber(1), ticker: 'TICKER' },
-        { signer: '0x6'.padEnd(66, '0') }
+        { signer }
       );
 
       expect(result).toEqual({
@@ -170,7 +171,7 @@ describe('CorporateActionsController', () => {
       expect(mockCorporateActionsService.remove).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
-        '0x6'.padEnd(66, '0'),
+        signer,
         undefined
       );
     });
@@ -184,8 +185,8 @@ describe('CorporateActionsController', () => {
       mockCorporateActionsService.payDividends.mockResolvedValue(response);
 
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
-        targets: ['0x6'.padEnd(66, '0')],
+        signer,
+        targets: [testDid],
       };
       const result = await controller.payDividends(
         {
@@ -218,7 +219,7 @@ describe('CorporateActionsController', () => {
             type: 'DOC_TYPE',
           }),
         ],
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
       };
 
       mockCorporateActionsService.linkDocuments.mockResolvedValue({ transactions });
@@ -241,7 +242,6 @@ describe('CorporateActionsController', () => {
       };
       mockCorporateActionsService.claimDividends.mockResolvedValue(response);
 
-      const signer = '0x6'.padEnd(66, '0');
       const result = await controller.claimDividends(
         {
           id: new BigNumber(1),
@@ -268,7 +268,6 @@ describe('CorporateActionsController', () => {
       };
       mockCorporateActionsService.reclaimRemainingFunds.mockResolvedValue(response);
 
-      const signer = '0x6'.padEnd(66, '0');
       const result = await controller.reclaimRemainingFunds(
         {
           id: new BigNumber(1),
@@ -295,7 +294,7 @@ describe('CorporateActionsController', () => {
 
       const body = {
         checkpoint: new Date(),
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
       };
 
       mockCorporateActionsService.modifyCheckpoint.mockResolvedValue({ transactions });

--- a/src/corporate-actions/corporate-actions.controller.spec.ts
+++ b/src/corporate-actions/corporate-actions.controller.spec.ts
@@ -12,7 +12,9 @@ import {
 import { MockCorporateActionDefaultConfig } from '~/corporate-actions/mocks/corporate-action-default-config.mock';
 import { MockDistributionWithDetails } from '~/corporate-actions/mocks/distribution-with-details.mock';
 import { MockDistribution } from '~/corporate-actions/mocks/dividend-distribution.mock';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
+
+const { did, signer } = testValues;
 
 describe('CorporateActionsController', () => {
   let controller: CorporateActionsController;
@@ -186,7 +188,7 @@ describe('CorporateActionsController', () => {
 
       const body = {
         signer,
-        targets: [testDid],
+        targets: [did],
       };
       const result = await controller.payDividends(
         {

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -18,6 +18,7 @@ import { CorporateActionsService } from '~/corporate-actions/corporate-actions.s
 import { MockCorporateActionDefaultConfig } from '~/corporate-actions/mocks/corporate-action-default-config.mock';
 import { MockDistributionWithDetails } from '~/corporate-actions/mocks/distribution-with-details.mock';
 import { MockDistribution } from '~/corporate-actions/mocks/dividend-distribution.mock';
+import { testSigner as signer } from '~/test-utils/consts';
 import { MockAsset, MockTransaction } from '~/test-utils/mocks';
 import { MockAssetService, mockTransactionsProvider } from '~/test-utils/service-mocks';
 
@@ -81,7 +82,7 @@ describe('CorporateActionsService', () => {
       it('should pass the error along the chain', async () => {
         const expectedError = new Error('New targets are the same as the current ones');
         const body = {
-          signer: '0x6'.padEnd(66, '0'),
+          signer,
           targets: {
             treatment: TargetTreatment.Exclude,
             identities: [],
@@ -116,7 +117,6 @@ describe('CorporateActionsService', () => {
         mockAsset.corporateActions.setDefaultConfig.mockResolvedValue(mockTransaction);
         mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        const signer = '0x6'.padEnd(66, '0');
         const body = {
           signer,
           defaultTaxWithholding: new BigNumber(25),
@@ -227,7 +227,7 @@ describe('CorporateActionsService', () => {
     const ticker = 'TICKER';
     const mockDate = new Date();
     const body = {
-      signer: '0x6'.padEnd(66, '0'),
+      signer,
       description: 'Corporate Action description',
       checkpoint: mockDate,
       originPortfolio: new BigNumber(0),
@@ -289,7 +289,7 @@ describe('CorporateActionsService', () => {
 
         let error = null;
         try {
-          await service.remove(ticker, new BigNumber(1), '0x6'.padEnd(66, '0'));
+          await service.remove(ticker, new BigNumber(1), signer);
         } catch (err) {
           error = err;
         }
@@ -309,7 +309,7 @@ describe('CorporateActionsService', () => {
         const mockTransaction = new MockTransaction(transaction);
         mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        const result = await service.remove(ticker, new BigNumber(1), '0x6'.padEnd(66, '0'));
+        const result = await service.remove(ticker, new BigNumber(1), signer);
 
         expect(result).toEqual({
           transactions: [mockTransaction],
@@ -320,7 +320,6 @@ describe('CorporateActionsService', () => {
   });
 
   describe('payDividends', () => {
-    const signer = '0x6'.padEnd(66, '0');
     const body = {
       signer,
       targets: ['0x6'.padEnd(66, '1')],
@@ -372,7 +371,7 @@ describe('CorporateActionsService', () => {
           type: 'DOC_TYPE',
         }),
       ],
-      signer: '0x6'.padEnd(66, '0'),
+      signer,
     };
 
     beforeEach(() => {
@@ -411,8 +410,6 @@ describe('CorporateActionsService', () => {
   });
 
   describe('claimDividends', () => {
-    const signer = '0x6'.padEnd(66, '0');
-
     describe('otherwise', () => {
       it('should return the transaction details', async () => {
         const transaction = {
@@ -449,7 +446,6 @@ describe('CorporateActionsService', () => {
   });
 
   describe('reclaimRemainingFunds', () => {
-    const signer = '0x6'.padEnd(66, '0');
     const webhookUrl = 'http://example.com';
 
     describe('otherwise', () => {
@@ -496,7 +492,7 @@ describe('CorporateActionsService', () => {
         id: new BigNumber(1),
         type: CaCheckpointType.Existing,
       },
-      signer: '0x6'.padEnd(66, '0'),
+      signer,
     };
 
     beforeEach(() => {

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -18,9 +18,11 @@ import { CorporateActionsService } from '~/corporate-actions/corporate-actions.s
 import { MockCorporateActionDefaultConfig } from '~/corporate-actions/mocks/corporate-action-default-config.mock';
 import { MockDistributionWithDetails } from '~/corporate-actions/mocks/distribution-with-details.mock';
 import { MockDistribution } from '~/corporate-actions/mocks/dividend-distribution.mock';
-import { testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockAsset, MockTransaction } from '~/test-utils/mocks';
 import { MockAssetService, mockTransactionsProvider } from '~/test-utils/service-mocks';
+
+const { signer } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),

--- a/src/corporate-actions/dto/corporate-action-default-config.dto.spec.ts
+++ b/src/corporate-actions/dto/corporate-action-default-config.dto.spec.ts
@@ -2,11 +2,11 @@ import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
 import { TargetTreatment } from '@polymeshassociation/polymesh-sdk/types';
 
 import { CorporateActionDefaultConfigDto } from '~/corporate-actions/dto/corporate-action-default-config.dto';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 import { InvalidCase, ValidCase } from '~/test-utils/types';
 
 describe('corporateActionDefaultConfigDto', () => {
   const target: ValidationPipe = new ValidationPipe({ transform: true });
-  const signer = '0x6'.padEnd(66, '0');
   const metadata: ArgumentMetadata = {
     type: 'body',
     metatype: CorporateActionDefaultConfigDto,
@@ -19,12 +19,12 @@ describe('corporateActionDefaultConfigDto', () => {
         {
           targets: {
             treatment: TargetTreatment.Include,
-            identities: ['0x6'.padEnd(66, '0')],
+            identities: [testDid],
           },
           defaultTaxWithholding: '25',
           taxWithholdings: [
             {
-              identity: '0x6'.padEnd(66, '0'),
+              identity: testDid,
               percentage: '10',
             },
           ],
@@ -36,7 +36,7 @@ describe('corporateActionDefaultConfigDto', () => {
         {
           targets: {
             treatment: TargetTreatment.Include,
-            identities: ['0x6'.padEnd(66, '0')],
+            identities: [testDid],
           },
           signer,
         },
@@ -53,7 +53,7 @@ describe('corporateActionDefaultConfigDto', () => {
         {
           taxWithholdings: [
             {
-              identity: '0x6'.padEnd(66, '0'),
+              identity: testDid,
               percentage: '10',
             },
           ],

--- a/src/corporate-actions/dto/corporate-action-default-config.dto.spec.ts
+++ b/src/corporate-actions/dto/corporate-action-default-config.dto.spec.ts
@@ -2,8 +2,10 @@ import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
 import { TargetTreatment } from '@polymeshassociation/polymesh-sdk/types';
 
 import { CorporateActionDefaultConfigDto } from '~/corporate-actions/dto/corporate-action-default-config.dto';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { InvalidCase, ValidCase } from '~/test-utils/types';
+
+const { did, signer } = testValues;
 
 describe('corporateActionDefaultConfigDto', () => {
   const target: ValidationPipe = new ValidationPipe({ transform: true });
@@ -19,12 +21,12 @@ describe('corporateActionDefaultConfigDto', () => {
         {
           targets: {
             treatment: TargetTreatment.Include,
-            identities: [testDid],
+            identities: [did],
           },
           defaultTaxWithholding: '25',
           taxWithholdings: [
             {
-              identity: testDid,
+              identity: did,
               percentage: '10',
             },
           ],
@@ -36,7 +38,7 @@ describe('corporateActionDefaultConfigDto', () => {
         {
           targets: {
             treatment: TargetTreatment.Include,
-            identities: [testDid],
+            identities: [did],
           },
           signer,
         },
@@ -53,7 +55,7 @@ describe('corporateActionDefaultConfigDto', () => {
         {
           taxWithholdings: [
             {
-              identity: testDid,
+              identity: did,
               percentage: '10',
             },
           ],

--- a/src/corporate-actions/dto/dividend-distribution.dto.spec.ts
+++ b/src/corporate-actions/dto/dividend-distribution.dto.spec.ts
@@ -2,8 +2,10 @@ import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
 import { CaCheckpointType } from '@polymeshassociation/polymesh-sdk/types';
 
 import { DividendDistributionDto } from '~/corporate-actions/dto/dividend-distribution.dto';
-import { testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { InvalidCase, ValidCase } from '~/test-utils/types';
+
+const { signer } = testValues;
 
 describe('dividendDistributionDto', () => {
   const target: ValidationPipe = new ValidationPipe({ transform: true });

--- a/src/corporate-actions/dto/dividend-distribution.dto.spec.ts
+++ b/src/corporate-actions/dto/dividend-distribution.dto.spec.ts
@@ -2,11 +2,11 @@ import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
 import { CaCheckpointType } from '@polymeshassociation/polymesh-sdk/types';
 
 import { DividendDistributionDto } from '~/corporate-actions/dto/dividend-distribution.dto';
+import { testSigner as signer } from '~/test-utils/consts';
 import { InvalidCase, ValidCase } from '~/test-utils/types';
 
 describe('dividendDistributionDto', () => {
   const target: ValidationPipe = new ValidationPipe({ transform: true });
-  const signer = '0x6'.padEnd(66, '0');
   const mockDate = new Date();
   const metadata: ArgumentMetadata = {
     type: 'body',

--- a/src/datastore/postgres/repos/api-key.repo.spec.ts
+++ b/src/datastore/postgres/repos/api-key.repo.spec.ts
@@ -4,8 +4,10 @@ import { Repository } from 'typeorm';
 import { ApiKeyRepo } from '~/auth/repos/api-key.repo';
 import { ApiKey } from '~/datastore/postgres/entities/api-key.entity';
 import { PostgresApiKeyRepo } from '~/datastore/postgres/repos/api-keys.repo';
-import { testUser } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockPostgresApiRepository } from '~/test-utils/repo-mocks';
+
+const { user } = testValues;
 
 describe(`PostgresApiKeyRepo does not meet ${ApiKeyRepo.type} requirements`, () => {
   const mockRepository = new MockPostgresApiRepository();
@@ -15,8 +17,8 @@ describe(`PostgresApiKeyRepo does not meet ${ApiKeyRepo.type} requirements`, () 
   when(mockRepository.create).mockImplementation(secret => {
     when(mockRepository.findOneBy)
       .calledWith({ secret })
-      .mockResolvedValue({ user: testUser, id: _id++ });
-    return { secret, user: testUser };
+      .mockResolvedValue({ user, id: _id++ });
+    return { secret, user };
   });
 
   mockRepository.delete.mockImplementation(secret => {

--- a/src/datastore/postgres/repos/users.repo.spec.ts
+++ b/src/datastore/postgres/repos/users.repo.spec.ts
@@ -4,11 +4,12 @@ import { Repository, TypeORMError } from 'typeorm';
 import { AppConflictError } from '~/common/errors';
 import { User } from '~/datastore/postgres/entities/user.entity';
 import { PostgresUsersRepo } from '~/datastore/postgres/repos/users.repo';
-import { testUser } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockPostgresUserRepository } from '~/test-utils/repo-mocks';
 import { UsersRepo } from '~/users/repo/user.repo';
 
 const uniqueViolation = new TypeORMError('duplicate key value violates unique constraint');
+const { user: testUser } = testValues;
 
 describe(`PostgresUsersRepo does not meet ${UsersRepo.type} requirements`, () => {
   const mockRepository = new MockPostgresUserRepository();

--- a/src/identities/dto/add-secondary-account-params.dto.spec.ts
+++ b/src/identities/dto/add-secondary-account-params.dto.spec.ts
@@ -8,7 +8,9 @@ import {
 } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AddSecondaryAccountParamsDto } from '~/identities/dto/add-secondary-account-params.dto';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
+
+const { signer, did } = testValues;
 
 type ValidInviteCase = [string, Record<string, unknown>];
 type InvalidInviteCase = [string, Record<string, unknown>, string[]];
@@ -71,11 +73,11 @@ describe('addSecondaryAccountParamsDto', () => {
               values: [
                 {
                   id: new BigNumber(1),
-                  did: testDid,
+                  did,
                 },
                 {
                   id: new BigNumber(2),
-                  did: testDid,
+                  did,
                 },
               ],
               type: PermissionType.Exclude,
@@ -97,11 +99,11 @@ describe('addSecondaryAccountParamsDto', () => {
               values: [
                 {
                   id: new BigNumber(1),
-                  did: testDid,
+                  did,
                 },
                 {
                   id: new BigNumber(2),
-                  did: testDid,
+                  did,
                 },
               ],
               type: PermissionType.Exclude,

--- a/src/identities/dto/add-secondary-account-params.dto.spec.ts
+++ b/src/identities/dto/add-secondary-account-params.dto.spec.ts
@@ -8,13 +8,13 @@ import {
 } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AddSecondaryAccountParamsDto } from '~/identities/dto/add-secondary-account-params.dto';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 
 type ValidInviteCase = [string, Record<string, unknown>];
 type InvalidInviteCase = [string, Record<string, unknown>, string[]];
 
 describe('addSecondaryAccountParamsDto', () => {
   const target: ValidationPipe = new ValidationPipe({ transform: true });
-  const signer = '0x6'.padEnd(66, '0');
   const metadata: ArgumentMetadata = {
     type: 'body',
     metatype: AddSecondaryAccountParamsDto,
@@ -71,11 +71,11 @@ describe('addSecondaryAccountParamsDto', () => {
               values: [
                 {
                   id: new BigNumber(1),
-                  did: '0x6'.padEnd(66, '0'),
+                  did: testDid,
                 },
                 {
                   id: new BigNumber(2),
-                  did: '0x6'.padEnd(66, '0'),
+                  did: testDid,
                 },
               ],
               type: PermissionType.Exclude,
@@ -97,11 +97,11 @@ describe('addSecondaryAccountParamsDto', () => {
               values: [
                 {
                   id: new BigNumber(1),
-                  did: '0x6'.padEnd(66, '0'),
+                  did: testDid,
                 },
                 {
                   id: new BigNumber(2),
-                  did: '0x6'.padEnd(66, '0'),
+                  did: testDid,
                 },
               ],
               type: PermissionType.Exclude,

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -21,6 +21,7 @@ import { IdentitySignerModel } from '~/identities/models/identity-signer.model';
 import { IdentityModel } from '~/identities/models/identity.model';
 import { mockPolymeshLoggerProvider } from '~/logger/mock-polymesh-logger';
 import { SettlementsService } from '~/settlements/settlements.service';
+import { testDid } from '~/test-utils/consts';
 import {
   MockAuthorizationRequest,
   MockIdentity,
@@ -112,7 +113,7 @@ describe('IdentitiesController', () => {
       const mockResults = [new MockVenue()];
       mockSettlementsService.findVenuesByOwner.mockResolvedValue(mockResults);
 
-      const result = await controller.getVenues({ did: '0x6'.padEnd(66, '0') });
+      const result = await controller.getVenues({ did: testDid });
       expect(result).toEqual({
         results: [
           expect.objectContaining({
@@ -125,7 +126,7 @@ describe('IdentitiesController', () => {
 
   describe('getIdentityDetails', () => {
     it("should return the Identity's details", async () => {
-      const did = '0x6'.padEnd(66, '0');
+      const did = testDid;
 
       const mockIdentityDetails = new IdentityModel({
         did,
@@ -168,7 +169,7 @@ describe('IdentitiesController', () => {
   });
 
   describe('getPendingAuthorizations', () => {
-    const did = '0x6'.padEnd(66, '0');
+    const did = testDid;
     const targetDid = '0x1'.padEnd(66, '0');
     const pendingAuthorization = {
       authId: new BigNumber(2236),
@@ -282,7 +283,7 @@ describe('IdentitiesController', () => {
       const mockAuthorization = new MockAuthorizationRequest();
       mockAuthorizationsService.findOneByDid.mockResolvedValue(mockAuthorization);
       const result = await controller.getPendingAuthorization({
-        did: '0x6'.padEnd(66, '0'),
+        did: testDid,
         id: new BigNumber(1),
       });
       expect(result).toEqual({
@@ -302,7 +303,7 @@ describe('IdentitiesController', () => {
   });
 
   describe('getIssuedClaims', () => {
-    const did = '0x6'.padEnd(66, '0');
+    const did = testDid;
     const targetDid = '0x6'.padEnd(66, '1');
     const claims = [
       {
@@ -355,7 +356,7 @@ describe('IdentitiesController', () => {
   });
 
   describe('getAssociatedClaims', () => {
-    const did = '0x6'.padEnd(66, '0');
+    const did = testDid;
     const mockAssociatedClaims = {
       data: [
         {
@@ -419,7 +420,7 @@ describe('IdentitiesController', () => {
 
   describe('getTrustingAssets', () => {
     it('should return the list of Assets for which the Identity is a default trusted Claim Issuer', async () => {
-      const did = '0x6'.padEnd(66, '0');
+      const did = testDid;
       const mockAssets = [
         {
           ticker: 'BAR_TICKER',
@@ -464,7 +465,7 @@ describe('IdentitiesController', () => {
 
       mockTickerReservationsService.findAllByOwner.mockResolvedValue([mockTickerReservation]);
 
-      const did = '0x6'.padEnd(66, '0');
+      const did = testDid;
 
       const result = await controller.getTickerReservations({ did });
       expect(result).toEqual({

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -21,7 +21,7 @@ import { IdentitySignerModel } from '~/identities/models/identity-signer.model';
 import { IdentityModel } from '~/identities/models/identity.model';
 import { mockPolymeshLoggerProvider } from '~/logger/mock-polymesh-logger';
 import { SettlementsService } from '~/settlements/settlements.service';
-import { testDid } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import {
   MockAuthorizationRequest,
   MockIdentity,
@@ -37,6 +37,8 @@ import {
   MockTickerReservationsService,
 } from '~/test-utils/service-mocks';
 import { TickerReservationsService } from '~/ticker-reservations/ticker-reservations.service';
+
+const { did } = testValues;
 
 describe('IdentitiesController', () => {
   let controller: IdentitiesController;
@@ -113,7 +115,7 @@ describe('IdentitiesController', () => {
       const mockResults = [new MockVenue()];
       mockSettlementsService.findVenuesByOwner.mockResolvedValue(mockResults);
 
-      const result = await controller.getVenues({ did: testDid });
+      const result = await controller.getVenues({ did });
       expect(result).toEqual({
         results: [
           expect.objectContaining({
@@ -126,8 +128,6 @@ describe('IdentitiesController', () => {
 
   describe('getIdentityDetails', () => {
     it("should return the Identity's details", async () => {
-      const did = testDid;
-
       const mockIdentityDetails = new IdentityModel({
         did,
         primaryAccount: {
@@ -169,7 +169,6 @@ describe('IdentitiesController', () => {
   });
 
   describe('getPendingAuthorizations', () => {
-    const did = testDid;
     const targetDid = '0x1'.padEnd(66, '0');
     const pendingAuthorization = {
       authId: new BigNumber(2236),
@@ -283,7 +282,7 @@ describe('IdentitiesController', () => {
       const mockAuthorization = new MockAuthorizationRequest();
       mockAuthorizationsService.findOneByDid.mockResolvedValue(mockAuthorization);
       const result = await controller.getPendingAuthorization({
-        did: testDid,
+        did,
         id: new BigNumber(1),
       });
       expect(result).toEqual({
@@ -303,7 +302,6 @@ describe('IdentitiesController', () => {
   });
 
   describe('getIssuedClaims', () => {
-    const did = testDid;
     const targetDid = '0x6'.padEnd(66, '1');
     const claims = [
       {
@@ -356,7 +354,6 @@ describe('IdentitiesController', () => {
   });
 
   describe('getAssociatedClaims', () => {
-    const did = testDid;
     const mockAssociatedClaims = {
       data: [
         {
@@ -420,7 +417,6 @@ describe('IdentitiesController', () => {
 
   describe('getTrustingAssets', () => {
     it('should return the list of Assets for which the Identity is a default trusted Claim Issuer', async () => {
-      const did = testDid;
       const mockAssets = [
         {
           ticker: 'BAR_TICKER',
@@ -464,8 +460,6 @@ describe('IdentitiesController', () => {
       const mockTickerReservation = new MockTickerReservation();
 
       mockTickerReservationsService.findAllByOwner.mockResolvedValue([mockTickerReservation]);
-
-      const did = testDid;
 
       const result = await controller.getTickerReservations({ did });
       expect(result).toEqual({

--- a/src/identities/identities.service.spec.ts
+++ b/src/identities/identities.service.spec.ts
@@ -14,13 +14,15 @@ import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { mockSigningProvider } from '~/signing/signing.mock';
-import { testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockIdentity, MockPolymesh, MockTransaction } from '~/test-utils/mocks';
 import {
   MockAccountsService,
   mockTransactionsProvider,
   MockTransactionsService,
 } from '~/test-utils/service-mocks';
+
+const { signer } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),

--- a/src/identities/identities.service.spec.ts
+++ b/src/identities/identities.service.spec.ts
@@ -14,6 +14,7 @@ import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { mockSigningProvider } from '~/signing/signing.mock';
+import { testSigner as signer } from '~/test-utils/consts';
 import { MockIdentity, MockPolymesh, MockTransaction } from '~/test-utils/mocks';
 import {
   MockAccountsService,
@@ -153,7 +154,6 @@ describe('IdentitiesService', () => {
         const mockTransaction = new MockTransaction(transaction);
         mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        const signer = '0x6'.padEnd(66, '0');
         const body = {
           signer,
           secondaryAccount: 'address',

--- a/src/portfolios/porfolios.controller.spec.ts
+++ b/src/portfolios/porfolios.controller.spec.ts
@@ -1,5 +1,3 @@
-/* eslint-disable import/first */
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 
@@ -9,6 +7,7 @@ import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
 import { PortfoliosController } from '~/portfolios/portfolios.controller';
 import { PortfoliosService } from '~/portfolios/portfolios.service';
 import { createPortfolioModel } from '~/portfolios/portfolios.util';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 import { MockPortfolio } from '~/test-utils/mocks';
 import { MockPortfoliosService } from '~/test-utils/service-mocks';
 
@@ -34,7 +33,7 @@ describe('PortfoliosController', () => {
 
   describe('getPortfolios', () => {
     it('should return list of all portfolios of an identity', async () => {
-      const did = '0x6'.padEnd(66, '0');
+      const did = testDid;
       const mockPortfolio = new MockPortfolio();
       mockPortfolio.getAssetBalances.mockResolvedValue([]);
       mockPortfolio.getCustodian.mockResolvedValue({ did });
@@ -100,8 +99,8 @@ describe('PortfoliosController', () => {
       mockPortfoliosService.deletePortfolio.mockResolvedValue(response);
 
       const result = await controller.deletePortfolio(
-        new PortfolioDto({ id: new BigNumber(1), did: '0x6'.padEnd(66, '0') }),
-        { signer: '0x6'.padEnd(66, '0') }
+        new PortfolioDto({ id: new BigNumber(1), did: testDid }),
+        { signer }
       );
 
       expect(result).toEqual({

--- a/src/portfolios/porfolios.controller.spec.ts
+++ b/src/portfolios/porfolios.controller.spec.ts
@@ -7,9 +7,11 @@ import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
 import { PortfoliosController } from '~/portfolios/portfolios.controller';
 import { PortfoliosService } from '~/portfolios/portfolios.service';
 import { createPortfolioModel } from '~/portfolios/portfolios.util';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockPortfolio } from '~/test-utils/mocks';
 import { MockPortfoliosService } from '~/test-utils/service-mocks';
+
+const { did, signer } = testValues;
 
 describe('PortfoliosController', () => {
   let controller: PortfoliosController;
@@ -33,7 +35,6 @@ describe('PortfoliosController', () => {
 
   describe('getPortfolios', () => {
     it('should return list of all portfolios of an identity', async () => {
-      const did = testDid;
       const mockPortfolio = new MockPortfolio();
       mockPortfolio.getAssetBalances.mockResolvedValue([]);
       mockPortfolio.getCustodian.mockResolvedValue({ did });
@@ -99,7 +100,7 @@ describe('PortfoliosController', () => {
       mockPortfoliosService.deletePortfolio.mockResolvedValue(response);
 
       const result = await controller.deletePortfolio(
-        new PortfolioDto({ id: new BigNumber(1), did: testDid }),
+        new PortfolioDto({ id: new BigNumber(1), did }),
         { signer }
       );
 

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -13,6 +13,7 @@ import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
 import { PortfoliosService } from '~/portfolios/portfolios.service';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 import { MockIdentity, MockPolymesh, MockPortfolio, MockTransaction } from '~/test-utils/mocks';
 import {
   MockIdentitiesService,
@@ -71,7 +72,6 @@ describe('PortfoliosService', () => {
   describe('findAllByOwner', () => {
     it('should return a list of Portfolios for a given DID', async () => {
       const mockIdentity = new MockIdentity();
-      const did = '0x6'.padEnd(66, '0');
       const mockPortfolios = [
         {
           name: 'Default',
@@ -89,7 +89,7 @@ describe('PortfoliosService', () => {
       ];
       mockIdentity.portfolios.getPortfolios.mockResolvedValue(mockPortfolios);
       mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
-      const result = await service.findAllByOwner(did);
+      const result = await service.findAllByOwner(testDid);
       expect(result).toEqual(mockPortfolios);
     });
   });
@@ -263,10 +263,9 @@ describe('PortfoliosService', () => {
         mockIdentitiesService.findOne.mockResolvedValue(mockIdentity);
         mockIdentity.portfolios.delete.mockResolvedValue(mockTransaction);
 
-        const signer = '0x6'.padEnd(66, '0');
         const portfolio = new PortfolioDto({
           id: new BigNumber(1),
-          did: '0x6'.padEnd(66, '0'),
+          did: testDid,
         });
 
         mockTransactionsService.submit.mockResolvedValue({

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -13,13 +13,15 @@ import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
 import { PortfoliosService } from '~/portfolios/portfolios.service';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockIdentity, MockPolymesh, MockPortfolio, MockTransaction } from '~/test-utils/mocks';
 import {
   MockIdentitiesService,
   mockTransactionsProvider,
   MockTransactionsService,
 } from '~/test-utils/service-mocks';
+
+const { signer, did } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
@@ -89,7 +91,7 @@ describe('PortfoliosService', () => {
       ];
       mockIdentity.portfolios.getPortfolios.mockResolvedValue(mockPortfolios);
       mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
-      const result = await service.findAllByOwner(testDid);
+      const result = await service.findAllByOwner(did);
       expect(result).toEqual(mockPortfolios);
     });
   });
@@ -265,7 +267,7 @@ describe('PortfoliosService', () => {
 
         const portfolio = new PortfolioDto({
           id: new BigNumber(1),
-          did: testDid,
+          did,
         });
 
         mockTransactionsService.submit.mockResolvedValue({

--- a/src/settlements/settlements.controller.spec.ts
+++ b/src/settlements/settlements.controller.spec.ts
@@ -12,6 +12,7 @@ import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { createPortfolioIdentifierModel } from '~/portfolios/portfolios.util';
 import { SettlementsController } from '~/settlements/settlements.controller';
 import { SettlementsService } from '~/settlements/settlements.service';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 import { MockInstruction, MockPortfolio, MockVenue } from '~/test-utils/mocks';
 import { MockSettlementsService } from '~/test-utils/service-mocks';
 
@@ -141,7 +142,7 @@ describe('SettlementsController', () => {
         data: [
           {
             identity: {
-              did: '0x6'.padEnd(66, '0'),
+              did: testDid,
             },
             status: AffirmationStatus.Pending,
           },
@@ -168,7 +169,7 @@ describe('SettlementsController', () => {
     it('should return the details of the Venue', async () => {
       const mockVenueDetails = {
         owner: {
-          did: '0x6'.padEnd(66, '0'),
+          did: testDid,
         },
         description: 'Venue desc',
         type: VenueType.Distribution,
@@ -184,7 +185,7 @@ describe('SettlementsController', () => {
   describe('createVenue', () => {
     it('should create a Venue and return the data returned by the service', async () => {
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
         description: 'Generic Exchange',
         type: VenueType.Exchange,
       };
@@ -212,7 +213,7 @@ describe('SettlementsController', () => {
       mockSettlementsService.modifyVenue.mockResolvedValue(mockData);
 
       const body = {
-        signer: '0x6'.padEnd(66, '0'),
+        signer,
         description: 'A generic exchange',
         type: VenueType.Exchange,
       };

--- a/src/settlements/settlements.controller.spec.ts
+++ b/src/settlements/settlements.controller.spec.ts
@@ -12,9 +12,11 @@ import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { createPortfolioIdentifierModel } from '~/portfolios/portfolios.util';
 import { SettlementsController } from '~/settlements/settlements.controller';
 import { SettlementsService } from '~/settlements/settlements.service';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { MockInstruction, MockPortfolio, MockVenue } from '~/test-utils/mocks';
 import { MockSettlementsService } from '~/test-utils/service-mocks';
+
+const { did, signer } = testValues;
 
 describe('SettlementsController', () => {
   let controller: SettlementsController;
@@ -142,7 +144,7 @@ describe('SettlementsController', () => {
         data: [
           {
             identity: {
-              did: testDid,
+              did,
             },
             status: AffirmationStatus.Pending,
           },
@@ -169,7 +171,7 @@ describe('SettlementsController', () => {
     it('should return the details of the Venue', async () => {
       const mockVenueDetails = {
         owner: {
-          did: testDid,
+          did,
         },
         description: 'Venue desc',
         type: VenueType.Distribution,

--- a/src/settlements/settlements.service.spec.ts
+++ b/src/settlements/settlements.service.spec.ts
@@ -20,7 +20,7 @@ import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
 import { SettlementsService } from '~/settlements/settlements.service';
-import { testDid, testSigner as signer } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import {
   MockAsset,
   MockIdentity,
@@ -40,6 +40,8 @@ jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
+
+const { signer, did } = testValues;
 
 describe('SettlementsService', () => {
   let service: SettlementsService;
@@ -471,7 +473,7 @@ describe('SettlementsService', () => {
     it('should return the Venue details', async () => {
       const mockDetails = {
         owner: {
-          did: testDid,
+          did,
         },
         description: 'Venue desc',
         type: VenueType.Distribution,
@@ -496,7 +498,7 @@ describe('SettlementsService', () => {
         data: [
           {
             identity: {
-              did: testDid,
+              did,
             },
             status: AffirmationStatus.Pending,
           },

--- a/src/settlements/settlements.service.spec.ts
+++ b/src/settlements/settlements.service.spec.ts
@@ -20,6 +20,7 @@ import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
 import { SettlementsService } from '~/settlements/settlements.service';
+import { testDid, testSigner as signer } from '~/test-utils/consts';
 import {
   MockAsset,
   MockIdentity,
@@ -262,7 +263,6 @@ describe('SettlementsService', () => {
         ],
       };
 
-      const signer = 'signer';
       const body = {
         signer,
         ...params,
@@ -310,7 +310,6 @@ describe('SettlementsService', () => {
       });
       mockPolymeshApi.settlements.createVenue.mockResolvedValue(mockTransaction);
       mockIdentitiesService.findOne.mockResolvedValue(mockIdentity);
-      const signer = '0x6'.padEnd(66, '0');
       const body = {
         signer,
         description: 'A generic exchange',
@@ -336,7 +335,7 @@ describe('SettlementsService', () => {
       it('should pass the error along the chain', async () => {
         const expectedError = new Error('New type is the same as the current one');
         const body = {
-          signer: '0x6'.padEnd(66, '0'),
+          signer,
           type: VenueType.Exchange,
           description: 'A generic exchange',
         };
@@ -377,7 +376,6 @@ describe('SettlementsService', () => {
         const mockTransaction = new MockTransaction(transaction);
         mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        const signer = '0x6'.padEnd(66, '0');
         const body = {
           signer,
           description: 'A generic exchange',
@@ -416,7 +414,6 @@ describe('SettlementsService', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       findInstructionSpy.mockResolvedValue(mockInstruction as any);
 
-      const signer = 'signer';
       const body = {
         signer,
       };
@@ -453,7 +450,6 @@ describe('SettlementsService', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       findInstructionSpy.mockResolvedValue(mockInstruction as any);
 
-      const signer = 'signer';
       const result = await service.rejectInstruction(new BigNumber(123), {
         signer,
       });
@@ -475,7 +471,7 @@ describe('SettlementsService', () => {
     it('should return the Venue details', async () => {
       const mockDetails = {
         owner: {
-          did: '0x6'.padEnd(66, '0'),
+          did: testDid,
         },
         description: 'Venue desc',
         type: VenueType.Distribution,
@@ -500,7 +496,7 @@ describe('SettlementsService', () => {
         data: [
           {
             identity: {
-              did: '0x6'.padEnd(66, '0'),
+              did: testDid,
             },
             status: AffirmationStatus.Pending,
           },

--- a/src/test-utils/consts.ts
+++ b/src/test-utils/consts.ts
@@ -5,7 +5,7 @@ const did = '0x01'.padEnd(66, '0');
 
 const user = new UserModel({
   id: '-1',
-  name: 'TestUtilUser',
+  name: 'TestUser',
 });
 
 const resource = {

--- a/src/test-utils/consts.ts
+++ b/src/test-utils/consts.ts
@@ -1,14 +1,21 @@
 import { UserModel } from '~/users/model/user.model';
 
-export const testSigner = 'alice';
-export const testDid = '0x01'.padEnd(66, '0');
+const signer = 'alice';
+const did = '0x01'.padEnd(66, '0');
 
-export const testUser = new UserModel({
+const user = new UserModel({
   id: '-1',
   name: 'TestUtilUser',
 });
 
-export const testResource = {
+const resource = {
   type: 'TestResource',
   id: '-1',
 } as const;
+
+export const testValues = {
+  signer,
+  did,
+  user,
+  resource,
+};

--- a/src/test-utils/consts.ts
+++ b/src/test-utils/consts.ts
@@ -1,6 +1,7 @@
 import { UserModel } from '~/users/model/user.model';
 
-export const testSigner = '0x6'.padEnd(66, '0');
+export const testSigner = 'alice';
+export const testDid = '0x01'.padEnd(66, '0');
 
 export const testUser = new UserModel({
   id: '-1',

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -2,11 +2,12 @@ import { DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { when } from 'jest-when';
 
-import { testUser } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { mockUserServiceProvider } from '~/test-utils/service-mocks';
 import { UsersController } from '~/users/users.controller';
 import { UsersService } from '~/users/users.service';
 
+const { user } = testValues;
 describe('UsersController', () => {
   let controller: UsersController;
   let mockUsersService: DeepMocked<UsersService>;
@@ -27,11 +28,11 @@ describe('UsersController', () => {
   });
 
   describe('createUser', () => {
-    const params = { name: testUser.name };
+    const params = { name: user.name };
     it('should call the service and return the result', () => {
-      when(mockUsersService.createUser).calledWith(params).mockResolvedValue(testUser);
+      when(mockUsersService.createUser).calledWith(params).mockResolvedValue(user);
 
-      return expect(controller.createUser(params)).resolves.toEqual(testUser);
+      return expect(controller.createUser(params)).resolves.toEqual(user);
     });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -2,10 +2,12 @@ import { DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { when } from 'jest-when';
 
-import { testUser } from '~/test-utils/consts';
+import { testValues } from '~/test-utils/consts';
 import { mockUserRepoProvider } from '~/test-utils/repo-mocks';
 import { UsersRepo } from '~/users/repo/user.repo';
 import { UsersService } from '~/users/users.service';
+
+const { user } = testValues;
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -27,23 +29,23 @@ describe('UsersService', () => {
 
   describe('method: getByName', () => {
     it('should return the User', async () => {
-      when(mockUsersRepo.findByName).calledWith(testUser.name).mockResolvedValue(testUser);
+      when(mockUsersRepo.findByName).calledWith(user.name).mockResolvedValue(user);
 
-      const foundUser = await service.getByName(testUser.name);
+      const foundUser = await service.getByName(user.name);
 
-      expect(foundUser).toEqual(testUser);
+      expect(foundUser).toEqual(user);
     });
   });
 
   describe('method: createUser', () => {
-    const params = { name: testUser.name };
+    const params = { name: user.name };
 
     it('should create and return a User', async () => {
-      when(mockUsersRepo.createUser).calledWith(params).mockResolvedValue(testUser);
+      when(mockUsersRepo.createUser).calledWith(params).mockResolvedValue(user);
 
       const createdUser = await service.createUser(params);
 
-      expect(createdUser).toEqual(testUser);
+      expect(createdUser).toEqual(user);
     });
   });
 });


### PR DESCRIPTION
### JIRA Link 

Prep work for: [DA-375](https://polymesh.atlassian.net/browse/DA-375)

### Changelog / Description 

Refactors repeated '0x06'.padEnd calls into a `const`. Also separates signer and DID in some tests

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
