### PR TITLE
feat: 🎸 support transaction details in response

### DIFF
--- a/src/accounts/accounts.controller.spec.ts
+++ b/src/accounts/accounts.controller.spec.ts
@@ -23,7 +23,7 @@ import {
 } from '~/test-utils/mocks';
 import { MockAccountsService, mockNetworkServiceProvider } from '~/test-utils/service-mocks';
 
-const { signer, did, testAccount } = testValues;
+const { signer, did, testAccount, txResult } = testValues;
 
 describe('AccountsController', () => {
   let controller: AccountsController;
@@ -63,8 +63,7 @@ describe('AccountsController', () => {
 
   describe('transferPolyx', () => {
     it('should return the transaction details on transferring POLYX balance', async () => {
-      const transactions = ['transaction'];
-      mockAccountsService.transferPolyx.mockResolvedValue({ transactions });
+      mockAccountsService.transferPolyx.mockResolvedValue(txResult);
 
       const body = {
         signer,
@@ -75,9 +74,7 @@ describe('AccountsController', () => {
 
       const result = await controller.transferPolyx(body);
 
-      expect(result).toEqual({
-        transactions,
-      });
+      expect(result).toEqual(txResult);
     });
   });
 
@@ -203,40 +200,33 @@ describe('AccountsController', () => {
 
   describe('freezeSecondaryAccounts', () => {
     it('should freeze secondary accounts', async () => {
-      const transactions = ['transaction'];
-      mockAccountsService.freezeSecondaryAccounts.mockResolvedValue({ transactions });
+      mockAccountsService.freezeSecondaryAccounts.mockResolvedValue(txResult);
       const body = {
         signer,
       };
 
       const result = await controller.freezeSecondaryAccounts(body);
 
-      expect(result).toEqual({
-        transactions,
-      });
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('unfreezeSecondaryAccounts', () => {
     it('should unfreeze secondary accounts', async () => {
-      const transactions = ['transaction'];
-      mockAccountsService.unfreezeSecondaryAccounts.mockResolvedValue({ transactions });
+      mockAccountsService.unfreezeSecondaryAccounts.mockResolvedValue(txResult);
       const body = {
         signer,
       };
 
       const result = await controller.unfreezeSecondaryAccounts(body);
 
-      expect(result).toEqual({
-        transactions,
-      });
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('revokePermissions', () => {
     it('should call the service and return the transaction details', async () => {
-      const transactions = ['transaction'];
-      mockAccountsService.revokePermissions.mockResolvedValue({ transactions });
+      mockAccountsService.revokePermissions.mockResolvedValue(txResult);
 
       const body = {
         signer,
@@ -245,16 +235,13 @@ describe('AccountsController', () => {
 
       const result = await controller.revokePermissions(body);
 
-      expect(result).toEqual({
-        transactions,
-      });
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('modifyPermissions', () => {
     it('should call the service and return the transaction details', async () => {
-      const transactions = ['transaction'];
-      mockAccountsService.modifyPermissions.mockResolvedValue({ transactions });
+      mockAccountsService.modifyPermissions.mockResolvedValue(txResult);
 
       const body = {
         signer,
@@ -272,9 +259,7 @@ describe('AccountsController', () => {
 
       const result = await controller.modifyPermissions(body);
 
-      expect(result).toEqual({
-        transactions,
-      });
+      expect(result).toEqual(txResult);
     });
   });
 

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -180,9 +180,9 @@ export class AccountsController {
   })
   @Post('freeze')
   async freezeSecondaryAccounts(
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.accountsService.freezeSecondaryAccounts(params);
+    const result = await this.accountsService.freezeSecondaryAccounts(transactionBaseDto);
 
     return handleServiceResult(result);
   }
@@ -202,9 +202,9 @@ export class AccountsController {
   })
   @Post('unfreeze')
   async unfreezeSecondaryAccounts(
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.accountsService.unfreezeSecondaryAccounts(params);
+    const result = await this.accountsService.unfreezeSecondaryAccounts(transactionBaseDto);
 
     return handleServiceResult(result);
   }

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -56,11 +56,11 @@ export class AccountsService {
   }
 
   public async transferPolyx(params: TransferPolyxDto): ServiceReturn<void> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const { polymeshService, transactionsService } = this;
 
     const { transferPolyx } = polymeshService.polymeshApi.network;
-    return transactionsService.submit(transferPolyx, rest, { signer, webhookUrl });
+    return transactionsService.submit(transferPolyx, rest, { signer, webhookUrl, dryRun });
   }
 
   public async getTransactionHistory(
@@ -99,28 +99,27 @@ export class AccountsService {
     return account.getSubsidy();
   }
 
-  public async freezeSecondaryAccounts(opts: TransactionBaseDto): ServiceReturn<void> {
-    const { signer, webhookUrl } = opts;
+  public async freezeSecondaryAccounts(
+    transactionBaseDto: TransactionBaseDto
+  ): ServiceReturn<void> {
     const { freezeSecondaryAccounts } = this.polymeshService.polymeshApi.accountManagement;
 
-    return this.transactionsService.submit(freezeSecondaryAccounts, undefined, {
-      signer,
-      webhookUrl,
-    });
+    return this.transactionsService.submit(freezeSecondaryAccounts, undefined, transactionBaseDto);
   }
 
   public async unfreezeSecondaryAccounts(opts: TransactionBaseDto): ServiceReturn<void> {
-    const { signer, webhookUrl } = opts;
+    const { signer, webhookUrl, dryRun } = opts;
     const { unfreezeSecondaryAccounts } = this.polymeshService.polymeshApi.accountManagement;
 
     return this.transactionsService.submit(unfreezeSecondaryAccounts, undefined, {
       signer,
       webhookUrl,
+      dryRun,
     });
   }
 
   public async revokePermissions(params: RevokePermissionsDto): ServiceReturn<void> {
-    const { signer, webhookUrl, secondaryAccounts } = params;
+    const { signer, webhookUrl, dryRun, secondaryAccounts } = params;
 
     const { revokePermissions } = this.polymeshService.polymeshApi.accountManagement;
 
@@ -129,12 +128,12 @@ export class AccountsService {
       {
         secondaryAccounts,
       },
-      { signer, webhookUrl }
+      { signer, webhookUrl, dryRun }
     );
   }
 
   public async modifyPermissions(params: ModifyPermissionsDto): ServiceReturn<void> {
-    const { signer, webhookUrl, secondaryAccounts } = params;
+    const { signer, webhookUrl, dryRun, secondaryAccounts } = params;
 
     const { modifyPermissions } = this.polymeshService.polymeshApi.accountManagement;
 
@@ -146,7 +145,7 @@ export class AccountsService {
           permissions: permissions.toPermissionsLike(),
         })),
       },
-      { signer, webhookUrl }
+      { signer, webhookUrl, dryRun }
     );
   }
 }

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -15,7 +15,7 @@ import { RevokePermissionsDto } from '~/accounts/dto/revoke-permissions.dto';
 import { TransactionHistoryFiltersDto } from '~/accounts/dto/transaction-history-filters.dto';
 import { TransferPolyxDto } from '~/accounts/dto/transfer-polyx.dto';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
-import { ServiceReturn } from '~/common/utils';
+import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { TransactionsService } from '~/transactions/transactions.service';
 
@@ -56,11 +56,11 @@ export class AccountsService {
   }
 
   public async transferPolyx(params: TransferPolyxDto): ServiceReturn<void> {
-    const { signer, webhookUrl, dryRun, ...rest } = params;
+    const { base, args } = extractTxBase(params);
     const { polymeshService, transactionsService } = this;
 
     const { transferPolyx } = polymeshService.polymeshApi.network;
-    return transactionsService.submit(transferPolyx, rest, { signer, webhookUrl, dryRun });
+    return transactionsService.submit(transferPolyx, args, base);
   }
 
   public async getTransactionHistory(
@@ -108,44 +108,35 @@ export class AccountsService {
   }
 
   public async unfreezeSecondaryAccounts(opts: TransactionBaseDto): ServiceReturn<void> {
-    const { signer, webhookUrl, dryRun } = opts;
     const { unfreezeSecondaryAccounts } = this.polymeshService.polymeshApi.accountManagement;
 
-    return this.transactionsService.submit(unfreezeSecondaryAccounts, undefined, {
-      signer,
-      webhookUrl,
-      dryRun,
-    });
+    return this.transactionsService.submit(unfreezeSecondaryAccounts, undefined, opts);
   }
 
   public async revokePermissions(params: RevokePermissionsDto): ServiceReturn<void> {
-    const { signer, webhookUrl, dryRun, secondaryAccounts } = params;
+    const { base, args } = extractTxBase(params);
 
     const { revokePermissions } = this.polymeshService.polymeshApi.accountManagement;
 
-    return this.transactionsService.submit(
-      revokePermissions,
-      {
-        secondaryAccounts,
-      },
-      { signer, webhookUrl, dryRun }
-    );
+    return this.transactionsService.submit(revokePermissions, args, base);
   }
 
   public async modifyPermissions(params: ModifyPermissionsDto): ServiceReturn<void> {
-    const { signer, webhookUrl, dryRun, secondaryAccounts } = params;
+    const { base, args } = extractTxBase(params);
 
     const { modifyPermissions } = this.polymeshService.polymeshApi.accountManagement;
 
     return this.transactionsService.submit(
       modifyPermissions,
       {
-        secondaryAccounts: secondaryAccounts.map(({ secondaryAccount: account, permissions }) => ({
-          account,
-          permissions: permissions.toPermissionsLike(),
-        })),
+        secondaryAccounts: args.secondaryAccounts.map(
+          ({ secondaryAccount: account, permissions }) => ({
+            account,
+            permissions: permissions.toPermissionsLike(),
+          })
+        ),
       },
-      { signer, webhookUrl, dryRun }
+      base
     );
   }
 }

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -14,7 +14,7 @@ import { testValues } from '~/test-utils/consts';
 import { MockAsset, MockAuthorizationRequest } from '~/test-utils/mocks';
 import { MockAssetService, MockComplianceRequirementsService } from '~/test-utils/service-mocks';
 
-const { signer, did } = testValues;
+const { signer, did, txResult } = testValues;
 
 describe('AssetsController', () => {
   let controller: AssetsController;
@@ -182,7 +182,6 @@ describe('AssetsController', () => {
 
   describe('setDocuments', () => {
     it('should call the service and return the results', async () => {
-      const transactions = ['transaction'];
       const body = {
         signer: '0x6000',
         documents: [
@@ -194,10 +193,10 @@ describe('AssetsController', () => {
         ],
       };
       const ticker = 'TICKER';
-      mockAssetsService.setDocuments.mockResolvedValue({ transactions });
+      mockAssetsService.setDocuments.mockResolvedValue(txResult);
 
       const result = await controller.setDocuments({ ticker }, body);
-      expect(result).toEqual({ transactions });
+      expect(result).toEqual(txResult);
       expect(mockAssetsService.setDocuments).toHaveBeenCalledWith(ticker, body);
     });
   });
@@ -212,10 +211,10 @@ describe('AssetsController', () => {
         assetType: KnownAssetType.EquityCommon,
         requireInvestorUniqueness: false,
       };
-      mockAssetsService.createAsset.mockResolvedValue({ transactions: ['transaction'] });
+      mockAssetsService.createAsset.mockResolvedValue(txResult);
 
       const result = await controller.createAsset(input);
-      expect(result).toEqual({ transactions: ['transaction'] });
+      expect(result).toEqual(txResult);
       expect(mockAssetsService.createAsset).toHaveBeenCalledWith(input);
     });
   });
@@ -224,10 +223,10 @@ describe('AssetsController', () => {
     it('should call the service and return the results', async () => {
       const ticker = 'TICKER';
       const amount = new BigNumber(1000);
-      mockAssetsService.issue.mockResolvedValue({ transactions: ['transaction'] });
+      mockAssetsService.issue.mockResolvedValue(txResult);
 
       const result = await controller.issue({ ticker }, { signer, amount });
-      expect(result).toEqual({ transactions: ['transaction'] });
+      expect(result).toEqual(txResult);
       expect(mockAssetsService.issue).toHaveBeenCalledWith(ticker, { signer, amount });
     });
   });
@@ -236,8 +235,8 @@ describe('AssetsController', () => {
     it('should call the service and return the results', async () => {
       const mockAuthorization = new MockAuthorizationRequest();
       const mockData = {
+        ...txResult,
         result: mockAuthorization,
-        transactions: ['transaction'],
       };
       mockAssetsService.transferOwnership.mockResolvedValue(mockData);
 
@@ -247,9 +246,9 @@ describe('AssetsController', () => {
       const result = await controller.transferOwnership({ ticker }, body);
 
       expect(result).toEqual({
+        ...txResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
-        transactions: ['transaction'],
       });
       expect(mockAssetsService.transferOwnership).toHaveBeenCalledWith(ticker, body);
     });
@@ -260,10 +259,10 @@ describe('AssetsController', () => {
       const ticker = 'TICKER';
       const amount = new BigNumber(1000);
       const from = new BigNumber(1);
-      mockAssetsService.redeem.mockResolvedValue({ transactions: ['transaction'] });
+      mockAssetsService.redeem.mockResolvedValue(txResult);
 
       const result = await controller.redeem({ ticker }, { signer, amount, from });
-      expect(result).toEqual({ transactions: ['transaction'] });
+      expect(result).toEqual(txResult);
       expect(mockAssetsService.redeem).toHaveBeenCalledWith(ticker, { signer, amount, from });
     });
   });
@@ -271,10 +270,10 @@ describe('AssetsController', () => {
   describe('freeze', () => {
     it('should call the service and return the results', async () => {
       const ticker = 'TICKER';
-      mockAssetsService.freeze.mockResolvedValue({ transactions: ['transaction'] });
+      mockAssetsService.freeze.mockResolvedValue(txResult);
 
       const result = await controller.freeze({ ticker }, { signer });
-      expect(result).toEqual({ transactions: ['transaction'] });
+      expect(result).toEqual(txResult);
       expect(mockAssetsService.freeze).toHaveBeenCalledWith(ticker, { signer });
     });
   });
@@ -282,10 +281,10 @@ describe('AssetsController', () => {
   describe('unfreeze', () => {
     it('should call the service and return the results', async () => {
       const ticker = 'TICKER';
-      mockAssetsService.unfreeze.mockResolvedValue({ transactions: ['transaction'] });
+      mockAssetsService.unfreeze.mockResolvedValue(txResult);
 
       const result = await controller.unfreeze({ ticker }, { signer });
-      expect(result).toEqual({ transactions: ['transaction'] });
+      expect(result).toEqual(txResult);
       expect(mockAssetsService.unfreeze).toHaveBeenCalledWith(ticker, { signer });
     });
   });
@@ -296,11 +295,11 @@ describe('AssetsController', () => {
       const amount = new BigNumber(1000);
       const origin = new PortfolioDto({ id: new BigNumber(1), did: '0x1000' });
 
-      mockAssetsService.controllerTransfer.mockResolvedValue({ transactions: ['transaction'] });
+      mockAssetsService.controllerTransfer.mockResolvedValue(txResult);
 
       const result = await controller.controllerTransfer({ ticker }, { signer, origin, amount });
 
-      expect(result).toEqual({ transactions: ['transaction'] });
+      expect(result).toEqual(txResult);
       expect(mockAssetsService.controllerTransfer).toHaveBeenCalledWith(ticker, {
         signer,
         origin,

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -267,9 +267,14 @@ export class AssetsController {
     @Body() params: TransferOwnershipDto
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.assetsService.transferOwnership(ticker, params);
-    const resolver: TransactionResolver<AuthorizationRequest> = ({ transactions, result }) =>
+    const resolver: TransactionResolver<AuthorizationRequest> = ({
+      transactions,
+      details,
+      result,
+    }) =>
       new CreatedAuthorizationRequestModel({
         transactions,
+        details,
         authorizationRequest: createAuthorizationRequestModel(result),
       });
 
@@ -325,9 +330,9 @@ export class AssetsController {
   @Post(':ticker/freeze')
   public async freeze(
     @Param() { ticker }: TickerParamsDto,
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.freeze(ticker, params);
+    const result = await this.assetsService.freeze(ticker, transactionBaseDto);
     return handleServiceResult(result);
   }
 
@@ -355,9 +360,9 @@ export class AssetsController {
   @Post(':ticker/unfreeze')
   public async unfreeze(
     @Param() { ticker }: TickerParamsDto,
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.unfreeze(ticker, params);
+    const result = await this.assetsService.unfreeze(ticker, transactionBaseDto);
     return handleServiceResult(result);
   }
 

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '~/test-utils/mocks';
 import { mockTransactionsProvider, MockTransactionsService } from '~/test-utils/service-mocks';
 
-const { did } = testValues;
+const { did, signer } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
@@ -270,7 +270,6 @@ describe('AssetsService', () => {
         transactions: [mockTransaction],
       });
 
-      const signer = 'signer';
       const body = {
         signer,
         documents: [
@@ -298,7 +297,7 @@ describe('AssetsService', () => {
 
   describe('createAsset', () => {
     const createBody = {
-      signer: '0x6000',
+      signer,
       name: 'Ticker Corp',
       ticker: 'TICKER',
       isDivisible: false,
@@ -349,7 +348,7 @@ describe('AssetsService', () => {
 
   describe('issue', () => {
     const issueBody = {
-      signer: '0x6000',
+      signer,
       amount: new BigNumber(1000),
     };
     it('should issue the asset', async () => {
@@ -379,7 +378,7 @@ describe('AssetsService', () => {
   describe('transferOwnership', () => {
     const ticker = 'TICKER';
     const body = {
-      signer: '0x6000',
+      signer,
       target: '0x1000',
       expiry: new Date(),
     };
@@ -418,7 +417,6 @@ describe('AssetsService', () => {
   describe('redeem', () => {
     const amount = new BigNumber(1000);
     const from = new BigNumber(1);
-    const signer = '0x6000';
     const redeemBody = {
       signer,
       amount,
@@ -465,7 +463,7 @@ describe('AssetsService', () => {
 
   describe('freeze', () => {
     const freezeBody = {
-      signer: '0x6000',
+      signer,
     };
     it('should freeze the asset', async () => {
       const transaction = {
@@ -493,7 +491,7 @@ describe('AssetsService', () => {
 
   describe('unfreeze', () => {
     const unfreezeBody = {
-      signer: '0x6000',
+      signer,
     };
     it('should unfreeze the asset', async () => {
       const transaction = {
@@ -521,8 +519,7 @@ describe('AssetsService', () => {
 
   describe('controllerTransfer', () => {
     it('should run a controllerTransfer procedure and return the queue results', async () => {
-      const signer = '0x6000';
-      const origin = new PortfolioDto({ id: new BigNumber(1), did: '0x1000' });
+      const origin = new PortfolioDto({ id: new BigNumber(1), did });
       const amount = new BigNumber(100);
 
       const transaction = {
@@ -552,7 +549,7 @@ describe('AssetsService', () => {
         mockAsset.controllerTransfer,
         {
           originPortfolio: {
-            identity: '0x1000',
+            identity: did,
             id: new BigNumber(1),
           },
           amount,

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -83,71 +83,79 @@ export class AssetsService {
     const {
       documents: { set },
     } = await this.findOne(ticker);
-    const { signer, webhookUrl, documents } = params;
-    return this.transactionsService.submit(set, { documents }, { signer, webhookUrl });
+    const { signer, webhookUrl, dryRun, documents } = params;
+    return this.transactionsService.submit(set, { documents }, { signer, webhookUrl, dryRun });
   }
 
   public async createAsset(params: CreateAssetDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
 
     const createAsset = this.polymeshService.polymeshApi.assets.createAsset;
-    return this.transactionsService.submit(createAsset, rest, { signer, webhookUrl });
+    return this.transactionsService.submit(createAsset, rest, { signer, webhookUrl, dryRun });
   }
 
   public async issue(ticker: string, params: IssueDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const asset = await this.findOne(ticker);
 
-    return this.transactionsService.submit(asset.issuance.issue, rest, { signer, webhookUrl });
+    return this.transactionsService.submit(asset.issuance.issue, rest, {
+      signer,
+      webhookUrl,
+      dryRun,
+    });
   }
 
   public async transferOwnership(
     ticker: string,
     params: TransferOwnershipDto
   ): ServiceReturn<AuthorizationRequest> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
 
     const { transferOwnership } = await this.findOne(ticker);
-    return this.transactionsService.submit(transferOwnership, rest, { signer, webhookUrl });
+    return this.transactionsService.submit(transferOwnership, rest, { signer, webhookUrl, dryRun });
   }
 
   public async redeem(ticker: string, params: RedeemTokensDto): ServiceReturn<void> {
-    const { signer, webhookUrl, amount, from } = params;
+    const { signer, webhookUrl, dryRun, amount, from } = params;
     const { redeem } = await this.findOne(ticker);
 
     return this.transactionsService.submit(
       redeem,
       { amount, from: toPortfolioId(from) },
-      { signer, webhookUrl }
+      { signer, webhookUrl, dryRun }
     );
   }
 
-  public async freeze(ticker: string, params: TransactionBaseDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
+  public async freeze(
+    ticker: string,
+    transactionBaseDto: TransactionBaseDto
+  ): ServiceReturn<Asset> {
     const asset = await this.findOne(ticker);
 
-    return this.transactionsService.submit(asset.freeze, {}, { signer, webhookUrl });
+    return this.transactionsService.submit(asset.freeze, {}, transactionBaseDto);
   }
 
-  public async unfreeze(ticker: string, params: TransactionBaseDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
+  public async unfreeze(
+    ticker: string,
+    transactionBaseDto: TransactionBaseDto
+  ): ServiceReturn<Asset> {
     const asset = await this.findOne(ticker);
 
-    return this.transactionsService.submit(asset.unfreeze, {}, { signer, webhookUrl });
+    return this.transactionsService.submit(asset.unfreeze, {}, transactionBaseDto);
   }
 
   public async controllerTransfer(
     ticker: string,
     params: ControllerTransferDto
   ): ServiceReturn<void> {
-    const { signer, webhookUrl, origin, amount } = params;
+    const { signer, webhookUrl, dryRun, origin, amount } = params;
 
     const { controllerTransfer } = await this.findOne(ticker);
 
     return this.transactionsService.submit(
       controllerTransfer,
       { originPortfolio: origin.toPortfolioLike(), amount },
-      { signer, webhookUrl }
+      { signer, webhookUrl, dryRun }
     );
   }
 

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -83,8 +83,9 @@ export class AssetsService {
     const {
       documents: { set },
     } = await this.findOne(ticker);
-    const { signer, webhookUrl, dryRun, documents } = params;
-    return this.transactionsService.submit(set, { documents }, { signer, webhookUrl, dryRun });
+    const { base, args } = extractTxBase(params);
+
+    return this.transactionsService.submit(set, args, base);
   }
 
   public async createAsset(params: CreateAssetDto): ServiceReturn<Asset> {

--- a/src/authorizations/authorizations.controller.spec.ts
+++ b/src/authorizations/authorizations.controller.spec.ts
@@ -3,11 +3,12 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 
 import { AuthorizationsController } from '~/authorizations/authorizations.controller';
 import { AuthorizationsService } from '~/authorizations/authorizations.service';
+import { testValues } from '~/test-utils/consts';
 import { MockAuthorizationsService } from '~/test-utils/service-mocks';
 
 describe('AuthorizationsController', () => {
   let controller: AuthorizationsController;
-
+  const { signer, txResult } = testValues;
   const mockAuthorizationsService = new MockAuthorizationsService();
 
   beforeEach(async () => {
@@ -28,37 +29,25 @@ describe('AuthorizationsController', () => {
 
   describe('accept', () => {
     it('should call the service and return the transaction details', async () => {
-      const transactions = ['transaction'];
-
-      mockAuthorizationsService.accept.mockResolvedValue({ transactions });
+      mockAuthorizationsService.accept.mockResolvedValue(txResult);
 
       const authId = new BigNumber(1);
-      const signer = '0x6000';
       const result = await controller.accept({ id: authId }, { signer });
 
-      expect(result).toEqual({
-        result: undefined,
-        transactions: ['transaction'],
-      });
-      expect(mockAuthorizationsService.accept).toHaveBeenCalledWith(authId, signer, undefined);
+      expect(result).toEqual(txResult);
+      expect(mockAuthorizationsService.accept).toHaveBeenCalledWith(authId, { signer });
     });
   });
 
   describe('remove', () => {
     it('should call the service and return the transaction details', async () => {
-      const transactions = ['transaction'];
-
-      mockAuthorizationsService.remove.mockResolvedValue({ transactions });
+      mockAuthorizationsService.remove.mockResolvedValue(txResult);
 
       const authId = new BigNumber(1);
-      const signer = '0x6000';
       const result = await controller.remove({ id: authId }, { signer });
 
-      expect(result).toEqual({
-        result: undefined,
-        transactions: ['transaction'],
-      });
-      expect(mockAuthorizationsService.remove).toHaveBeenCalledWith(authId, signer, undefined);
+      expect(result).toEqual(txResult);
+      expect(mockAuthorizationsService.remove).toHaveBeenCalledWith(authId, { signer });
     });
   });
 });

--- a/src/authorizations/authorizations.controller.ts
+++ b/src/authorizations/authorizations.controller.ts
@@ -39,9 +39,9 @@ export class AuthorizationsController {
   @Post('/:id/accept')
   public async accept(
     @Param() { id }: IdParamsDto,
-    @Body() { signer, webhookUrl }: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.authorizationsService.accept(id, signer, webhookUrl);
+    const result = await this.authorizationsService.accept(id, transactionBaseDto);
 
     return handleServiceResult(result);
   }
@@ -72,9 +72,9 @@ export class AuthorizationsController {
   @Post('/:id/remove')
   public async remove(
     @Param() { id }: IdParamsDto,
-    @Body() { signer, webhookUrl }: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.authorizationsService.remove(id, signer, webhookUrl);
+    const result = await this.authorizationsService.remove(id, transactionBaseDto);
 
     return handleServiceResult(result);
   }

--- a/src/authorizations/authorizations.service.spec.ts
+++ b/src/authorizations/authorizations.service.spec.ts
@@ -31,7 +31,7 @@ jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
 
-const { signer, did } = testValues;
+const { signer, did, txResult } = testValues;
 
 describe('AuthorizationsService', () => {
   let service: AuthorizationsService;
@@ -343,10 +343,14 @@ describe('AuthorizationsService', () => {
       getAuthRequestSpy.mockResolvedValue(mockAuthorizationRequest as any);
 
       mockTransactionsService.getSigningAccount.mockResolvedValue('address');
-      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
+      mockTransactionsService.submit.mockResolvedValue({
+        ...txResult,
+        transactions: [mockTransaction],
+      });
 
-      const result = await service.accept(new BigNumber(1), '0x6000');
+      const result = await service.accept(new BigNumber(1), { signer });
       expect(result).toEqual({
+        ...txResult,
         result: undefined,
         transactions: [mockTransaction],
       });
@@ -372,10 +376,14 @@ describe('AuthorizationsService', () => {
       getAuthRequestSpy.mockResolvedValue(mockAuthorizationRequest as any);
 
       mockTransactionsService.getSigningAccount.mockResolvedValue('address');
-      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
+      mockTransactionsService.submit.mockResolvedValue({
+        ...txResult,
+        transactions: [mockTransaction],
+      });
 
-      const result = await service.remove(new BigNumber(2), '0x6000');
+      const result = await service.remove(new BigNumber(2), { signer });
       expect(result).toEqual({
+        ...txResult,
         result: undefined,
         transactions: [mockTransaction],
       });

--- a/src/authorizations/authorizations.service.ts
+++ b/src/authorizations/authorizations.service.ts
@@ -11,6 +11,7 @@ import {
 import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { AccountsService } from '~/accounts/accounts.service';
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { ServiceReturn } from '~/common/utils';
 import { IdentitiesService } from '~/identities/identities.service';
 import { TransactionsService } from '~/transactions/transactions.service';
@@ -90,19 +91,21 @@ export class AuthorizationsService {
     return authRequest;
   }
 
-  public async accept(id: BigNumber, signer: string, webhookUrl?: string): ServiceReturn<void> {
+  public async accept(id: BigNumber, transactionBaseDto: TransactionBaseDto): ServiceReturn<void> {
+    const { signer } = transactionBaseDto;
     const address = await this.transactionsService.getSigningAccount(signer);
 
     const { accept } = await this.getAuthRequest(address, id);
 
-    return this.transactionsService.submit(accept, {}, { signer, webhookUrl });
+    return this.transactionsService.submit(accept, {}, transactionBaseDto);
   }
 
-  public async remove(id: BigNumber, signer: string, webhookUrl?: string): ServiceReturn<void> {
+  public async remove(id: BigNumber, transactionBaseDto: TransactionBaseDto): ServiceReturn<void> {
+    const { signer } = transactionBaseDto;
     const address = await this.transactionsService.getSigningAccount(signer);
 
     const { remove } = await this.getAuthRequest(address, id);
 
-    return this.transactionsService.submit(remove, {}, { signer, webhookUrl });
+    return this.transactionsService.submit(remove, {}, transactionBaseDto);
   }
 }

--- a/src/authorizations/models/created-authorization-request.model.ts
+++ b/src/authorizations/models/created-authorization-request.model.ts
@@ -15,8 +15,8 @@ export class CreatedAuthorizationRequestModel extends TransactionQueueModel {
   readonly authorizationRequest: AuthorizationRequestModel;
 
   constructor(model: CreatedAuthorizationRequestModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/checkpoints/checkpoints.controller.spec.ts
+++ b/src/checkpoints/checkpoints.controller.spec.ts
@@ -13,7 +13,7 @@ import { testValues } from '~/test-utils/consts';
 import { MockCheckpoint, MockCheckpointSchedule } from '~/test-utils/mocks';
 import { MockCheckpointsService } from '~/test-utils/service-mocks';
 
-const { did, signer } = testValues;
+const { did, signer, txResult } = testValues;
 
 describe('CheckpointsController', () => {
   let controller: CheckpointsController;
@@ -107,8 +107,8 @@ describe('CheckpointsController', () => {
     it('should return the details of newly created Checkpoint', async () => {
       const mockCheckpoint = new MockCheckpoint();
       const response = {
+        ...txResult,
         result: mockCheckpoint,
-        transactions: ['transaction'],
       };
       mockCheckpointsService.createByTicker.mockResolvedValue(response);
       const body = {
@@ -118,8 +118,8 @@ describe('CheckpointsController', () => {
       const result = await controller.createCheckpoint({ ticker: 'TICKER' }, body);
 
       expect(result).toEqual({
+        ...txResult,
         checkpoint: mockCheckpoint,
-        transactions: ['transaction'],
       });
     });
   });
@@ -198,8 +198,8 @@ describe('CheckpointsController', () => {
 
       const mockCheckpointSchedule = new MockCheckpointSchedule();
       const response = {
+        ...txResult,
         result: mockCheckpointSchedule,
-        transactions: ['transaction'],
       };
       mockCheckpointsService.createScheduleByTicker.mockResolvedValue(response);
 
@@ -226,8 +226,8 @@ describe('CheckpointsController', () => {
         ...mockScheduleWithDetails.details,
       });
       expect(result).toEqual({
+        ...txResult,
         schedule: mockCreatedSchedule,
-        transactions: ['transaction'],
       });
     });
   });
@@ -300,19 +300,14 @@ describe('CheckpointsController', () => {
 
   describe('deleteSchedule', () => {
     it('should return the transaction details', async () => {
-      const response = {
-        transactions: ['transaction'],
-      };
-      mockCheckpointsService.deleteScheduleByTicker.mockResolvedValue(response);
+      mockCheckpointsService.deleteScheduleByTicker.mockResolvedValue(txResult);
 
       const result = await controller.deleteSchedule(
         { id: new BigNumber(1), ticker: 'TICKER' },
         { signer }
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
     });
   });
 });

--- a/src/checkpoints/checkpoints.controller.ts
+++ b/src/checkpoints/checkpoints.controller.ts
@@ -157,10 +157,15 @@ export class CheckpointsController {
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.checkpointsService.createByTicker(ticker, signerDto);
 
-    const resolver: TransactionResolver<Checkpoint> = ({ result: checkpoint, transactions }) =>
+    const resolver: TransactionResolver<Checkpoint> = ({
+      result: checkpoint,
+      transactions,
+      details,
+    }) =>
       new CreatedCheckpointModel({
         checkpoint,
         transactions,
+        details,
       });
 
     return handleServiceResult(serviceResult, resolver);
@@ -271,10 +276,11 @@ export class CheckpointsController {
     const resolver: TransactionResolver<CheckpointSchedule> = async ({
       result: { id: createdScheduleId },
       transactions,
+      details,
     }) => {
       const {
         schedule: { id, period, start, complexity, expiryDate },
-        details,
+        details: scheduleDetails,
       } = await this.checkpointsService.findScheduleById(ticker, createdScheduleId);
 
       return new CreatedCheckpointScheduleModel({
@@ -285,9 +291,10 @@ export class CheckpointsController {
           start,
           complexity,
           expiryDate,
-          ...details,
+          ...scheduleDetails,
         }),
         transactions,
+        details,
       });
     };
 
@@ -412,13 +419,12 @@ export class CheckpointsController {
   @Post('schedules/:id/delete')
   public async deleteSchedule(
     @Param() { ticker, id }: DeleteCheckpointScheduleParamsDto,
-    @Query() { signer, webhookUrl }: TransactionBaseDto
+    @Query() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.checkpointsService.deleteScheduleByTicker(
       ticker,
       id,
-      signer,
-      webhookUrl
+      transactionBaseDto
     );
     return handleServiceResult(result);
   }

--- a/src/checkpoints/checkpoints.service.spec.ts
+++ b/src/checkpoints/checkpoints.service.spec.ts
@@ -428,7 +428,7 @@ describe('CheckpointsService', () => {
         const ticker = 'TICKER';
         const id = new BigNumber(1);
 
-        const result = await service.deleteScheduleByTicker(ticker, id, signer);
+        const result = await service.deleteScheduleByTicker(ticker, id, { signer });
         expect(result).toEqual({
           result: undefined,
           transactions: [mockTransaction],

--- a/src/checkpoints/checkpoints.service.ts
+++ b/src/checkpoints/checkpoints.service.ts
@@ -83,17 +83,21 @@ export class CheckpointsService {
     ticker: string,
     signerDto: TransactionBaseDto
   ): ServiceReturn<Checkpoint> {
-    const { signer, webhookUrl } = signerDto;
+    const { signer, webhookUrl, dryRun } = signerDto;
     const asset = await this.assetsService.findOne(ticker);
 
-    return this.transactionsService.submit(asset.checkpoints.create, {}, { signer, webhookUrl });
+    return this.transactionsService.submit(
+      asset.checkpoints.create,
+      {},
+      { signer, webhookUrl, dryRun }
+    );
   }
 
   public async createScheduleByTicker(
     ticker: string,
     createCheckpointScheduleDto: CreateCheckpointScheduleDto
   ): ServiceReturn<CheckpointSchedule> {
-    const { signer, webhookUrl, ...rest } = createCheckpointScheduleDto;
+    const { signer, webhookUrl, dryRun, ...rest } = createCheckpointScheduleDto;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(asset.checkpoints.schedules.create, rest, {
@@ -125,14 +129,13 @@ export class CheckpointsService {
   public async deleteScheduleByTicker(
     ticker: string,
     id: BigNumber,
-    signer: string,
-    webhookUrl?: string
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const asset = await this.assetsService.findOne(ticker);
     return this.transactionsService.submit(
       asset.checkpoints.schedules.remove,
       { schedule: id },
-      { signer, webhookUrl }
+      transactionBaseDto
     );
   }
 }

--- a/src/checkpoints/checkpoints.service.ts
+++ b/src/checkpoints/checkpoints.service.ts
@@ -15,7 +15,7 @@ import { AssetsService } from '~/assets/assets.service';
 import { IdentityBalanceModel } from '~/assets/models/identity-balance.model';
 import { CreateCheckpointScheduleDto } from '~/checkpoints/dto/create-checkpoint-schedule.dto';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
-import { ServiceReturn } from '~/common/utils';
+import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { PolymeshLogger } from '~/logger/polymesh-logger.service';
 import { TransactionsService } from '~/transactions/transactions.service';
 
@@ -83,27 +83,20 @@ export class CheckpointsService {
     ticker: string,
     signerDto: TransactionBaseDto
   ): ServiceReturn<Checkpoint> {
-    const { signer, webhookUrl, dryRun } = signerDto;
     const asset = await this.assetsService.findOne(ticker);
 
-    return this.transactionsService.submit(
-      asset.checkpoints.create,
-      {},
-      { signer, webhookUrl, dryRun }
-    );
+    return this.transactionsService.submit(asset.checkpoints.create, {}, signerDto);
   }
 
   public async createScheduleByTicker(
     ticker: string,
     createCheckpointScheduleDto: CreateCheckpointScheduleDto
   ): ServiceReturn<CheckpointSchedule> {
-    const { signer, webhookUrl, dryRun, ...rest } = createCheckpointScheduleDto;
+    const { base, args } = extractTxBase(createCheckpointScheduleDto);
+
     const asset = await this.assetsService.findOne(ticker);
 
-    return this.transactionsService.submit(asset.checkpoints.schedules.create, rest, {
-      signer,
-      webhookUrl,
-    });
+    return this.transactionsService.submit(asset.checkpoints.schedules.create, args, base);
   }
 
   public async getAssetBalance(

--- a/src/checkpoints/models/created-checkpoint-schedule.model.ts
+++ b/src/checkpoints/models/created-checkpoint-schedule.model.ts
@@ -15,8 +15,8 @@ export class CreatedCheckpointScheduleModel extends TransactionQueueModel {
   readonly schedule: CheckpointScheduleModel;
 
   constructor(model: CreatedCheckpointScheduleModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/checkpoints/models/created-checkpoint.model.ts
+++ b/src/checkpoints/models/created-checkpoint.model.ts
@@ -18,8 +18,8 @@ export class CreatedCheckpointModel extends TransactionQueueModel {
   readonly checkpoint: Checkpoint;
 
   constructor(model: CreatedCheckpointModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/common/dto/transaction-base-dto.ts
+++ b/src/common/dto/transaction-base-dto.ts
@@ -21,7 +21,7 @@ export class TransactionBaseDto {
   @ApiProperty({
     description:
       'An optional property that when set to `true` will will verify the validity of the transaction without submitting it to the chain',
-    example: true,
+    example: false,
   })
   @IsBoolean()
   @IsOptional()

--- a/src/common/dto/transaction-base-dto.ts
+++ b/src/common/dto/transaction-base-dto.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
 import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUrl } from 'class-validator';
+import { IsBoolean, IsOptional, IsString, IsUrl } from 'class-validator';
 
 export class TransactionBaseDto {
   @ApiProperty({
@@ -17,4 +17,13 @@ export class TransactionBaseDto {
   @IsString()
   @IsUrl()
   readonly webhookUrl?: string;
+
+  @ApiProperty({
+    description:
+      'An optional property that when set to `true` will will verify the validity of the transaction without submitting it to the chain',
+    example: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  readonly dryRun?: boolean;
 }

--- a/src/common/models/fees.model.ts
+++ b/src/common/models/fees.model.ts
@@ -1,0 +1,24 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+
+export class FeesModel {
+  @ApiProperty({ type: 'string' })
+  @FromBigNumber()
+  readonly protocol: BigNumber;
+
+  @ApiProperty({ type: 'string' })
+  @FromBigNumber()
+  readonly gas: BigNumber;
+
+  @ApiProperty({ type: 'string' })
+  @FromBigNumber()
+  readonly total: BigNumber;
+
+  constructor(model: FeesModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/common/models/fees.model.ts
+++ b/src/common/models/fees.model.ts
@@ -6,15 +6,27 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { FromBigNumber } from '~/common/decorators/transformation';
 
 export class FeesModel {
-  @ApiProperty({ type: 'string' })
+  @ApiProperty({
+    type: 'string',
+    description: 'The amount of POLYX that will be charged for the transaction as protocol fee',
+    example: '0.5',
+  })
   @FromBigNumber()
   readonly protocol: BigNumber;
 
-  @ApiProperty({ type: 'string' })
+  @ApiProperty({
+    type: 'string',
+    description: 'The amount of POLYX that will be charged for the transaction as GAS fee',
+    example: '0.5',
+  })
   @FromBigNumber()
   readonly gas: BigNumber;
 
-  @ApiProperty({ type: 'string' })
+  @ApiProperty({
+    type: 'string',
+    description: 'The total amount of POLYX that will be charged for the transaction',
+    example: '1',
+  })
   @FromBigNumber()
   readonly total: BigNumber;
 

--- a/src/common/models/paying-account.model.ts
+++ b/src/common/models/paying-account.model.ts
@@ -21,15 +21,13 @@ export class PayingAccountModel {
     enum: PayingAccountType,
     example: PayingAccountType.Caller,
   })
-  @FromBigNumber()
   readonly type: string;
 
   @ApiProperty({
     type: 'string',
-    description: 'Paying account address on the chain',
+    description: 'The paying account address',
     example: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
   })
-  @FromBigNumber()
   readonly address: string;
 
   constructor(model: PayingAccountModel) {

--- a/src/common/models/paying-account.model.ts
+++ b/src/common/models/paying-account.model.ts
@@ -15,7 +15,6 @@ export class PayingAccountModel {
   @FromBigNumber()
   readonly balance: BigNumber;
 
-  @ApiProperty({ type: 'string', description: 'Paying account type', example: 'Caller' })
   @ApiProperty({
     description: 'Paying account type',
     enum: PayingAccountType,

--- a/src/common/models/paying-account.model.ts
+++ b/src/common/models/paying-account.model.ts
@@ -1,0 +1,38 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+import { PayingAccountType } from '@polymeshassociation/polymesh-sdk/types';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+
+export class PayingAccountModel {
+  @ApiProperty({
+    type: 'string',
+    description: 'The balance of the paying account',
+    example: '29996999.366176',
+  })
+  @FromBigNumber()
+  readonly balance: BigNumber;
+
+  @ApiProperty({ type: 'string', description: 'Paying account type', example: 'Caller' })
+  @ApiProperty({
+    description: 'Paying account type',
+    enum: PayingAccountType,
+    example: PayingAccountType.Caller,
+  })
+  @FromBigNumber()
+  readonly type: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'Paying account address on the chain',
+    example: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+  })
+  @FromBigNumber()
+  readonly address: string;
+
+  constructor(model: PayingAccountModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/common/models/transaction-details.model.ts
+++ b/src/common/models/transaction-details.model.ts
@@ -17,7 +17,12 @@ export class TransactionDetailsModel {
   @ApiProperty({ description: 'Transaction fees', type: FeesModel })
   readonly fees: FeesModel;
 
-  @ApiProperty({ type: 'boolean', example: true })
+  @ApiProperty({
+    type: 'boolean',
+    example: true,
+    description:
+      'Not all transaction can be subsidized. Can be used to check if the transaction can be subsidized',
+  })
   readonly supportsSubsidy: boolean;
 
   @ApiProperty({

--- a/src/common/models/transaction-details.model.ts
+++ b/src/common/models/transaction-details.model.ts
@@ -1,0 +1,25 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+
+import { FeesModel } from '~/common/models/fees.model';
+import { TransactionDetails } from '~/transactions/transactions.util';
+
+export class TransactionDetailsModel {
+  @ApiProperty({ type: 'string', example: 'pending' })
+  readonly status: string;
+
+  @ApiProperty({ type: 'string', example: '2' })
+  readonly fees: FeesModel;
+
+  @ApiProperty({ type: 'boolean', example: true })
+  readonly supportsSubsidy: boolean;
+
+  // TODO: define a model for this
+  @ApiProperty({ type: 'string', example: '2' })
+  readonly payingAccount: TransactionDetails['payingAccount'];
+
+  constructor(model: TransactionDetails) {
+    Object.assign(this, model);
+  }
+}

--- a/src/common/models/transaction-details.model.ts
+++ b/src/common/models/transaction-details.model.ts
@@ -33,12 +33,7 @@ export class TransactionDetailsModel {
   @Type(() => PayingAccountModel)
   readonly payingAccount: PayingAccountModel;
 
-  constructor({ status, fees, supportsSubsidy, payingAccount }: TransactionDetailsModel) {
-    Object.assign(this, {
-      status,
-      supportsSubsidy,
-      payingAccount,
-      fees,
-    });
+  constructor(model: TransactionDetailsModel) {
+    Object.assign(this, model);
   }
 }

--- a/src/common/models/transaction-details.model.ts
+++ b/src/common/models/transaction-details.model.ts
@@ -1,25 +1,37 @@
 /* istanbul ignore file */
 
 import { ApiProperty } from '@nestjs/swagger';
+import { TransactionStatus } from '@polymeshassociation/polymesh-sdk/types';
 
 import { FeesModel } from '~/common/models/fees.model';
-import { TransactionDetails } from '~/transactions/transactions.util';
+import { PayingAccountModel } from '~/common/models/paying-account.model';
 
 export class TransactionDetailsModel {
-  @ApiProperty({ type: 'string', example: 'pending' })
+  @ApiProperty({
+    description: 'Transaction status',
+    enum: TransactionStatus,
+    example: TransactionStatus.Idle,
+  })
   readonly status: string;
 
-  @ApiProperty({ type: 'string', example: '2' })
+  @ApiProperty({ description: 'Transaction fees', type: FeesModel })
   readonly fees: FeesModel;
 
   @ApiProperty({ type: 'boolean', example: true })
   readonly supportsSubsidy: boolean;
 
-  // TODO: define a model for this
-  @ApiProperty({ type: 'string', example: '2' })
-  readonly payingAccount: TransactionDetails['payingAccount'];
+  @ApiProperty({
+    description: 'Paying account details',
+    type: PayingAccountModel,
+  })
+  readonly payingAccount: PayingAccountModel;
 
-  constructor(model: TransactionDetails) {
-    Object.assign(this, model);
+  constructor({ status, fees, supportsSubsidy, payingAccount }: TransactionDetailsModel) {
+    Object.assign(this, {
+      status,
+      supportsSubsidy,
+      payingAccount: new PayingAccountModel(payingAccount),
+      fees: new FeesModel(fees),
+    });
   }
 }

--- a/src/common/models/transaction-details.model.ts
+++ b/src/common/models/transaction-details.model.ts
@@ -2,6 +2,7 @@
 
 import { ApiProperty } from '@nestjs/swagger';
 import { TransactionStatus } from '@polymeshassociation/polymesh-sdk/types';
+import { Type } from 'class-transformer';
 
 import { FeesModel } from '~/common/models/fees.model';
 import { PayingAccountModel } from '~/common/models/paying-account.model';
@@ -15,13 +16,13 @@ export class TransactionDetailsModel {
   readonly status: string;
 
   @ApiProperty({ description: 'Transaction fees', type: FeesModel })
+  @Type(() => FeesModel)
   readonly fees: FeesModel;
 
   @ApiProperty({
     type: 'boolean',
     example: true,
-    description:
-      'Not all transaction can be subsidized. Can be used to check if the transaction can be subsidized',
+    description: 'Indicates if the transaction can be subsidized',
   })
   readonly supportsSubsidy: boolean;
 
@@ -29,14 +30,15 @@ export class TransactionDetailsModel {
     description: 'Paying account details',
     type: PayingAccountModel,
   })
+  @Type(() => PayingAccountModel)
   readonly payingAccount: PayingAccountModel;
 
   constructor({ status, fees, supportsSubsidy, payingAccount }: TransactionDetailsModel) {
     Object.assign(this, {
       status,
       supportsSubsidy,
-      payingAccount: new PayingAccountModel(payingAccount),
-      fees: new FeesModel(fees),
+      payingAccount,
+      fees,
     });
   }
 }

--- a/src/common/models/transaction-queue.model.ts
+++ b/src/common/models/transaction-queue.model.ts
@@ -42,7 +42,7 @@ export class TransactionQueueModel {
   @Type(() => TransactionDetailsModel)
   details: TransactionDetailsModel;
 
-  constructor(transactionDetails: TransactionQueueModel) {
-    Object.assign(this, transactionDetails);
+  constructor(model: TransactionQueueModel) {
+    Object.assign(this, model);
   }
 }

--- a/src/common/models/transaction-queue.model.ts
+++ b/src/common/models/transaction-queue.model.ts
@@ -39,9 +39,10 @@ export class TransactionQueueModel {
     description: 'Transaction details',
     isArray: true,
   })
+  @Type(() => TransactionDetailsModel)
   details: TransactionDetailsModel;
 
-  constructor({ details, ...rest }: TransactionQueueModel) {
-    Object.assign(this, { ...rest, details: new TransactionDetailsModel(details) });
+  constructor(transactionDetails: TransactionQueueModel) {
+    Object.assign(this, transactionDetails);
   }
 }

--- a/src/common/models/transaction-queue.model.ts
+++ b/src/common/models/transaction-queue.model.ts
@@ -1,10 +1,11 @@
 /* istanbul ignore file */
 
-import { ApiExtraModels } from '@nestjs/swagger';
+import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { ApiPropertyOneOf } from '~/common/decorators/swagger';
 import { BatchTransactionModel } from '~/common/models/batch-transaction.model';
+import { TransactionDetailsModel } from '~/common/models/transaction-details.model';
 import { TransactionIdentifierModel } from '~/common/models/transaction-identifier.model';
 import { TransactionModel } from '~/common/models/transaction.model';
 import { TransactionType } from '~/common/types';
@@ -33,6 +34,12 @@ export class TransactionQueueModel {
     },
   })
   transactions: (TransactionModel | BatchTransactionModel)[];
+
+  @ApiProperty({
+    description: 'Transaction details',
+    isArray: true,
+  })
+  details: TransactionDetailsModel;
 
   constructor(model: TransactionQueueModel) {
     Object.assign(this, model);

--- a/src/common/models/transaction-queue.model.ts
+++ b/src/common/models/transaction-queue.model.ts
@@ -41,7 +41,7 @@ export class TransactionQueueModel {
   })
   details: TransactionDetailsModel;
 
-  constructor(model: TransactionQueueModel) {
-    Object.assign(this, model);
+  constructor({ details, ...rest }: TransactionQueueModel) {
+    Object.assign(this, { ...rest, details: new TransactionDetailsModel(details) });
   }
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -46,16 +46,16 @@ export const handleServiceResult = <T>(
 ): NotificationPayloadModel | Promise<TransactionQueueModel> | TransactionQueueModel => {
   if ('transactions' in result) {
     return resolver(result);
-  } else {
-    return new NotificationPayloadModel(result);
   }
+
+  return new NotificationPayloadModel(result);
 };
 
 /**
  * A helper function for controllers when they should return a basic TransactionQueueModel
  */
-const basicModelResolver: TransactionResolver<unknown> = ({ transactions }) => {
-  return new TransactionQueueModel({ transactions });
+const basicModelResolver: TransactionResolver<unknown> = ({ transactions, details }) => {
+  return new TransactionQueueModel({ transactions, details });
 };
 
 /**

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'crypto';
 import { flatten } from 'lodash';
 import { promisify } from 'util';
 
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { NotificationPayloadModel } from '~/common/models/notification-payload-model';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { EventType } from '~/events/types';
@@ -78,3 +79,16 @@ export class UnreachableCaseError extends Error {
     super(`Unreachable case: ${JSON.stringify(val)}`);
   }
 }
+
+export const extractTxBase = <T extends TransactionBaseDto>(
+  params: T
+): {
+  base: TransactionBaseDto;
+  args: Omit<T, keyof TransactionBaseDto>;
+} => {
+  const { signer, webhookUrl, dryRun, ...args } = params;
+  return {
+    base: { signer, webhookUrl, dryRun },
+    args,
+  };
+};

--- a/src/compliance/compliance-requirements.controller.spec.ts
+++ b/src/compliance/compliance-requirements.controller.spec.ts
@@ -8,12 +8,14 @@ import { RequirementDto } from '~/compliance/dto/requirement.dto';
 import { SetRequirementsDto } from '~/compliance/dto/set-requirements.dto';
 import { MockComplianceRequirements } from '~/compliance/mocks/compliance-requirements.mock';
 import { ComplianceRequirementsModel } from '~/compliance/models/compliance-requirements.model';
+import { testValues } from '~/test-utils/consts';
 import { MockComplianceRequirementsService } from '~/test-utils/service-mocks';
 
 describe('ComplianceRequirementsController', () => {
   let controller: ComplianceRequirementsController;
 
   const mockService = new MockComplianceRequirementsService();
+  const { txResult } = testValues;
 
   const ticker = 'TICKER';
   const validBody = {
@@ -65,94 +67,73 @@ describe('ComplianceRequirementsController', () => {
 
   describe('setRequirements', () => {
     it('should accept SetRulesDto and set new Asset Compliance Rules', async () => {
-      const response = {
-        transactions: [],
-      };
-      mockService.setRequirements.mockResolvedValue(response);
+      mockService.setRequirements.mockResolvedValue(txResult);
       const result = await controller.setRequirements({ ticker }, validBody as SetRequirementsDto);
-      expect(result).toEqual(response);
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('pauseRequirements', () => {
     it('should accept TransactionBaseDto and pause Asset Compliance Rules', async () => {
-      const response = {
-        transactions: [],
-      };
-      mockService.pauseRequirements.mockResolvedValue(response);
+      mockService.pauseRequirements.mockResolvedValue(txResult);
       const result = await controller.pauseRequirements(
         { ticker },
         validBody as TransactionBaseDto
       );
-      expect(result).toEqual(response);
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('unpauseRequirements', () => {
     it('should accept TransactionBaseDto and unpause Asset Compliance Rules', async () => {
-      const response = {
-        transactions: [],
-      };
-      mockService.unpauseRequirements.mockResolvedValue(response);
+      mockService.unpauseRequirements.mockResolvedValue(txResult);
       const result = await controller.pauseRequirements(
         { ticker },
         validBody as TransactionBaseDto
       );
-      expect(result).toEqual(response);
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('deleteRequirement', () => {
     it('should accept TransactionBaseDto and compliance requirement ID and delete the corresponding Asset Compliance rule for the given ticker', async () => {
-      const response = {
-        transactions: [],
-      };
-      mockService.deleteOne.mockResolvedValue(response);
+      mockService.deleteOne.mockResolvedValue(txResult);
       const result = await controller.deleteRequirement(
         { ticker, id: new BigNumber(1) },
         validBody as TransactionBaseDto
       );
 
-      expect(result).toEqual(response);
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('deleteRequirements', () => {
     it('should accept TransactionBaseDto and delete all the Asset Compliance rules for the given ticker', async () => {
-      const response = {
-        transactions: [],
-      };
-      mockService.deleteAll.mockResolvedValue(response);
+      mockService.deleteAll.mockResolvedValue(txResult);
       const result = await controller.deleteRequirements(
         { ticker },
         validBody as TransactionBaseDto
       );
 
-      expect(result).toEqual(response);
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('addRequirement', () => {
     it('should accept RequirementDto and add an Asset Compliance rule', async () => {
-      const response = {
-        transactions: [],
-      };
-      mockService.add.mockResolvedValue(response);
+      mockService.add.mockResolvedValue(txResult);
       const { signer, requirements } = validBody;
       const result = await controller.addRequirement({ ticker }, {
         signer,
         conditions: requirements[0],
       } as RequirementDto);
-      expect(result).toEqual(response);
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('modifyComplianceRequirement', () => {
     it('should accept RequirementDto and modify the corresponding Asset Compliance rule', async () => {
-      const response = {
-        transactions: [],
-      };
-      mockService.modify.mockResolvedValue(response);
+      mockService.modify.mockResolvedValue(txResult);
       const { signer, requirements } = validBody;
       const result = await controller.modifyComplianceRequirement(
         { ticker, id: new BigNumber(1) },
@@ -161,7 +142,7 @@ describe('ComplianceRequirementsController', () => {
           conditions: requirements[0],
         } as RequirementDto
       );
-      expect(result).toEqual(response);
+      expect(result).toEqual(txResult);
     });
   });
 });

--- a/src/compliance/compliance-requirements.controller.ts
+++ b/src/compliance/compliance-requirements.controller.ts
@@ -109,9 +109,12 @@ export class ComplianceRequirementsController {
   @Post('pause')
   public async pauseRequirements(
     @Param() { ticker }: TickerParamsDto,
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.pauseRequirements(ticker, params);
+    const result = await this.complianceRequirementsService.pauseRequirements(
+      ticker,
+      transactionBaseDto
+    );
     return handleServiceResult(result);
   }
 
@@ -135,9 +138,12 @@ export class ComplianceRequirementsController {
   @Post('unpause')
   public async unpauseRequirements(
     @Param() { ticker }: TickerParamsDto,
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.unpauseRequirements(ticker, params);
+    const result = await this.complianceRequirementsService.unpauseRequirements(
+      ticker,
+      transactionBaseDto
+    );
     return handleServiceResult(result);
   }
 
@@ -168,9 +174,13 @@ export class ComplianceRequirementsController {
   @Post(':id/delete')
   public async deleteRequirement(
     @Param() { id, ticker }: RequirementParamsDto,
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.deleteOne(ticker, id, params);
+    const result = await this.complianceRequirementsService.deleteOne(
+      ticker,
+      id,
+      transactionBaseDto
+    );
 
     return handleServiceResult(result);
   }
@@ -198,9 +208,9 @@ export class ComplianceRequirementsController {
   @Post('delete')
   public async deleteRequirements(
     @Param() { ticker }: TickerParamsDto,
-    @Body() params: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.deleteAll(ticker, params);
+    const result = await this.complianceRequirementsService.deleteAll(ticker, transactionBaseDto);
 
     return handleServiceResult(result);
   }

--- a/src/compliance/compliance-requirements.service.ts
+++ b/src/compliance/compliance-requirements.service.ts
@@ -29,7 +29,7 @@ export class ComplianceRequirementsService {
   }
 
   public async setRequirements(ticker: string, params: SetRequirementsDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
+    const { signer, webhookUrl, dryRun } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
@@ -38,92 +38,89 @@ export class ComplianceRequirementsService {
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }
 
-  public async pauseRequirements(ticker: string, params: TransactionBaseDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
+  public async pauseRequirements(
+    ticker: string,
+    transactionBaseDto: TransactionBaseDto
+  ): ServiceReturn<Asset> {
     const asset = await this.assetsService.findOne(ticker);
     return this.transactionsService.submit(
       asset.compliance.requirements.pause,
       {},
-      {
-        signer,
-        webhookUrl,
-      }
+      transactionBaseDto
     );
   }
 
   public async unpauseRequirements(
     ticker: string,
-    params: TransactionBaseDto
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
       asset.compliance.requirements.unpause,
       {},
-      {
-        signer,
-        webhookUrl,
-      }
+      transactionBaseDto
     );
   }
 
   public async deleteOne(
     ticker: string,
     id: BigNumber,
-    params: TransactionBaseDto
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
       asset.compliance.requirements.remove,
       { requirement: id },
-      {
-        signer,
-        webhookUrl,
-      }
+      transactionBaseDto
     );
   }
 
-  public async deleteAll(ticker: string, params: TransactionBaseDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
+  public async deleteAll(
+    ticker: string,
+    transactionBaseDto: TransactionBaseDto
+  ): ServiceReturn<Asset> {
     const asset = await this.assetsService.findOne(ticker);
 
-    return this.transactionsService.submit(asset.compliance.requirements.reset, undefined, {
-      signer,
-      webhookUrl,
-    });
+    return this.transactionsService.submit(
+      asset.compliance.requirements.reset,
+      undefined,
+      transactionBaseDto
+    );
   }
 
   public async add(ticker: string, params: RequirementDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
       asset.compliance.requirements.add,
-      params as AddAssetRequirementParams,
+      rest as AddAssetRequirementParams,
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }
 
   public async modify(ticker: string, id: BigNumber, params: RequirementDto): ServiceReturn<void> {
-    const { signer, webhookUrl } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
       asset.compliance.requirements.modify,
-      { id, ...params } as ModifyComplianceRequirementParams,
+      { id, ...rest } as ModifyComplianceRequirementParams,
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }

--- a/src/compliance/compliance-requirements.service.ts
+++ b/src/compliance/compliance-requirements.service.ts
@@ -10,7 +10,7 @@ import {
 
 import { AssetsService } from '~/assets/assets.service';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
-import { ServiceReturn } from '~/common/utils';
+import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { RequirementDto } from '~/compliance/dto/requirement.dto';
 import { SetRequirementsDto } from '~/compliance/dto/set-requirements.dto';
 import { TransactionsService } from '~/transactions/transactions.service';
@@ -29,17 +29,14 @@ export class ComplianceRequirementsService {
   }
 
   public async setRequirements(ticker: string, params: SetRequirementsDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, dryRun } = params;
+    const { base, args } = extractTxBase(params);
+
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
       asset.compliance.requirements.set,
-      params as SetAssetRequirementsParams,
-      {
-        signer,
-        webhookUrl,
-        dryRun,
-      }
+      args as SetAssetRequirementsParams,
+      base
     );
   }
 
@@ -96,32 +93,26 @@ export class ComplianceRequirementsService {
   }
 
   public async add(ticker: string, params: RequirementDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, dryRun, ...rest } = params;
+    const { base, args } = extractTxBase(params);
+
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
       asset.compliance.requirements.add,
-      rest as AddAssetRequirementParams,
-      {
-        signer,
-        webhookUrl,
-        dryRun,
-      }
+      args as AddAssetRequirementParams,
+      base
     );
   }
 
   public async modify(ticker: string, id: BigNumber, params: RequirementDto): ServiceReturn<void> {
-    const { signer, webhookUrl, dryRun, ...rest } = params;
+    const { base, args } = extractTxBase(params);
+
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(
       asset.compliance.requirements.modify,
-      { id, ...rest } as ModifyComplianceRequirementParams,
-      {
-        signer,
-        webhookUrl,
-        dryRun,
-      }
+      { id, ...args } as ModifyComplianceRequirementParams,
+      base
     );
   }
 }

--- a/src/compliance/trusted-claim-issuers.controller.spec.ts
+++ b/src/compliance/trusted-claim-issuers.controller.spec.ts
@@ -9,11 +9,13 @@ import { RemoveTrustedClaimIssuersDto } from '~/compliance/dto/remove-trusted-cl
 import { SetTrustedClaimIssuersDto } from '~/compliance/dto/set-trusted-claim-issuers.dto';
 import { TrustedClaimIssuersController } from '~/compliance/trusted-claim-issuers.controller';
 import { TrustedClaimIssuersService } from '~/compliance/trusted-claim-issuers.service';
+import { testValues } from '~/test-utils/consts';
 import { createMockTransactionResult, mockTrustedClaimIssuer } from '~/test-utils/mocks';
 import { mockTrustedClaimIssuersServiceProvider } from '~/test-utils/service-mocks';
 
 describe('TrustedClaimIssuersController', () => {
   const mockParams = { ticker: 'TICKER' };
+  const { txResult } = testValues;
   let controller: TrustedClaimIssuersController;
   let mockService: DeepMocked<TrustedClaimIssuersService>;
 
@@ -60,7 +62,10 @@ describe('TrustedClaimIssuersController', () => {
         type: TransactionType.Single,
         transactionTag: TxTags.complianceManager.AddDefaultTrustedClaimIssuer,
       };
-      const testTxResult = createMockTransactionResult<Asset>({ transactions: [transaction] });
+      const testTxResult = createMockTransactionResult<Asset>({
+        ...txResult,
+        transactions: [transaction],
+      });
       const mockPayload: SetTrustedClaimIssuersDto = {
         claimIssuers: [],
         signer: 'Alice',
@@ -85,7 +90,10 @@ describe('TrustedClaimIssuersController', () => {
         type: TransactionType.Single,
         transactionTag: TxTags.complianceManager.AddDefaultTrustedClaimIssuer,
       };
-      const testTxResult = createMockTransactionResult<Asset>({ transactions: [transaction] });
+      const testTxResult = createMockTransactionResult<Asset>({
+        ...txResult,
+        transactions: [transaction],
+      });
       const mockPayload: SetTrustedClaimIssuersDto = {
         claimIssuers: [],
         signer: 'Alice',
@@ -110,7 +118,10 @@ describe('TrustedClaimIssuersController', () => {
         type: TransactionType.Single,
         transactionTag: TxTags.complianceManager.RemoveDefaultTrustedClaimIssuer,
       };
-      const testTxResult = createMockTransactionResult<Asset>({ transactions: [transaction] });
+      const testTxResult = createMockTransactionResult<Asset>({
+        ...txResult,
+        transactions: [transaction],
+      });
 
       const mockPayload: RemoveTrustedClaimIssuersDto = {
         claimIssuers: [],

--- a/src/compliance/trusted-claim-issuers.service.spec.ts
+++ b/src/compliance/trusted-claim-issuers.service.spec.ts
@@ -8,6 +8,7 @@ import { TransactionModel } from '~/common/models/transaction.model';
 import { TransactionType } from '~/common/types';
 import { ComplianceRequirementsService } from '~/compliance/compliance-requirements.service';
 import { TrustedClaimIssuersService } from '~/compliance/trusted-claim-issuers.service';
+import { testValues } from '~/test-utils/consts';
 import { createMockTransactionResult, MockAsset } from '~/test-utils/mocks';
 import {
   MockAssetService,
@@ -29,6 +30,7 @@ describe('TrustedClaimIssuersService', () => {
     type: TransactionType.Single,
     transactionTag,
   });
+  const { txResult, signer } = testValues;
 
   const mockClaimIssuers = [
     {
@@ -36,7 +38,6 @@ describe('TrustedClaimIssuersService', () => {
       trustedFor: [ClaimType.Accredited, ClaimType.InvestorUniqueness],
     },
   ];
-  const signer = 'Alice';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -81,6 +82,7 @@ describe('TrustedClaimIssuersService', () => {
     it('should set trusted Claim Issuers for an Asset', async () => {
       const mockAsset = new MockAsset();
       const testTxResult = createMockTransactionResult<Asset>({
+        ...txResult,
         transactions: [getMockTransaction(TxTags.complianceManager.AddDefaultTrustedClaimIssuer)],
       });
 
@@ -97,6 +99,7 @@ describe('TrustedClaimIssuersService', () => {
     it('should add trusted Claim Issuers for an Asset', async () => {
       const mockAsset = new MockAsset();
       const testTxResult = createMockTransactionResult<Asset>({
+        ...txResult,
         transactions: [getMockTransaction(TxTags.complianceManager.AddDefaultTrustedClaimIssuer)],
       });
 
@@ -118,6 +121,7 @@ describe('TrustedClaimIssuersService', () => {
     it('should remove trusted Claim Issuers for an Asset', async () => {
       const mockAsset = new MockAsset();
       const testTxResult = createMockTransactionResult<Asset>({
+        ...txResult,
         transactions: [
           getMockTransaction(TxTags.complianceManager.RemoveDefaultTrustedClaimIssuer),
         ],

--- a/src/compliance/trusted-claim-issuers.service.ts
+++ b/src/compliance/trusted-claim-issuers.service.ts
@@ -21,32 +21,35 @@ export class TrustedClaimIssuersService {
   }
 
   public async set(ticker: string, params: SetTrustedClaimIssuersDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.set, rest, {
       signer,
       webhookUrl,
+      dryRun,
     });
   }
 
   public async add(ticker: string, params: SetTrustedClaimIssuersDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.add, rest, {
       signer,
       webhookUrl,
+      dryRun,
     });
   }
 
   public async remove(ticker: string, params: RemoveTrustedClaimIssuersDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.remove, rest, {
       signer,
       webhookUrl,
+      dryRun,
     });
   }
 }

--- a/src/compliance/trusted-claim-issuers.service.ts
+++ b/src/compliance/trusted-claim-issuers.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Asset, TrustedClaimIssuer } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AssetsService } from '~/assets/assets.service';
-import { ServiceReturn } from '~/common/utils';
+import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { RemoveTrustedClaimIssuersDto } from '~/compliance/dto/remove-trusted-claim-issuers.dto';
 import { SetTrustedClaimIssuersDto } from '~/compliance/dto/set-trusted-claim-issuers.dto';
 import { TransactionsService } from '~/transactions/transactions.service';
@@ -21,35 +21,23 @@ export class TrustedClaimIssuersService {
   }
 
   public async set(ticker: string, params: SetTrustedClaimIssuersDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, dryRun, ...rest } = params;
+    const { base, args } = extractTxBase(params);
     const asset = await this.assetsService.findOne(ticker);
 
-    return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.set, rest, {
-      signer,
-      webhookUrl,
-      dryRun,
-    });
+    return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.set, args, base);
   }
 
   public async add(ticker: string, params: SetTrustedClaimIssuersDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, dryRun, ...rest } = params;
+    const { base, args } = extractTxBase(params);
     const asset = await this.assetsService.findOne(ticker);
 
-    return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.add, rest, {
-      signer,
-      webhookUrl,
-      dryRun,
-    });
+    return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.add, args, base);
   }
 
   public async remove(ticker: string, params: RemoveTrustedClaimIssuersDto): ServiceReturn<Asset> {
-    const { signer, webhookUrl, dryRun, ...rest } = params;
+    const { base, args } = extractTxBase(params);
     const asset = await this.assetsService.findOne(ticker);
 
-    return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.remove, rest, {
-      signer,
-      webhookUrl,
-      dryRun,
-    });
+    return this.transactionsService.submit(asset.compliance.trustedClaimIssuers.remove, args, base);
   }
 }

--- a/src/corporate-actions/corporate-actions.controller.spec.ts
+++ b/src/corporate-actions/corporate-actions.controller.spec.ts
@@ -161,12 +161,9 @@ describe('CorporateActionsController', () => {
       );
 
       expect(result).toEqual(txResult);
-      expect(mockCorporateActionsService.remove).toHaveBeenCalledWith(
-        'TICKER',
-        new BigNumber(1),
+      expect(mockCorporateActionsService.remove).toHaveBeenCalledWith('TICKER', new BigNumber(1), {
         signer,
-        undefined
-      );
+      });
     });
   });
 

--- a/src/corporate-actions/corporate-actions.controller.spec.ts
+++ b/src/corporate-actions/corporate-actions.controller.spec.ts
@@ -14,7 +14,7 @@ import { MockDistributionWithDetails } from '~/corporate-actions/mocks/distribut
 import { MockDistribution } from '~/corporate-actions/mocks/dividend-distribution.mock';
 import { testValues } from '~/test-utils/consts';
 
-const { did, signer } = testValues;
+const { did, signer, txResult } = testValues;
 
 describe('CorporateActionsController', () => {
   let controller: CorporateActionsController;
@@ -65,10 +65,7 @@ describe('CorporateActionsController', () => {
 
   describe('updateDefaultConfig', () => {
     it('should update the Corporate Action Default Config and return the details of transaction', async () => {
-      const response = {
-        transactions: ['transaction'],
-      };
-      mockCorporateActionsService.updateDefaultConfigByTicker.mockResolvedValue(response);
+      mockCorporateActionsService.updateDefaultConfigByTicker.mockResolvedValue(txResult);
       const body = {
         signer,
         defaultTaxWithholding: new BigNumber(25),
@@ -76,9 +73,7 @@ describe('CorporateActionsController', () => {
 
       const result = await controller.updateDefaultConfig({ ticker: 'TICKER' }, body);
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
       expect(mockCorporateActionsService.updateDefaultConfigByTicker).toHaveBeenCalledWith(
         'TICKER',
         body
@@ -126,7 +121,7 @@ describe('CorporateActionsController', () => {
       const mockDistribution = new MockDistribution();
       const response = {
         result: mockDistribution,
-        transactions: ['transaction'],
+        ...txResult,
       };
       mockCorporateActionsService.createDividendDistribution.mockResolvedValue(response);
       const mockDate = new Date();
@@ -147,6 +142,7 @@ describe('CorporateActionsController', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         dividendDistribution: createDividendDistributionModel(mockDistribution as any),
         transactions: ['transaction'],
+        details: txResult.details,
       });
       expect(mockCorporateActionsService.createDividendDistribution).toHaveBeenCalledWith(
         'TICKER',
@@ -157,19 +153,14 @@ describe('CorporateActionsController', () => {
 
   describe('deleteCorporateAction', () => {
     it('should call the service and return the transaction details', async () => {
-      const response = {
-        transactions: ['transaction'],
-      };
-      mockCorporateActionsService.remove.mockResolvedValue(response);
+      mockCorporateActionsService.remove.mockResolvedValue(txResult);
 
       const result = await controller.deleteCorporateAction(
         { id: new BigNumber(1), ticker: 'TICKER' },
         { signer }
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
       expect(mockCorporateActionsService.remove).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
@@ -181,10 +172,7 @@ describe('CorporateActionsController', () => {
 
   describe('payDividends', () => {
     it('should call the service and return the transaction details', async () => {
-      const response = {
-        transactions: ['transaction'],
-      };
-      mockCorporateActionsService.payDividends.mockResolvedValue(response);
+      mockCorporateActionsService.payDividends.mockResolvedValue(txResult);
 
       const body = {
         signer,
@@ -198,9 +186,7 @@ describe('CorporateActionsController', () => {
         body
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
       expect(mockCorporateActionsService.payDividends).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
@@ -211,8 +197,6 @@ describe('CorporateActionsController', () => {
 
   describe('linkDocuments', () => {
     it('should call the service and return the results', async () => {
-      const transactions = ['transaction'];
-
       const body = {
         documents: [
           new AssetDocumentDto({
@@ -224,25 +208,20 @@ describe('CorporateActionsController', () => {
         signer,
       };
 
-      mockCorporateActionsService.linkDocuments.mockResolvedValue({ transactions });
+      mockCorporateActionsService.linkDocuments.mockResolvedValue(txResult);
 
       const result = await controller.linkDocuments(
         { ticker: 'TICKER', id: new BigNumber(1) },
         body
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('claimDividends', () => {
     it('should call the service and return the transaction details', async () => {
-      const response = {
-        transactions: ['transaction'],
-      };
-      mockCorporateActionsService.claimDividends.mockResolvedValue(response);
+      mockCorporateActionsService.claimDividends.mockResolvedValue(txResult);
 
       const result = await controller.claimDividends(
         {
@@ -252,23 +231,18 @@ describe('CorporateActionsController', () => {
         { signer }
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
       expect(mockCorporateActionsService.claimDividends).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
-        signer
+        { signer }
       );
     });
   });
 
   describe('reclaimDividends', () => {
     it('should call the service and return the transaction details', async () => {
-      const response = {
-        transactions: ['transaction'],
-      };
-      mockCorporateActionsService.reclaimRemainingFunds.mockResolvedValue(response);
+      mockCorporateActionsService.reclaimRemainingFunds.mockResolvedValue(txResult);
 
       const result = await controller.reclaimRemainingFunds(
         {
@@ -278,37 +252,30 @@ describe('CorporateActionsController', () => {
         { signer }
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
       expect(mockCorporateActionsService.reclaimRemainingFunds).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
-        signer,
-        undefined
+        { signer }
       );
     });
   });
 
   describe('modifyCheckpoint', () => {
     it('should call the service and return the results', async () => {
-      const transactions = ['transaction'];
-
       const body = {
         checkpoint: new Date(),
         signer,
       };
 
-      mockCorporateActionsService.modifyCheckpoint.mockResolvedValue({ transactions });
+      mockCorporateActionsService.modifyCheckpoint.mockResolvedValue(txResult);
 
       const result = await controller.modifyDistributionCheckpoint(
         { ticker: 'TICKER', id: new BigNumber(1) },
         body
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
       expect(mockCorporateActionsService.modifyCheckpoint).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),

--- a/src/corporate-actions/corporate-actions.controller.ts
+++ b/src/corporate-actions/corporate-actions.controller.ts
@@ -222,10 +222,15 @@ export class CorporateActionsController {
       dividendDistributionDto
     );
 
-    const resolver: TransactionResolver<DividendDistribution> = ({ transactions, result }) =>
+    const resolver: TransactionResolver<DividendDistribution> = ({
+      transactions,
+      result,
+      details,
+    }) =>
       new CreatedDividendDistributionModel({
         dividendDistribution: createDividendDistributionModel(result),
         transactions,
+        details,
       });
 
     return handleServiceResult(serviceResult, resolver);
@@ -258,7 +263,7 @@ export class CorporateActionsController {
   @Post(':id/delete')
   public async deleteCorporateAction(
     @Param() { id, ticker }: DeleteCorporateActionParamsDto,
-    @Query() { signer, webhookUrl }: TransactionBaseDto
+    @Query() { signer, webhookUrl, dryRun }: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.corporateActionsService.remove(ticker, id, signer, webhookUrl);
     return handleServiceResult(result);
@@ -373,9 +378,13 @@ export class CorporateActionsController {
   @Post(':id/payments/claim')
   public async claimDividends(
     @Param() { id, ticker }: DividendDistributionParamsDto,
-    @Body() { signer }: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.corporateActionsService.claimDividends(ticker, id, signer);
+    const result = await this.corporateActionsService.claimDividends(
+      ticker,
+      id,
+      transactionBaseDto
+    );
     return handleServiceResult(result);
   }
 
@@ -412,13 +421,12 @@ export class CorporateActionsController {
   @Post(':id/reclaim-funds')
   public async reclaimRemainingFunds(
     @Param() { id, ticker }: DividendDistributionParamsDto,
-    @Body() { signer, webhookUrl }: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.corporateActionsService.reclaimRemainingFunds(
       ticker,
       id,
-      signer,
-      webhookUrl
+      transactionBaseDto
     );
     return handleServiceResult(result);
   }

--- a/src/corporate-actions/corporate-actions.controller.ts
+++ b/src/corporate-actions/corporate-actions.controller.ts
@@ -263,9 +263,9 @@ export class CorporateActionsController {
   @Post(':id/delete')
   public async deleteCorporateAction(
     @Param() { id, ticker }: DeleteCorporateActionParamsDto,
-    @Query() { signer, webhookUrl, dryRun }: TransactionBaseDto
+    @Query() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.corporateActionsService.remove(ticker, id, signer, webhookUrl);
+    const result = await this.corporateActionsService.remove(ticker, id, transactionBaseDto);
     return handleServiceResult(result);
   }
 

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -430,7 +430,7 @@ describe('CorporateActionsService', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         findDistributionSpy.mockResolvedValue(distributionWithDetails as any);
 
-        const result = await service.claimDividends('TICKER', new BigNumber(1), signer);
+        const result = await service.claimDividends('TICKER', new BigNumber(1), { signer });
         expect(result).toEqual({
           result: undefined,
           transactions: [mockTransaction],
@@ -449,6 +449,7 @@ describe('CorporateActionsService', () => {
 
   describe('reclaimRemainingFunds', () => {
     const webhookUrl = 'http://example.com';
+    const dryRun = false;
 
     describe('otherwise', () => {
       it('should return the transaction details', async () => {
@@ -467,12 +468,11 @@ describe('CorporateActionsService', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         findDistributionSpy.mockResolvedValue(distributionWithDetails as any);
 
-        const result = await service.reclaimRemainingFunds(
-          'TICKER',
-          new BigNumber(1),
+        const result = await service.reclaimRemainingFunds('TICKER', new BigNumber(1), {
           signer,
-          webhookUrl
-        );
+          webhookUrl,
+          dryRun,
+        });
         expect(result).toEqual({
           result: undefined,
           transactions: [mockTransaction],

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -480,7 +480,7 @@ describe('CorporateActionsService', () => {
         expect(mockTransactionsService.submit).toHaveBeenCalledWith(
           distributionWithDetails.distribution.reclaimFunds,
           undefined,
-          { signer, webhookUrl }
+          { signer, webhookUrl, dryRun }
         );
         findDistributionSpy.mockRestore();
       });

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -291,7 +291,7 @@ describe('CorporateActionsService', () => {
 
         let error = null;
         try {
-          await service.remove(ticker, new BigNumber(1), signer);
+          await service.remove(ticker, new BigNumber(1), { signer });
         } catch (err) {
           error = err;
         }
@@ -311,7 +311,7 @@ describe('CorporateActionsService', () => {
         const mockTransaction = new MockTransaction(transaction);
         mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        const result = await service.remove(ticker, new BigNumber(1), signer);
+        const result = await service.remove(ticker, new BigNumber(1), { signer });
 
         expect(result).toEqual({
           transactions: [mockTransaction],

--- a/src/corporate-actions/corporate-actions.service.ts
+++ b/src/corporate-actions/corporate-actions.service.ts
@@ -9,6 +9,7 @@ import {
 import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { AssetsService } from '~/assets/assets.service';
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { ServiceReturn } from '~/common/utils';
 import { CorporateActionDefaultConfigDto } from '~/corporate-actions/dto/corporate-action-default-config.dto';
 import { DividendDistributionDto } from '~/corporate-actions/dto/dividend-distribution.dto';
@@ -34,7 +35,7 @@ export class CorporateActionsService {
     ticker: string,
     corporateActionDefaultConfigDto: CorporateActionDefaultConfigDto
   ): ServiceReturn<void> {
-    const { signer, webhookUrl, ...rest } = corporateActionDefaultConfigDto;
+    const { signer, webhookUrl, dryRun, ...rest } = corporateActionDefaultConfigDto;
     const asset = await this.assetsService.findOne(ticker);
 
     return this.transactionService.submit(
@@ -43,6 +44,7 @@ export class CorporateActionsService {
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }
@@ -75,7 +77,7 @@ export class CorporateActionsService {
     ticker: string,
     dividendDistributionDto: DividendDistributionDto
   ): ServiceReturn<DividendDistribution> {
-    const { signer, webhookUrl, originPortfolio, ...rest } = dividendDistributionDto;
+    const { signer, webhookUrl, dryRun, originPortfolio, ...rest } = dividendDistributionDto;
     const asset = await this.assetsService.findOne(ticker);
     return this.transactionService.submit(
       asset.corporateActions.distributions.configureDividendDistribution,
@@ -86,6 +88,7 @@ export class CorporateActionsService {
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }
@@ -94,7 +97,8 @@ export class CorporateActionsService {
     ticker: string,
     corporateAction: BigNumber,
     signer: string,
-    webhookUrl?: string
+    webhookUrl?: string,
+    dryRun?: boolean
   ): ServiceReturn<void> {
     const asset = await this.assetsService.findOne(ticker);
     return this.transactionService.submit(
@@ -103,6 +107,7 @@ export class CorporateActionsService {
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }
@@ -112,7 +117,7 @@ export class CorporateActionsService {
     id: BigNumber,
     payDividendsDto: PayDividendsDto
   ): ServiceReturn<void> {
-    const { signer, webhookUrl, targets } = payDividendsDto;
+    const { signer, webhookUrl, dryRun, targets } = payDividendsDto;
     const { distribution } = await this.findDistribution(ticker, id);
 
     return this.transactionService.submit(
@@ -121,6 +126,7 @@ export class CorporateActionsService {
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }
@@ -130,7 +136,7 @@ export class CorporateActionsService {
     id: BigNumber,
     linkDocumentsDto: LinkDocumentsDto
   ): ServiceReturn<void> {
-    const { signer, webhookUrl, documents } = linkDocumentsDto;
+    const { signer, webhookUrl, dryRun, documents } = linkDocumentsDto;
     const { distribution } = await this.findDistribution(ticker, id);
 
     const params = {
@@ -139,34 +145,27 @@ export class CorporateActionsService {
     return this.transactionService.submit(distribution.linkDocuments, params, {
       signer,
       webhookUrl,
+      dryRun,
     });
   }
 
   public async claimDividends(
     ticker: string,
     id: BigNumber,
-    signer: string,
-    webhookUrl?: string
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const { distribution } = await this.findDistribution(ticker, id);
-    return this.transactionService.submit(distribution.claim, undefined, {
-      signer,
-      webhookUrl,
-    });
+    return this.transactionService.submit(distribution.claim, undefined, transactionBaseDto);
   }
 
   public async reclaimRemainingFunds(
     ticker: string,
     id: BigNumber,
-    signer: string,
-    webhookUrl?: string
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const { distribution } = await this.findDistribution(ticker, id);
 
-    return this.transactionService.submit(distribution.reclaimFunds, undefined, {
-      signer,
-      webhookUrl,
-    });
+    return this.transactionService.submit(distribution.reclaimFunds, undefined, transactionBaseDto);
   }
 
   public async modifyCheckpoint(
@@ -174,7 +173,7 @@ export class CorporateActionsService {
     id: BigNumber,
     modifyDistributionCheckpointDto: ModifyDistributionCheckpointDto
   ): ServiceReturn<void> {
-    const { signer, webhookUrl, checkpoint } = modifyDistributionCheckpointDto;
+    const { signer, webhookUrl, dryRun, checkpoint } = modifyDistributionCheckpointDto;
     const { distribution } = await this.findDistribution(ticker, id);
 
     return this.transactionService.submit(
@@ -183,6 +182,7 @@ export class CorporateActionsService {
       {
         signer,
         webhookUrl,
+        dryRun,
       }
     );
   }

--- a/src/corporate-actions/corporate-actions.service.ts
+++ b/src/corporate-actions/corporate-actions.service.ts
@@ -73,14 +73,17 @@ export class CorporateActionsService {
     ticker: string,
     dividendDistributionDto: DividendDistributionDto
   ): ServiceReturn<DividendDistribution> {
-    const { base, args } = extractTxBase(dividendDistributionDto);
+    const {
+      base,
+      args: { originPortfolio, ...rest },
+    } = extractTxBase(dividendDistributionDto);
 
     const asset = await this.assetsService.findOne(ticker);
     return this.transactionService.submit(
       asset.corporateActions.distributions.configureDividendDistribution,
       {
-        ...args,
-        originPortfolio: toPortfolioId(args.originPortfolio),
+        ...rest,
+        originPortfolio: toPortfolioId(originPortfolio),
       },
       base
     );
@@ -115,12 +118,15 @@ export class CorporateActionsService {
     id: BigNumber,
     linkDocumentsDto: LinkDocumentsDto
   ): ServiceReturn<void> {
-    const { base, args } = extractTxBase(linkDocumentsDto);
+    const {
+      base,
+      args: { documents },
+    } = extractTxBase(linkDocumentsDto);
 
     const { distribution } = await this.findDistribution(ticker, id);
 
     const params = {
-      documents: args.documents.map(document => document.toAssetDocument()),
+      documents: documents.map(document => document.toAssetDocument()),
     };
     return this.transactionService.submit(distribution.linkDocuments, params, base);
   }

--- a/src/corporate-actions/models/created-dividend-distribution.model.ts
+++ b/src/corporate-actions/models/created-dividend-distribution.model.ts
@@ -15,8 +15,8 @@ export class CreatedDividendDistributionModel extends TransactionQueueModel {
   readonly dividendDistribution: DividendDistributionModel;
 
   constructor(model: CreatedDividendDistributionModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -448,8 +448,8 @@ describe('IdentitiesController', () => {
       });
 
       expect(result).toEqual({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...txResult,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });
     });

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -38,7 +38,7 @@ import {
 } from '~/test-utils/service-mocks';
 import { TickerReservationsService } from '~/ticker-reservations/ticker-reservations.service';
 
-const { did } = testValues;
+const { did, txResult } = testValues;
 
 describe('IdentitiesController', () => {
   let controller: IdentitiesController;
@@ -437,8 +437,8 @@ describe('IdentitiesController', () => {
     it('should return the transaction details on adding a Secondary Account', async () => {
       const mockAuthorization = new MockAuthorizationRequest();
       const mockData = {
+        ...txResult,
         result: mockAuthorization,
-        transactions: ['transaction'],
       };
       mockIdentitiesService.addSecondaryAccount.mockResolvedValue(mockData);
 
@@ -449,8 +449,8 @@ describe('IdentitiesController', () => {
 
       expect(result).toEqual({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...txResult,
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
-        transactions: ['transaction'],
       });
     });
   });

--- a/src/identities/identities.controller.ts
+++ b/src/identities/identities.controller.ts
@@ -418,9 +418,14 @@ export class IdentitiesController {
     const serviceResult = await this.identitiesService.addSecondaryAccount(
       addSecondaryAccountParamsDto
     );
-    const resolver: TransactionResolver<AuthorizationRequest> = ({ transactions, result }) =>
+    const resolver: TransactionResolver<AuthorizationRequest> = ({
+      transactions,
+      details,
+      result,
+    }) =>
       new CreatedAuthorizationRequestModel({
         transactions,
+        details,
         authorizationRequest: createAuthorizationRequestModel(result),
       });
 

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -67,7 +67,7 @@ export class IdentitiesService {
   public async addSecondaryAccount(
     addSecondaryAccountParamsDto: AddSecondaryAccountParamsDto
   ): ServiceReturn<AuthorizationRequest> {
-    const { signer, webhookUrl, expiry, permissions, secondaryAccount } =
+    const { signer, webhookUrl, dryRun, expiry, permissions, secondaryAccount } =
       addSecondaryAccountParamsDto;
 
     const params = {
@@ -76,7 +76,7 @@ export class IdentitiesService {
       expiry,
     };
     const { inviteAccount } = this.polymeshService.polymeshApi.accountManagement;
-    return this.transactionsService.submit(inviteAccount, params, { signer, webhookUrl });
+    return this.transactionsService.submit(inviteAccount, params, { signer, webhookUrl, dryRun });
   }
 
   /**

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -67,11 +67,14 @@ export class IdentitiesService {
   public async addSecondaryAccount(
     addSecondaryAccountParamsDto: AddSecondaryAccountParamsDto
   ): ServiceReturn<AuthorizationRequest> {
-    const { base, args } = extractTxBase(addSecondaryAccountParamsDto);
+    const {
+      base,
+      args: { secondaryAccount: targetAccount, permissions, expiry },
+    } = extractTxBase(addSecondaryAccountParamsDto);
     const params = {
-      targetAccount: args.secondaryAccount,
-      permissions: args.permissions?.toPermissionsLike(),
-      expiry: args.expiry,
+      targetAccount,
+      permissions: permissions?.toPermissionsLike(),
+      expiry,
     };
     const { inviteAccount } = this.polymeshService.polymeshApi.accountManagement;
 

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -15,7 +15,7 @@ import {
 import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { AccountsService } from '~/accounts/accounts.service';
-import { ServiceReturn } from '~/common/utils';
+import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { AddSecondaryAccountParamsDto } from '~/identities/dto/add-secondary-account-params.dto';
 import { CreateMockIdentityDto } from '~/identities/dto/create-mock-identity.dto';
 import { PolymeshLogger } from '~/logger/polymesh-logger.service';
@@ -67,16 +67,15 @@ export class IdentitiesService {
   public async addSecondaryAccount(
     addSecondaryAccountParamsDto: AddSecondaryAccountParamsDto
   ): ServiceReturn<AuthorizationRequest> {
-    const { signer, webhookUrl, dryRun, expiry, permissions, secondaryAccount } =
-      addSecondaryAccountParamsDto;
-
+    const { base, args } = extractTxBase(addSecondaryAccountParamsDto);
     const params = {
-      targetAccount: secondaryAccount,
-      permissions: permissions?.toPermissionsLike(),
-      expiry,
+      targetAccount: args.secondaryAccount,
+      permissions: args.permissions?.toPermissionsLike(),
+      expiry: args.expiry,
     };
     const { inviteAccount } = this.polymeshService.polymeshApi.accountManagement;
-    return this.transactionsService.submit(inviteAccount, params, { signer, webhookUrl, dryRun });
+
+    return this.transactionsService.submit(inviteAccount, params, base);
   }
 
   /**

--- a/src/portfolios/models/created-portfolio.model.ts
+++ b/src/portfolios/models/created-portfolio.model.ts
@@ -15,8 +15,8 @@ export class CreatedPortfolioModel extends TransactionQueueModel {
   readonly portfolio: PortfolioIdentifierModel;
 
   constructor(model: CreatedPortfolioModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/portfolios/porfolios.controller.spec.ts
+++ b/src/portfolios/porfolios.controller.spec.ts
@@ -11,7 +11,7 @@ import { testValues } from '~/test-utils/consts';
 import { MockPortfolio } from '~/test-utils/mocks';
 import { MockPortfoliosService } from '~/test-utils/service-mocks';
 
-const { did, signer } = testValues;
+const { did, signer, txResult } = testValues;
 
 describe('PortfoliosController', () => {
   let controller: PortfoliosController;
@@ -52,8 +52,7 @@ describe('PortfoliosController', () => {
 
   describe('moveAssets', () => {
     it('should return the transaction details', async () => {
-      const response = { transactions: ['transaction'] };
-      mockPortfoliosService.moveAssets.mockResolvedValue(response);
+      mockPortfoliosService.moveAssets.mockResolvedValue(txResult);
       const params = {
         signer: '0x6000',
         to: new BigNumber(2),
@@ -63,7 +62,7 @@ describe('PortfoliosController', () => {
 
       const result = await controller.moveAssets({ did: '0x6000' }, params);
 
-      expect(result).toEqual({ transactions: ['transaction'] });
+      expect(result).toEqual(txResult);
     });
   });
 
@@ -71,8 +70,8 @@ describe('PortfoliosController', () => {
     it('should return the transaction details', async () => {
       const mockPortfolio = new MockPortfolio();
       const response = {
+        ...txResult,
         result: mockPortfolio,
-        transactions: ['transaction'],
       };
       mockPortfoliosService.createPortfolio.mockResolvedValue(response);
       const params = {
@@ -83,30 +82,25 @@ describe('PortfoliosController', () => {
       const result = await controller.createPortfolio(params);
 
       expect(result).toEqual({
+        ...txResult,
         portfolio: {
           id: '1',
           did,
         },
-        transactions: ['transaction'],
       });
     });
   });
 
   describe('deletePortfolio', () => {
     it('should return the transaction details', async () => {
-      const response = {
-        transactions: ['transaction'],
-      };
-      mockPortfoliosService.deletePortfolio.mockResolvedValue(response);
+      mockPortfoliosService.deletePortfolio.mockResolvedValue(txResult);
 
       const result = await controller.deletePortfolio(
         new PortfolioDto({ id: new BigNumber(1), did }),
         { signer }
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
     });
   });
 });

--- a/src/portfolios/portfolios.controller.ts
+++ b/src/portfolios/portfolios.controller.ts
@@ -99,9 +99,10 @@ export class PortfoliosController {
     @Body() createPortfolioParams: CreatePortfolioDto
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.portfoliosService.createPortfolio(createPortfolioParams);
-    const resolver: TransactionResolver<NumberedPortfolio> = ({ transactions, result }) =>
+    const resolver: TransactionResolver<NumberedPortfolio> = ({ transactions, details, result }) =>
       new CreatedPortfolioModel({
         portfolio: createPortfolioIdentifierModel(result),
+        details,
         transactions,
       });
     return handleServiceResult(serviceResult, resolver);
@@ -137,7 +138,7 @@ export class PortfoliosController {
   @Post('/identities/:did/portfolios/:id/delete')
   public async deletePortfolio(
     @Param() portfolio: PortfolioDto,
-    @Query() { signer, webhookUrl }: TransactionBaseDto
+    @Query() { signer, webhookUrl, dryRun }: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.portfoliosService.deletePortfolio(portfolio, signer, webhookUrl);
     return handleServiceResult(result);

--- a/src/portfolios/portfolios.controller.ts
+++ b/src/portfolios/portfolios.controller.ts
@@ -138,9 +138,9 @@ export class PortfoliosController {
   @Post('/identities/:did/portfolios/:id/delete')
   public async deletePortfolio(
     @Param() portfolio: PortfolioDto,
-    @Query() { signer, webhookUrl, dryRun }: TransactionBaseDto
+    @Query() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.portfoliosService.deletePortfolio(portfolio, signer, webhookUrl);
+    const result = await this.portfoliosService.deletePortfolio(portfolio, transactionBaseDto);
     return handleServiceResult(result);
   }
 }

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -275,7 +275,7 @@ describe('PortfoliosService', () => {
           transactions: [mockTransaction],
         });
 
-        const result = await service.deletePortfolio(portfolio, signer);
+        const result = await service.deletePortfolio(portfolio, { signer });
         expect(result).toEqual({
           result: undefined,
           transactions: [mockTransaction],

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@polymeshassociation/polymesh-sdk/types';
 import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { IdentitiesService } from '~/identities/identities.service';
 import { PolymeshService } from '~/polymesh/polymesh.service';
@@ -74,25 +75,20 @@ export class PortfoliosService {
     const {
       polymeshService: { polymeshApi },
     } = this;
-    const { signer, webhookUrl, dryRun, ...rest } = params;
-    return this.transactionsService.submit(polymeshApi.identities.createPortfolio, rest, {
-      signer,
-      webhookUrl,
-      dryRun,
-    });
+    const { base, args } = extractTxBase(params);
+
+    return this.transactionsService.submit(polymeshApi.identities.createPortfolio, args, base);
   }
 
   public async deletePortfolio(
     portfolio: PortfolioDto,
-    signer: string,
-    webhookUrl?: string,
-    dryRun?: boolean
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const identity = await this.identitiesService.findOne(portfolio.did);
     return this.transactionsService.submit(
       identity.portfolios.delete,
       { portfolio: portfolio.id },
-      { signer, webhookUrl, dryRun }
+      transactionBaseDto
     );
   }
 }

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -52,7 +52,7 @@ export class PortfoliosService {
   }
 
   public async moveAssets(owner: string, params: AssetMovementDto): ServiceReturn<void> {
-    const { signer, webhookUrl, to, items, from } = params;
+    const { signer, webhookUrl, dryRun, to, items, from } = params;
     const fromPortfolio = await this.findOne(owner, toPortfolioId(from));
     const args = {
       to: toPortfolioId(to),
@@ -64,30 +64,36 @@ export class PortfoliosService {
         };
       }),
     };
-    return this.transactionsService.submit(fromPortfolio.moveFunds, args, { signer, webhookUrl });
+    return this.transactionsService.submit(fromPortfolio.moveFunds, args, {
+      signer,
+      webhookUrl,
+      dryRun,
+    });
   }
 
   public async createPortfolio(params: CreatePortfolioDto): ServiceReturn<NumberedPortfolio> {
     const {
       polymeshService: { polymeshApi },
     } = this;
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     return this.transactionsService.submit(polymeshApi.identities.createPortfolio, rest, {
       signer,
       webhookUrl,
+      dryRun,
     });
   }
 
   public async deletePortfolio(
     portfolio: PortfolioDto,
     signer: string,
-    webhookUrl?: string
+    webhookUrl?: string,
+    dryRun?: boolean
   ): ServiceReturn<void> {
     const identity = await this.identitiesService.findOne(portfolio.did);
     return this.transactionsService.submit(
       identity.portfolios.delete,
       { portfolio: portfolio.id },
-      { signer, webhookUrl }
+      { signer, webhookUrl, dryRun }
     );
   }
 }

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -53,8 +53,10 @@ export class PortfoliosService {
   }
 
   public async moveAssets(owner: string, params: AssetMovementDto): ServiceReturn<void> {
-    const { base, args } = extractTxBase(params);
-    const { to, items, from } = args;
+    const {
+      base,
+      args: { to, items, from },
+    } = extractTxBase(params);
 
     const fromPortfolio = await this.findOne(owner, toPortfolioId(from));
     const formattedArgs = {

--- a/src/settlements/models/created-instruction.model.ts
+++ b/src/settlements/models/created-instruction.model.ts
@@ -16,8 +16,8 @@ export class CreatedInstructionModel extends TransactionQueueModel {
   readonly instruction: Instruction;
 
   constructor(model: CreatedInstructionModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/settlements/models/created-venue.model.ts
+++ b/src/settlements/models/created-venue.model.ts
@@ -16,8 +16,8 @@ export class CreatedVenueModel extends TransactionQueueModel {
   readonly venue: Venue;
 
   constructor(model: CreatedVenueModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/settlements/settlements.controller.spec.ts
+++ b/src/settlements/settlements.controller.spec.ts
@@ -16,7 +16,7 @@ import { testValues } from '~/test-utils/consts';
 import { MockInstruction, MockPortfolio, MockVenue } from '~/test-utils/mocks';
 import { MockSettlementsService } from '~/test-utils/service-mocks';
 
-const { did, signer } = testValues;
+const { did, signer, txResult } = testValues;
 
 describe('SettlementsController', () => {
   let controller: SettlementsController;
@@ -89,8 +89,8 @@ describe('SettlementsController', () => {
   describe('createInstruction', () => {
     it('should create an instruction and return the data returned by the service', async () => {
       const mockData = {
+        ...txResult,
         result: 'fakeInstruction',
-        transactions: ['transaction'],
       };
       mockSettlementsService.createInstruction.mockResolvedValue(mockData);
 
@@ -98,43 +98,33 @@ describe('SettlementsController', () => {
       const result = await controller.createInstruction({ id: new BigNumber(3) }, {} as any);
 
       expect(result).toEqual({
+        ...txResult,
         instruction: 'fakeInstruction',
-        transactions: ['transaction'],
       });
     });
   });
 
   describe('affirmInstruction', () => {
     it('should affirm an instruction and return the data returned by the service', async () => {
-      const mockData = {
-        transactions: ['transaction'],
-      };
-      mockSettlementsService.affirmInstruction.mockResolvedValue(mockData);
+      mockSettlementsService.affirmInstruction.mockResolvedValue(txResult);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await controller.affirmInstruction({ id: new BigNumber(3) }, {} as any);
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
     });
   });
 
   describe('rejectInstruction', () => {
     it('should reject an instruction and return the data returned by the service', async () => {
-      const mockData = {
-        transactions: ['transaction'],
-      };
-      mockSettlementsService.rejectInstruction.mockResolvedValue(mockData);
+      mockSettlementsService.rejectInstruction.mockResolvedValue(txResult);
 
       const result = await controller.affirmInstruction(
         { id: new BigNumber(3) },
         { signer: 'signer' }
       );
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
     });
   });
 
@@ -193,26 +183,23 @@ describe('SettlementsController', () => {
       };
       const mockVenue = new MockVenue();
       const mockData = {
+        ...txResult,
         result: mockVenue,
-        transactions: ['transaction'],
       };
       mockSettlementsService.createVenue.mockResolvedValue(mockData);
 
       const result = await controller.createVenue(body);
 
       expect(result).toEqual({
+        ...txResult,
         venue: mockVenue,
-        transactions: ['transaction'],
       });
     });
   });
 
   describe('modifyVenue', () => {
     it('should modify a venue and return the data returned by the service', async () => {
-      const mockData = {
-        transactions: ['transaction'],
-      };
-      mockSettlementsService.modifyVenue.mockResolvedValue(mockData);
+      mockSettlementsService.modifyVenue.mockResolvedValue(txResult);
 
       const body = {
         signer,
@@ -222,9 +209,7 @@ describe('SettlementsController', () => {
 
       const result = await controller.modifyVenue({ id: new BigNumber(3) }, body);
 
-      expect(result).toEqual({
-        transactions: ['transaction'],
-      });
+      expect(result).toEqual(txResult);
     });
   });
 

--- a/src/settlements/settlements.controller.ts
+++ b/src/settlements/settlements.controller.ts
@@ -70,9 +70,14 @@ export class SettlementsController {
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.settlementsService.createInstruction(id, createInstructionDto);
 
-    const resolver: TransactionResolver<Instruction> = ({ result: instruction, transactions }) =>
+    const resolver: TransactionResolver<Instruction> = ({
+      result: instruction,
+      transactions,
+      details,
+    }) =>
       new CreatedInstructionModel({
         instruction,
+        details,
         transactions,
       });
 
@@ -216,9 +221,10 @@ export class SettlementsController {
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.settlementsService.createVenue(createVenueDto);
 
-    const resolver: TransactionResolver<Venue> = ({ result: venue, transactions }) =>
+    const resolver: TransactionResolver<Venue> = ({ result: venue, transactions, details }) =>
       new CreatedVenueModel({
         venue,
+        details,
         transactions,
       });
 

--- a/src/settlements/settlements.service.ts
+++ b/src/settlements/settlements.service.ts
@@ -14,7 +14,7 @@ import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { AssetsService } from '~/assets/assets.service';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
-import { ServiceReturn } from '~/common/utils';
+import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { IdentitiesService } from '~/identities/identities.service';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { CreateInstructionDto } from '~/settlements/dto/create-instruction.dto';
@@ -63,13 +63,12 @@ export class SettlementsService {
     venueId: BigNumber,
     createInstructionDto: CreateInstructionDto
   ): ServiceReturn<Instruction> {
-    const { signer, webhookUrl, dryRun, ...rest } = createInstructionDto;
-
+    const { base, args } = extractTxBase(createInstructionDto);
     const venue = await this.findVenue(venueId);
 
     const params = {
-      ...rest,
-      legs: rest.legs.map(({ amount, asset, from, to }) => ({
+      ...args,
+      legs: args.legs.map(({ amount, asset, from, to }) => ({
         amount,
         asset,
         from: from.toPortfolioLike(),
@@ -77,33 +76,25 @@ export class SettlementsService {
       })),
     };
 
-    return this.transactionsService.submit(venue.addInstruction, params, {
-      signer,
-      webhookUrl,
-      dryRun,
-    });
+    return this.transactionsService.submit(venue.addInstruction, params, base);
   }
 
   public async affirmInstruction(
     id: BigNumber,
     signerDto: TransactionBaseDto
   ): ServiceReturn<Instruction> {
-    const { signer, webhookUrl, dryRun } = signerDto;
-
     const instruction = await this.findInstruction(id);
 
-    return this.transactionsService.submit(instruction.affirm, {}, { signer, webhookUrl, dryRun });
+    return this.transactionsService.submit(instruction.affirm, {}, signerDto);
   }
 
   public async rejectInstruction(
     id: BigNumber,
     signerDto: TransactionBaseDto
   ): ServiceReturn<Instruction> {
-    const { signer, webhookUrl, dryRun } = signerDto;
-
     const instruction = await this.findInstruction(id);
 
-    return this.transactionsService.submit(instruction.reject, {}, { signer, webhookUrl, dryRun });
+    return this.transactionsService.submit(instruction.reject, {}, signerDto);
   }
 
   public async findVenuesByOwner(did: string): Promise<Venue[]> {
@@ -148,24 +139,20 @@ export class SettlementsService {
   }
 
   public async createVenue(createVenueDto: CreateVenueDto): ServiceReturn<Venue> {
-    const { signer, webhookUrl, dryRun, description, type } = createVenueDto;
-    const params = {
-      description,
-      type,
-    };
+    const { base, args } = extractTxBase(createVenueDto);
 
     const method = this.polymeshService.polymeshApi.settlements.createVenue;
-    return this.transactionsService.submit(method, params, { signer, webhookUrl, dryRun });
+    return this.transactionsService.submit(method, args, base);
   }
 
   public async modifyVenue(
     venueId: BigNumber,
     modifyVenueDto: ModifyVenueDto
   ): ServiceReturn<void> {
-    const { signer, webhookUrl, dryRun, ...rest } = modifyVenueDto;
+    const { base, args } = extractTxBase(modifyVenueDto);
     const venue = await this.findVenue(venueId);
-    const params = rest as Required<typeof rest>;
-    return this.transactionsService.submit(venue.modify, params, { signer, webhookUrl, dryRun });
+
+    return this.transactionsService.submit(venue.modify, args as Required<typeof args>, base);
   }
 
   public async canTransfer(

--- a/src/settlements/settlements.service.ts
+++ b/src/settlements/settlements.service.ts
@@ -63,7 +63,7 @@ export class SettlementsService {
     venueId: BigNumber,
     createInstructionDto: CreateInstructionDto
   ): ServiceReturn<Instruction> {
-    const { signer, webhookUrl, ...rest } = createInstructionDto;
+    const { signer, webhookUrl, dryRun, ...rest } = createInstructionDto;
 
     const venue = await this.findVenue(venueId);
 
@@ -77,29 +77,33 @@ export class SettlementsService {
       })),
     };
 
-    return this.transactionsService.submit(venue.addInstruction, params, { signer, webhookUrl });
+    return this.transactionsService.submit(venue.addInstruction, params, {
+      signer,
+      webhookUrl,
+      dryRun,
+    });
   }
 
   public async affirmInstruction(
     id: BigNumber,
     signerDto: TransactionBaseDto
   ): ServiceReturn<Instruction> {
-    const { signer, webhookUrl } = signerDto;
+    const { signer, webhookUrl, dryRun } = signerDto;
 
     const instruction = await this.findInstruction(id);
 
-    return this.transactionsService.submit(instruction.affirm, {}, { signer, webhookUrl });
+    return this.transactionsService.submit(instruction.affirm, {}, { signer, webhookUrl, dryRun });
   }
 
   public async rejectInstruction(
     id: BigNumber,
     signerDto: TransactionBaseDto
   ): ServiceReturn<Instruction> {
-    const { signer, webhookUrl } = signerDto;
+    const { signer, webhookUrl, dryRun } = signerDto;
 
     const instruction = await this.findInstruction(id);
 
-    return this.transactionsService.submit(instruction.reject, {}, { signer, webhookUrl });
+    return this.transactionsService.submit(instruction.reject, {}, { signer, webhookUrl, dryRun });
   }
 
   public async findVenuesByOwner(did: string): Promise<Venue[]> {
@@ -144,24 +148,24 @@ export class SettlementsService {
   }
 
   public async createVenue(createVenueDto: CreateVenueDto): ServiceReturn<Venue> {
-    const { signer, webhookUrl, description, type } = createVenueDto;
+    const { signer, webhookUrl, dryRun, description, type } = createVenueDto;
     const params = {
       description,
       type,
     };
 
     const method = this.polymeshService.polymeshApi.settlements.createVenue;
-    return this.transactionsService.submit(method, params, { signer, webhookUrl });
+    return this.transactionsService.submit(method, params, { signer, webhookUrl, dryRun });
   }
 
   public async modifyVenue(
     venueId: BigNumber,
     modifyVenueDto: ModifyVenueDto
   ): ServiceReturn<void> {
-    const { signer, webhookUrl, ...rest } = modifyVenueDto;
+    const { signer, webhookUrl, dryRun, ...rest } = modifyVenueDto;
     const venue = await this.findVenue(venueId);
     const params = rest as Required<typeof rest>;
-    return this.transactionsService.submit(venue.modify, params, { signer, webhookUrl });
+    return this.transactionsService.submit(venue.modify, params, { signer, webhookUrl, dryRun });
   }
 
   public async canTransfer(

--- a/src/test-utils/consts.ts
+++ b/src/test-utils/consts.ts
@@ -1,5 +1,6 @@
 import { createMock } from '@golevelup/ts-jest';
-import { Account } from '@polymeshassociation/polymesh-sdk/types';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+import { Account , PayingAccountType, TransactionStatus } from '@polymeshassociation/polymesh-sdk/types';
 
 import { UserModel } from '~/users/model/user.model';
 
@@ -21,10 +22,17 @@ export const testAccount = createMock<Account>({ address: 'address' });
 export const txResult = {
   transactions: ['transaction'],
   details: {
-    status: '',
-    fees: {},
+    status: TransactionStatus.Succeeded,
+    fees: {
+      gas: new BigNumber(1),
+      protocol: new BigNumber(1),
+      total: new BigNumber(1),
+    },
+    supportsSubsidy: false,
     payingAccount: {
-      did,
+      address: did,
+      balance: new BigNumber(1),
+      type: PayingAccountType.Caller,
     },
   },
 };

--- a/src/test-utils/consts.ts
+++ b/src/test-utils/consts.ts
@@ -5,6 +5,7 @@ import { UserModel } from '~/users/model/user.model';
 
 const signer = 'alice';
 const did = '0x01'.padEnd(66, '0');
+const dryRun = false;
 
 const user = new UserModel({
   id: '-1',
@@ -17,6 +18,16 @@ const resource = {
 } as const;
 
 export const testAccount = createMock<Account>({ address: 'address' });
+export const txResult = {
+  transactions: ['transaction'],
+  details: {
+    status: '',
+    fees: {},
+    payingAccount: {
+      did,
+    },
+  },
+};
 
 export const testValues = {
   signer,
@@ -24,4 +35,6 @@ export const testValues = {
   user,
   resource,
   testAccount,
+  txResult,
+  dryRun,
 };

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -299,12 +299,10 @@ class MockPolymeshTransactionBase {
   blockNumber?: BigNumber;
   status: TransactionStatus = TransactionStatus.Unapproved;
   error: Error;
-  getTotalFees = jest.fn().mockReturnValue(
-    Promise.resolve({
-      total: new BigNumber(1),
-      payingAccountData: { account: { address: 'address' } },
-    })
-  );
+  getTotalFees = jest.fn().mockResolvedValue({
+    total: new BigNumber(1),
+    payingAccountData: { account: { address: 'address' } },
+  });
 
   supportsSubsidy = jest.fn().mockReturnValue(false);
   run = jest.fn().mockReturnValue(Promise.resolve());

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -33,7 +33,7 @@ export const createMockTransactionResult = <T>({
   transactions: TransactionResult<T>['transactions'];
   result?: TransactionResult<T>['result'];
 }): DeepMocked<TransactionResult<T>> => {
-  return { transactions, result } as DeepMocked<TransactionResult<T>>;
+  return { transactions, result, details: {} } as DeepMocked<TransactionResult<T>>;
 };
 
 export const createMockResponseObject = (): DeepMocked<Response> => {
@@ -297,7 +297,16 @@ class MockPolymeshTransactionBase {
   blockNumber?: BigNumber;
   status: TransactionStatus = TransactionStatus.Unapproved;
   error: Error;
+  getTotalFees = jest
+    .fn()
+    .mockReturnValue(
+      Promise.resolve({
+        total: new BigNumber(1),
+        payingAccountData: { account: { address: '0x06'.padEnd(66, '0') } },
+      })
+    );
 
+  supportsSubsidy = jest.fn().mockReturnValue(false);
   run = jest.fn().mockReturnValue(Promise.resolve());
   onStatusChange = jest.fn();
 }

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -302,7 +302,7 @@ class MockPolymeshTransactionBase {
   getTotalFees = jest.fn().mockReturnValue(
     Promise.resolve({
       total: new BigNumber(1),
-      payingAccountData: { account: { address: '0x06'.padEnd(66, '0') } },
+      payingAccountData: { account: { address: 'address' } },
     })
   );
 

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -27,13 +27,15 @@ export type Mocked<T> = T &
 export const mockTrustedClaimIssuer = createMock<TrustedClaimIssuer<true>>();
 
 export const createMockTransactionResult = <T>({
+  details,
   transactions,
   result,
 }: {
+  details: TransactionResult<T>['details'];
   transactions: TransactionResult<T>['transactions'];
   result?: TransactionResult<T>['result'];
 }): DeepMocked<TransactionResult<T>> => {
-  return { transactions, result, details: {} } as DeepMocked<TransactionResult<T>>;
+  return { transactions, result, details } as DeepMocked<TransactionResult<T>>;
 };
 
 export const createMockResponseObject = (): DeepMocked<Response> => {
@@ -297,14 +299,12 @@ class MockPolymeshTransactionBase {
   blockNumber?: BigNumber;
   status: TransactionStatus = TransactionStatus.Unapproved;
   error: Error;
-  getTotalFees = jest
-    .fn()
-    .mockReturnValue(
-      Promise.resolve({
-        total: new BigNumber(1),
-        payingAccountData: { account: { address: '0x06'.padEnd(66, '0') } },
-      })
-    );
+  getTotalFees = jest.fn().mockReturnValue(
+    Promise.resolve({
+      total: new BigNumber(1),
+      payingAccountData: { account: { address: '0x06'.padEnd(66, '0') } },
+    })
+  );
 
   supportsSubsidy = jest.fn().mockReturnValue(false);
   run = jest.fn().mockReturnValue(Promise.resolve());

--- a/src/ticker-reservations/models/extended-ticker-reservation.model.ts
+++ b/src/ticker-reservations/models/extended-ticker-reservation.model.ts
@@ -15,8 +15,8 @@ export class ExtendedTickerReservationModel extends TransactionQueueModel {
   readonly tickerReservation: TickerReservationModel;
 
   constructor(model: ExtendedTickerReservationModel) {
-    const { transactions, ...rest } = model;
-    super({ transactions });
+    const { transactions, details, ...rest } = model;
+    super({ transactions, details });
 
     Object.assign(this, rest);
   }

--- a/src/ticker-reservations/ticker-reservations.controller.spec.ts
+++ b/src/ticker-reservations/ticker-reservations.controller.spec.ts
@@ -107,7 +107,7 @@ describe('TickerReservationsController', () => {
       const webhookUrl = 'http://example.com/webhook';
       const ticker = 'SOME_TICKER';
 
-      const result = await controller.extendReservation({ ticker }, { signer, webhookUrl });
+      const result = await controller.extendReservation({ ticker }, { signer, webhookUrl, dryRun });
 
       expect(result).toEqual({
         tickerReservation: mockResult,

--- a/src/ticker-reservations/ticker-reservations.controller.spec.ts
+++ b/src/ticker-reservations/ticker-reservations.controller.spec.ts
@@ -75,8 +75,8 @@ describe('TickerReservationsController', () => {
       const result = await controller.transferOwnership({ ticker }, body);
 
       expect(result).toEqual({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...txResult,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });
       expect(mockTickerReservationsService.transferOwnership).toHaveBeenCalledWith(ticker, body);

--- a/src/ticker-reservations/ticker-reservations.controller.ts
+++ b/src/ticker-reservations/ticker-reservations.controller.ts
@@ -40,9 +40,9 @@ export class TickerReservationsController {
   })
   @Post('reserve-ticker')
   public async reserve(
-    @Body() { ticker, signer, webhookUrl }: ReserveTickerDto
+    @Body() { ticker, ...transactionBaseDto }: ReserveTickerDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.tickerReservationsService.reserve(ticker, signer, webhookUrl);
+    const result = await this.tickerReservationsService.reserve(ticker, transactionBaseDto);
 
     return handleServiceResult(result);
   }
@@ -92,9 +92,14 @@ export class TickerReservationsController {
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.tickerReservationsService.transferOwnership(ticker, params);
 
-    const resolver: TransactionResolver<AuthorizationRequest> = ({ transactions, result }) =>
+    const resolver: TransactionResolver<AuthorizationRequest> = ({
+      transactions,
+      details,
+      result,
+    }) =>
       new CreatedAuthorizationRequestModel({
         transactions,
+        details,
         authorizationRequest: createAuthorizationRequestModel(result),
       });
 
@@ -126,13 +131,18 @@ export class TickerReservationsController {
   @Post(':ticker/extend')
   public async extendReservation(
     @Param() { ticker }: TickerParamsDto,
-    @Body() { signer, webhookUrl }: TransactionBaseDto
+    @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const serviceResult = await this.tickerReservationsService.extend(ticker, signer, webhookUrl);
+    const serviceResult = await this.tickerReservationsService.extend(ticker, transactionBaseDto);
 
-    const resolver: TransactionResolver<TickerReservation> = async ({ transactions, result }) =>
+    const resolver: TransactionResolver<TickerReservation> = async ({
+      transactions,
+      details,
+      result,
+    }) =>
       new ExtendedTickerReservationModel({
         transactions,
+        details,
         tickerReservation: await createTickerReservationModel(result),
       });
 

--- a/src/ticker-reservations/ticker-reservations.service.spec.ts
+++ b/src/ticker-reservations/ticker-reservations.service.spec.ts
@@ -84,7 +84,7 @@ describe('TickerReservationsService', () => {
 
         let error;
         try {
-          await service.reserve(ticker, signer);
+          await service.reserve(ticker, { signer });
         } catch (err) {
           error = err;
         }
@@ -109,7 +109,7 @@ describe('TickerReservationsService', () => {
           transactions: [mockTransaction],
         });
 
-        const result = await service.reserve(ticker, signer);
+        const result = await service.reserve(ticker, { signer });
         expect(result).toEqual({
           result: mockResult,
           transactions: [mockTransaction],
@@ -209,7 +209,7 @@ describe('TickerReservationsService', () => {
 
         let error;
         try {
-          await service.extend(ticker, signer);
+          await service.extend(ticker, { signer });
         } catch (err) {
           error = err;
         }
@@ -240,7 +240,7 @@ describe('TickerReservationsService', () => {
           transactions: [mockTransaction],
         });
 
-        const result = await service.extend(ticker, signer);
+        const result = await service.extend(ticker, { signer });
         expect(result).toEqual({
           result: mockResult,
           transactions: [mockTransaction],

--- a/src/ticker-reservations/ticker-reservations.service.ts
+++ b/src/ticker-reservations/ticker-reservations.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { AuthorizationRequest, TickerReservation } from '@polymeshassociation/polymesh-sdk/types';
 
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { TransferOwnershipDto } from '~/common/dto/transfer-ownership.dto';
 import { ServiceReturn } from '~/common/utils';
 import { PolymeshService } from '~/polymesh/polymesh.service';
@@ -21,32 +22,30 @@ export class TickerReservationsService {
 
   public async reserve(
     ticker: string,
-    signer: string,
-    webhookUrl?: string
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<TickerReservation> {
     const { transactionsService, polymeshService } = this;
     const { reserveTicker } = polymeshService.polymeshApi.assets;
 
-    return transactionsService.submit(reserveTicker, { ticker }, { signer, webhookUrl });
+    return transactionsService.submit(reserveTicker, { ticker }, transactionBaseDto);
   }
 
   public async transferOwnership(
     ticker: string,
     params: TransferOwnershipDto
   ): ServiceReturn<AuthorizationRequest> {
-    const { signer, webhookUrl, ...rest } = params;
+    const { signer, webhookUrl, dryRun, ...rest } = params;
     const { transferOwnership } = await this.findOne(ticker);
-    return this.transactionsService.submit(transferOwnership, rest, { signer, webhookUrl });
+    return this.transactionsService.submit(transferOwnership, rest, { signer, webhookUrl, dryRun });
   }
 
   public async extend(
     ticker: string,
-    signer: string,
-    webhookUrl?: string
+    transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<TickerReservation> {
     const { extend } = await this.findOne(ticker);
 
-    return this.transactionsService.submit(extend, {}, { webhookUrl, signer });
+    return this.transactionsService.submit(extend, {}, transactionBaseDto);
   }
 
   public async findAllByOwner(owner: string): Promise<TickerReservation[]> {

--- a/src/ticker-reservations/ticker-reservations.service.ts
+++ b/src/ticker-reservations/ticker-reservations.service.ts
@@ -3,7 +3,7 @@ import { AuthorizationRequest, TickerReservation } from '@polymeshassociation/po
 
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { TransferOwnershipDto } from '~/common/dto/transfer-ownership.dto';
-import { ServiceReturn } from '~/common/utils';
+import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { TransactionsService } from '~/transactions/transactions.service';
 
@@ -34,9 +34,10 @@ export class TickerReservationsService {
     ticker: string,
     params: TransferOwnershipDto
   ): ServiceReturn<AuthorizationRequest> {
-    const { signer, webhookUrl, dryRun, ...rest } = params;
+    const { base, args } = extractTxBase(params);
+
     const { transferOwnership } = await this.findOne(ticker);
-    return this.transactionsService.submit(transferOwnership, rest, { signer, webhookUrl, dryRun });
+    return this.transactionsService.submit(transferOwnership, args, base);
   }
 
   public async extend(

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -158,7 +158,7 @@ describe('TransactionsService', () => {
 
       mockIsPolymeshTransaction.mockReturnValue(true);
 
-      const result = await service.submit(mockMethod, {}, { signer, webhookUrl });
+      const result = await service.submit(mockMethod, {}, { signer, webhookUrl, dryRun });
 
       const expectedPayload = {
         type: TransactionType.Single,
@@ -236,7 +236,7 @@ describe('TransactionsService', () => {
 
       const mockMethod = makeMockMethod(transaction);
 
-      const result = await service.submit(mockMethod, {}, { signer, webhookUrl });
+      const result = await service.submit(mockMethod, {}, { signer, webhookUrl, dryRun });
 
       expect(mockPolymeshLoggerProvider.useValue.error).toHaveBeenCalled();
 

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -20,6 +20,7 @@ import {
 import { MockEventsService, MockSubscriptionsService } from '~/test-utils/service-mocks';
 import transactionsConfig from '~/transactions/config/transactions.config';
 import { TransactionsService } from '~/transactions/transactions.service';
+import { TransactionResult } from '~/transactions/transactions.util';
 import { Transaction } from '~/transactions/types';
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
@@ -46,6 +47,7 @@ const makeMockMethod = (
 describe('TransactionsService', () => {
   const signer = 'signer';
   const legitimacySecret = 'someSecret';
+  const dryRun = false;
   let service: TransactionsService;
 
   let mockEventsService: MockEventsService;
@@ -92,19 +94,23 @@ describe('TransactionsService', () => {
       mockIsPolymeshTransaction.mockReturnValue(true);
       const mockMethod = makeMockMethod(transaction);
 
-      const result = await service.submit(mockMethod, {}, { signer });
-      expect(result).toEqual({
-        result: undefined,
-        transactions: [
-          {
-            blockHash: undefined,
-            blockNumber: undefined,
-            transactionHash: undefined,
-            transactionTag: TxTags.asset.RegisterTicker,
-            type: TransactionType.Single,
-          },
-        ],
-      });
+      const { result, transactions, details } = (await service.submit(
+        mockMethod,
+        {},
+        { signer }
+      )) as TransactionResult<undefined>;
+
+      expect(result).toBeUndefined();
+      expect(transactions).toEqual([
+        {
+          blockHash: undefined,
+          blockNumber: undefined,
+          transactionHash: undefined,
+          transactionTag: TxTags.asset.RegisterTicker,
+          type: TransactionType.Single,
+        },
+      ]);
+      expect(details).toBeDefined();
     });
 
     it('should process batch transactions and return the result', async () => {
@@ -113,19 +119,25 @@ describe('TransactionsService', () => {
       mockIsPolymeshTransactionBatch.mockReturnValue(true);
       const mockMethod = makeMockMethod(transaction);
 
-      const result = await service.submit(mockMethod, {}, { signer });
-      expect(result).toEqual({
-        result: undefined,
-        transactions: [
-          {
-            blockHash: undefined,
-            blockNumber: undefined,
-            transactionHash: undefined,
-            transactionTags: [TxTags.asset.RegisterTicker, TxTags.asset.CreateAsset],
-            type: TransactionType.Batch,
-          },
-        ],
-      });
+      const { result, transactions, details } = (await service.submit(
+        mockMethod,
+        {},
+        { signer }
+      )) as TransactionResult<undefined>;
+
+      expect(result).toBeUndefined();
+
+      expect(transactions).toEqual([
+        {
+          blockHash: undefined,
+          blockNumber: undefined,
+          transactionHash: undefined,
+          transactionTags: [TxTags.asset.RegisterTicker, TxTags.asset.CreateAsset],
+          type: TransactionType.Batch,
+        },
+      ]);
+
+      expect(details).toBeDefined();
     });
   });
 

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -71,11 +71,11 @@ export class TransactionsService {
     args: MethodArgs,
     transactionBaseDto: TransactionBaseDto
   ): Promise<NotificationPayload | TransactionResult<TransformedReturnType>> {
-    const { signer, webhookUrl } = transactionBaseDto;
+    const { signer, webhookUrl, dryRun } = transactionBaseDto;
     const signingAccount = await this.getSigningAccount(signer);
     try {
       if (!webhookUrl) {
-        return processTransaction(method, args, { signingAccount });
+        return processTransaction(method, args, { signingAccount }, dryRun);
       } else {
         // prepare the procedure so the SDK will run its validation and throw if something isn't right
         const transaction = await prepareProcedure(method, args, { signingAccount });

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -36,7 +36,7 @@ export type TransactionDetails = {
 };
 
 export type TransactionResult<T> = {
-  result: T;
+  result?: T;
   transactions: (TransactionModel | BatchTransactionModel)[];
   details: TransactionDetails;
 };
@@ -91,13 +91,11 @@ export async function processTransaction<
       },
     };
 
-    let result = undefined as unknown as TransformedReturnType;
-
     if (dryRun) {
-      return { details, result, transactions: [] };
+      return { details, transactions: [] };
     }
 
-    result = await procedure.run();
+    const result = await procedure.run();
 
     const assembleTransactionResponse = <T, R = T>(
       transaction: GenericPolymeshTransaction<T, R>

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -11,7 +11,7 @@ import {
   Fees,
   GenericPolymeshTransaction,
   NoArgsProcedureMethod,
-  PayingAccount,
+  PayingAccountType,
   ProcedureMethod,
   ProcedureOpts,
   TransactionStatus,
@@ -29,10 +29,11 @@ export type TransactionDetails = {
   status: TransactionStatus;
   fees: Fees;
   supportsSubsidy: boolean;
-  payingAccount: Pick<PayingAccount, 'type'> &
-    Pick<Account, 'address'> & {
-      balance: BigNumber;
-    };
+  payingAccount: {
+    type: PayingAccountType;
+    address: string;
+    balance: BigNumber;
+  };
 };
 
 export type TransactionResult<T> = {

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -78,11 +78,11 @@ export async function processTransaction<
 
     const batch: [
       feesPromise: Promise<PayingAccountFees>,
-      resultPromise: Promise<TransformedReturnType | void>
+      resultPromise: Promise<TransformedReturnType | undefined>
     ] = [
       procedure.getTotalFees(),
       new Promise(resolve => {
-        resolve();
+        resolve(undefined);
       }),
     ];
 
@@ -91,9 +91,10 @@ export async function processTransaction<
     }
 
     const supportsSubsidy = procedure.supportsSubsidy();
-    const [totalFees, result] = await Promise.all<PayingAccountFees, TransformedReturnType | void>(
-      batch
-    );
+    const [totalFees, result] = await Promise.all<
+      PayingAccountFees,
+      TransformedReturnType | undefined
+    >(batch);
 
     const {
       fees,
@@ -112,7 +113,7 @@ export async function processTransaction<
     };
 
     if (dryRun) {
-      return { details, result: {} as TransformedReturnType, transactions: [] };
+      return { details, result: result as unknown as TransformedReturnType, transactions: [] };
     }
 
     const assembleTransactionResponse = <T, R = T>(
@@ -149,7 +150,7 @@ export async function processTransaction<
     };
 
     return {
-      result: result || ({} as TransformedReturnType),
+      result: result as unknown as TransformedReturnType,
       transactions: [assembleTransactionResponse(procedure)],
       details: {
         ...details,

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -78,14 +78,14 @@ export async function processTransaction<
 
     const batch: [
       feesPromise: Promise<PayingAccountFees>,
-      resultPromise: Promise<TransformedReturnType | undefined>
-    ] = [procedure.getTotalFees(), dryRun ? Promise.resolve(undefined) : procedure.run()];
+      resultPromise: Promise<TransformedReturnType>
+    ] = [
+      procedure.getTotalFees(),
+      dryRun ? Promise.resolve({} as TransformedReturnType) : procedure.run(),
+    ];
 
     const supportsSubsidy = procedure.supportsSubsidy();
-    const [totalFees, result] = await Promise.all<
-      PayingAccountFees,
-      TransformedReturnType | undefined
-    >(batch);
+    const [totalFees, result] = await Promise.all<PayingAccountFees, TransformedReturnType>(batch);
 
     const {
       fees,
@@ -104,7 +104,7 @@ export async function processTransaction<
     };
 
     if (dryRun) {
-      return { details, result: result as unknown as TransformedReturnType, transactions: [] };
+      return { details, result, transactions: [] };
     }
 
     const assembleTransactionResponse = <T, R = T>(
@@ -141,7 +141,7 @@ export async function processTransaction<
     };
 
     return {
-      result: result as unknown as TransformedReturnType,
+      result,
       transactions: [assembleTransactionResponse(procedure)],
       details: {
         ...details,

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -79,16 +79,7 @@ export async function processTransaction<
     const batch: [
       feesPromise: Promise<PayingAccountFees>,
       resultPromise: Promise<TransformedReturnType | undefined>
-    ] = [
-      procedure.getTotalFees(),
-      new Promise(resolve => {
-        resolve(undefined);
-      }),
-    ];
-
-    if (!dryRun) {
-      batch[1] = procedure.run();
-    }
+    ] = [procedure.getTotalFees(), dryRun ? Promise.resolve(undefined) : procedure.run()];
 
     const supportsSubsidy = procedure.supportsSubsidy();
     const [totalFees, result] = await Promise.all<

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -6,7 +6,6 @@ import {
 } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
-  Account,
   ErrorCode,
   Fees,
   GenericPolymeshTransaction,

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -36,7 +36,7 @@ export type TransactionDetails = {
 };
 
 export type TransactionResult<T> = {
-  result?: T;
+  result: T;
   transactions: (TransactionModel | BatchTransactionModel)[];
   details: TransactionDetails;
 };
@@ -92,7 +92,7 @@ export async function processTransaction<
     };
 
     if (dryRun) {
-      return { details, transactions: [] };
+      return { details, result: {} as TransformedReturnType, transactions: [] };
     }
 
     const result = await procedure.run();


### PR DESCRIPTION
return the details of fees and paying account for transaction as well as enable dryRun

### JIRA Link 

https://polymesh.atlassian.net/browse/DA-108

### Changelog / Description 

- adds `dryRun` tag to enable testing the transaction without submitting it to blockchain
- adds transactionDetails in the response (fees, paying account data)

Note: should carefully look if I haven't missed nay part where the dryRun should be added to

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [] Updated the Readme.md (if required) ?
