### PR TITLE
test: 💍 Use generic `handleSdkError` function to handle errors

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
   testRegex: '.*\\.spec\\.ts$',
   coverageDirectory: './coverage',
   collectCoverage: true,
+  restoreMocks: true,
 };

--- a/src/accounts/accounts.service.spec.ts
+++ b/src/accounts/accounts.service.spec.ts
@@ -169,7 +169,6 @@ describe('AccountsService', () => {
         order: Order.Desc,
       });
       expect(result).toEqual(mockTransactions);
-      findOneSpy.mockRestore();
     });
   });
 
@@ -206,8 +205,6 @@ describe('AccountsService', () => {
       const result = await service.getPermissions('address');
 
       expect(result).toEqual(mockPermissions);
-
-      findOneSpy.mockRestore();
     });
 
     describe('otherwise', () => {

--- a/src/accounts/accounts.service.spec.ts
+++ b/src/accounts/accounts.service.spec.ts
@@ -64,7 +64,7 @@ describe('AccountsService', () => {
     it('should return the Account for valid Account address', async () => {
       const mockAccount = 'account';
 
-      mockPolymeshApi.accountManagement.getAccount.mockReturnValue(mockAccount);
+      mockPolymeshApi.accountManagement.getAccount.mockResolvedValue(mockAccount);
 
       const result = await service.findOne('address');
 
@@ -74,9 +74,7 @@ describe('AccountsService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockPolymeshApi.accountManagement.getAccount.mockImplementation(() => {
-          throw mockError;
-        });
+        mockPolymeshApi.accountManagement.getAccount.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
@@ -215,9 +213,7 @@ describe('AccountsService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockAccount.getPermissions.mockImplementation(() => {
-          throw mockError;
-        });
+        mockAccount.getPermissions.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -28,11 +28,7 @@ export class AccountsService {
     const {
       polymeshService: { polymeshApi },
     } = this;
-    try {
-      return await polymeshApi.accountManagement.getAccount({ address });
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await polymeshApi.accountManagement.getAccount({ address }).catch(handleSdkError);
   }
 
   public async getAccountBalance(account: string): Promise<AccountBalance> {
@@ -68,11 +64,7 @@ export class AccountsService {
 
   public async getPermissions(address: string): Promise<Permissions> {
     const account = await this.findOne(address);
-    try {
-      return await account.getPermissions();
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await account.getPermissions().catch(handleSdkError);
   }
 
   public async freezeSecondaryAccounts(

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -70,7 +70,7 @@ describe('AssetsService', () => {
     it('should return the Asset for a valid ticker', async () => {
       const mockAsset = new MockAsset();
 
-      mockPolymeshApi.assets.getAsset.mockReturnValue(mockAsset);
+      mockPolymeshApi.assets.getAsset.mockResolvedValue(mockAsset);
 
       const result = await service.findOne('TICKER');
 
@@ -80,9 +80,7 @@ describe('AssetsService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockPolymeshApi.assets.getAsset.mockImplementation(() => {
-          throw mockError;
-        });
+        mockPolymeshApi.assets.getAsset.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -145,7 +145,6 @@ describe('AssetsService', () => {
 
       const result = await service.findHolders('TICKER', new BigNumber(10));
       expect(result).toEqual(mockHolders);
-      findOneSpy.mockRestore();
     });
 
     it('should return the list of Asset holders from a start value', async () => {
@@ -158,7 +157,6 @@ describe('AssetsService', () => {
 
       const result = await service.findHolders('TICKER', new BigNumber(10), 'NEXT_KEY');
       expect(result).toEqual(mockHolders);
-      findOneSpy.mockRestore();
     });
   });
 
@@ -185,7 +183,6 @@ describe('AssetsService', () => {
 
       const result = await service.findDocuments('TICKER', new BigNumber(10));
       expect(result).toEqual(mockAssetDocuments);
-      findOneSpy.mockRestore();
     });
 
     it('should return the list of Asset documents from a start value', async () => {
@@ -198,7 +195,6 @@ describe('AssetsService', () => {
 
       const result = await service.findDocuments('TICKER', new BigNumber(10), 'NEXT_KEY');
       expect(result).toEqual(mockAssetDocuments);
-      findOneSpy.mockRestore();
     });
   });
 
@@ -243,7 +239,6 @@ describe('AssetsService', () => {
         { documents: body.documents },
         { signer }
       );
-      findOneSpy.mockRestore();
     });
   });
 
@@ -304,7 +299,6 @@ describe('AssetsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-      findSpy.mockRestore();
     });
   });
 
@@ -343,7 +337,6 @@ describe('AssetsService', () => {
         result: mockResult,
         transactions: [mockTransaction],
       });
-      findOneSpy.mockRestore();
     });
   });
 
@@ -389,8 +382,6 @@ describe('AssetsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-
-      findSpy.mockRestore();
     });
   });
 
@@ -418,7 +409,6 @@ describe('AssetsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-      findSpy.mockRestore();
     });
   });
 
@@ -446,7 +436,6 @@ describe('AssetsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-      findSpy.mockRestore();
     });
   });
 
@@ -489,7 +478,6 @@ describe('AssetsService', () => {
         },
         { signer }
       );
-      findSpy.mockRestore();
     });
   });
 
@@ -520,7 +508,6 @@ describe('AssetsService', () => {
 
       const result = await service.getOperationHistory('TICKER');
       expect(result).toEqual(mockOperations);
-      findOneSpy.mockRestore();
     });
   });
 });

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -30,11 +30,7 @@ export class AssetsService {
   ) {}
 
   public async findOne(ticker: string): Promise<Asset> {
-    try {
-      return await this.polymeshService.polymeshApi.assets.getAsset({ ticker });
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await this.polymeshService.polymeshApi.assets.getAsset({ ticker }).catch(handleSdkError);
   }
 
   public async findAllByOwner(owner: string): Promise<Asset[]> {

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -4,12 +4,10 @@ import {
   Asset,
   AssetDocument,
   AuthorizationRequest,
-  ErrorCode,
   HistoricAgentOperation,
   IdentityBalance,
   ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
-import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { ControllerTransferDto } from '~/assets/dto/controller-transfer.dto';
 import { CreateAssetDto } from '~/assets/dto/create-asset.dto';
@@ -22,6 +20,7 @@ import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { toPortfolioId } from '~/portfolios/portfolios.util';
 import { TransactionsService } from '~/transactions/transactions.service';
+import { handleSdkError } from '~/transactions/transactions.util';
 
 @Injectable()
 export class AssetsService {
@@ -33,18 +32,8 @@ export class AssetsService {
   public async findOne(ticker: string): Promise<Asset> {
     try {
       return await this.polymeshService.polymeshApi.assets.getAsset({ ticker });
-    } catch (err: unknown) {
-      if (isPolymeshError(err)) {
-        const { code, message } = err;
-        if (
-          code === ErrorCode.DataUnavailable &&
-          message.startsWith('There is no Asset with ticker')
-        ) {
-          throw new NotFoundException(`There is no Asset with ticker "${ticker}"`);
-        }
-      }
-
-      throw err;
+    } catch (err) {
+      handleSdkError(err);
     }
   }
 

--- a/src/assets/dto/ticker-params.dto.ts
+++ b/src/assets/dto/ticker-params.dto.ts
@@ -1,8 +1,9 @@
 /* istanbul ignore file */
 
-import { IsTicker } from '~/common/decorators/validation';
+import { IsString } from 'class-validator';
 
 export class TickerParamsDto {
-  @IsTicker()
+  // @IsTicker()
+  @IsString()
   readonly ticker: string;
 }

--- a/src/assets/dto/ticker-params.dto.ts
+++ b/src/assets/dto/ticker-params.dto.ts
@@ -1,9 +1,8 @@
 /* istanbul ignore file */
 
-import { IsString } from 'class-validator';
+import { IsTicker } from '~/common/decorators/validation';
 
 export class TickerParamsDto {
-  // @IsTicker()
-  @IsString()
+  @IsTicker()
   readonly ticker: string;
 }

--- a/src/authorizations/authorizations.service.spec.ts
+++ b/src/authorizations/authorizations.service.spec.ts
@@ -241,8 +241,6 @@ describe('AuthorizationsService', () => {
       await expect(() => service.getAuthRequest(address, id)).rejects.toBeInstanceOf(
         NotFoundException
       );
-
-      findOneSpy.mockRestore();
     });
 
     it('should return an AuthorizationRequest targeted to an Identity', async () => {
@@ -255,8 +253,6 @@ describe('AuthorizationsService', () => {
 
       const result = await service.getAuthRequest(address, id);
       expect(result).toBe(mockAuthorizationRequest);
-
-      findOneSpy.mockRestore();
     });
 
     it('should return an AuthorizationRequest targeted to an Account', async () => {
@@ -310,7 +306,6 @@ describe('AuthorizationsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-      getAuthRequestSpy.mockRestore();
     });
   });
 
@@ -343,7 +338,6 @@ describe('AuthorizationsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-      getAuthRequestSpy.mockRestore();
     });
   });
 });

--- a/src/authorizations/authorizations.service.spec.ts
+++ b/src/authorizations/authorizations.service.spec.ts
@@ -171,9 +171,7 @@ describe('AuthorizationsService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockAccount.authorizations.getOne.mockImplementation(() => {
-          throw mockError;
-        });
+        mockAccount.authorizations.getOne.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/authorizations/authorizations.service.ts
+++ b/src/authorizations/authorizations.service.ts
@@ -4,17 +4,16 @@ import {
   Account,
   AuthorizationRequest,
   AuthorizationType,
-  ErrorCode,
   Identity,
   ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
-import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { AccountsService } from '~/accounts/accounts.service';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { ServiceReturn } from '~/common/utils';
 import { IdentitiesService } from '~/identities/identities.service';
 import { TransactionsService } from '~/transactions/transactions.service';
+import { handleSdkError } from '~/transactions/transactions.util';
 
 @Injectable()
 export class AuthorizationsService {
@@ -49,16 +48,8 @@ export class AuthorizationsService {
   ): Promise<AuthorizationRequest> {
     try {
       return await signatory.authorizations.getOne({ id });
-    } catch (err: unknown) {
-      if (isPolymeshError(err)) {
-        const { code } = err;
-        if (code === ErrorCode.DataUnavailable) {
-          throw new NotFoundException(
-            `There is no pending Authorization with ID "${id.toString()}"`
-          );
-        }
-      }
-      throw err;
+    } catch (err) {
+      handleSdkError(err);
     }
   }
 

--- a/src/authorizations/authorizations.service.ts
+++ b/src/authorizations/authorizations.service.ts
@@ -46,11 +46,7 @@ export class AuthorizationsService {
     signatory: Identity | Account,
     id: BigNumber
   ): Promise<AuthorizationRequest> {
-    try {
-      return await signatory.authorizations.getOne({ id });
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await signatory.authorizations.getOne({ id }).catch(handleSdkError);
   }
 
   public async findOneByDid(did: string, id: BigNumber): Promise<AuthorizationRequest> {

--- a/src/checkpoints/checkpoints.service.spec.ts
+++ b/src/checkpoints/checkpoints.service.spec.ts
@@ -319,7 +319,6 @@ describe('CheckpointsService', () => {
         size: new BigNumber(1),
         start: undefined,
       });
-      findOneSpy.mockRestore();
     });
 
     it('should return the list of Asset holders at a Checkpoint from a start key', async () => {
@@ -341,7 +340,6 @@ describe('CheckpointsService', () => {
         start: 'START_KEY',
         size: new BigNumber(10),
       });
-      findOneSpy.mockRestore();
     });
   });
 
@@ -365,8 +363,6 @@ describe('CheckpointsService', () => {
       expect(result).toEqual({ balance, identity: did });
       expect(mockCheckpoint.balance).toHaveBeenCalledWith({ identity: did });
       expect(mockAssetsService.findOne).toHaveBeenCalledWith('TICKER');
-
-      findOneSpy.mockRestore();
     });
   });
 

--- a/src/checkpoints/checkpoints.service.spec.ts
+++ b/src/checkpoints/checkpoints.service.spec.ts
@@ -115,9 +115,7 @@ describe('CheckpointsService', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
         const mockAsset = new MockAsset();
-        mockAsset.checkpoints.getOne.mockImplementation(() => {
-          throw mockError;
-        });
+        mockAsset.checkpoints.getOne.mockRejectedValue(mockError);
         mockAssetsService.findOne.mockResolvedValue(mockAsset);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
@@ -189,9 +187,7 @@ describe('CheckpointsService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockAsset.checkpoints.schedules.getOne.mockImplementation(() => {
-          throw mockError;
-        });
+        mockAsset.checkpoints.schedules.getOne.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/checkpoints/checkpoints.service.ts
+++ b/src/checkpoints/checkpoints.service.ts
@@ -39,11 +39,7 @@ export class CheckpointsService {
 
   public async findOne(ticker: string, id: BigNumber): Promise<Checkpoint> {
     const asset = await this.assetsService.findOne(ticker);
-    try {
-      return await asset.checkpoints.getOne({ id });
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await asset.checkpoints.getOne({ id }).catch(handleSdkError);
   }
 
   public async findSchedulesByTicker(ticker: string): Promise<ScheduleWithDetails[]> {
@@ -53,11 +49,7 @@ export class CheckpointsService {
 
   public async findScheduleById(ticker: string, id: BigNumber): Promise<ScheduleWithDetails> {
     const asset = await this.assetsService.findOne(ticker);
-    try {
-      return await asset.checkpoints.schedules.getOne({ id });
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await asset.checkpoints.schedules.getOne({ id }).catch(handleSdkError);
   }
 
   public async createByTicker(

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -260,7 +260,6 @@ describe('CorporateActionsService', () => {
           signer,
         }
       );
-      findDistributionSpy.mockRestore();
     });
   });
 
@@ -298,7 +297,6 @@ describe('CorporateActionsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-      findDistributionSpy.mockRestore();
     });
   });
 
@@ -333,7 +331,6 @@ describe('CorporateActionsService', () => {
             signer,
           }
         );
-        findDistributionSpy.mockRestore();
       });
     });
   });
@@ -372,7 +369,6 @@ describe('CorporateActionsService', () => {
         undefined,
         { signer, webhookUrl, dryRun }
       );
-      findDistributionSpy.mockRestore();
     });
   });
 
@@ -405,7 +401,6 @@ describe('CorporateActionsService', () => {
         result: undefined,
         transactions: [mockTransaction],
       });
-      findDistributionSpy.mockRestore();
     });
   });
 });

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -1,16 +1,9 @@
 /* eslint-disable import/first */
-const mockIsPolymeshError = jest.fn();
 const mockIsPolymeshTransaction = jest.fn();
 
-import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import {
-  CaCheckpointType,
-  ErrorCode,
-  TargetTreatment,
-  TxTags,
-} from '@polymeshassociation/polymesh-sdk/types';
+import { CaCheckpointType, TxTags } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AssetsService } from '~/assets/assets.service';
 import { AssetDocumentDto } from '~/assets/dto/asset-document.dto';
@@ -21,12 +14,12 @@ import { MockDistribution } from '~/corporate-actions/mocks/dividend-distributio
 import { testValues } from '~/test-utils/consts';
 import { MockAsset, MockTransaction } from '~/test-utils/mocks';
 import { MockAssetService, mockTransactionsProvider } from '~/test-utils/service-mocks';
+import * as transactionsUtilModule from '~/transactions/transactions.util';
 
 const { signer } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
-  isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
 
@@ -80,62 +73,34 @@ describe('CorporateActionsService', () => {
       mockAssetsService.findOne.mockResolvedValue(mockAsset);
     });
 
-    describe('if there is an error while modifying the Corporate Action Default Config', () => {
-      it('should pass the error along the chain', async () => {
-        const expectedError = new Error('New targets are the same as the current ones');
-        const body = {
-          signer,
-          targets: {
-            treatment: TargetTreatment.Exclude,
-            identities: [],
-          },
-        };
-        mockTransactionsService.submit.mockImplementation(() => {
-          throw expectedError;
-        });
+    it('should run a setDefaultConfig procedure and return the queue data', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.corporateAction.SetDefaultWithholdingTax,
+      };
+      const mockTransaction = new MockTransaction(transaction);
 
-        mockIsPolymeshError.mockReturnValue(true);
+      mockAsset.corporateActions.setDefaultConfig.mockResolvedValue(mockTransaction);
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        let error = null;
-        try {
-          await service.updateDefaultConfigByTicker(ticker, body);
-        } catch (err) {
-          error = err;
-        }
-        expect(error).toEqual(expectedError);
-        expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
+      const body = {
+        signer,
+        defaultTaxWithholding: new BigNumber(25),
+      };
+      const result = await service.updateDefaultConfigByTicker(ticker, body);
+
+      expect(result).toEqual({
+        result: undefined,
+        transactions: [mockTransaction],
       });
-    });
-    describe('otherwise', () => {
-      it('should run a setDefaultConfig procedure and return the queue data', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.corporateAction.SetDefaultWithholdingTax,
-        };
-        const mockTransaction = new MockTransaction(transaction);
-
-        mockAsset.corporateActions.setDefaultConfig.mockResolvedValue(mockTransaction);
-        mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
-
-        const body = {
-          signer,
-          defaultTaxWithholding: new BigNumber(25),
-        };
-        const result = await service.updateDefaultConfigByTicker(ticker, body);
-
-        expect(result).toEqual({
-          result: undefined,
-          transactions: [mockTransaction],
-        });
-        expect(mockTransactionsService.submit).toHaveBeenCalledWith(
-          mockAsset.corporateActions.setDefaultConfig,
-          { defaultTaxWithholding: new BigNumber(25) },
-          { signer }
-        );
-        expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
-      });
+      expect(mockTransactionsService.submit).toHaveBeenCalledWith(
+        mockAsset.corporateActions.setDefaultConfig,
+        { defaultTaxWithholding: new BigNumber(25) },
+        { signer }
+      );
+      expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
     });
   });
 
@@ -155,71 +120,35 @@ describe('CorporateActionsService', () => {
   });
 
   describe('findDistribution', () => {
-    beforeEach(() => {
-      mockIsPolymeshError.mockReturnValue(false);
+    it('should return a specific Dividend Distribution associated with an given ticker', async () => {
+      const mockDistributions = new MockDistributionWithDetails();
+
+      const mockAsset = new MockAsset();
+      mockAsset.corporateActions.distributions.getOne.mockResolvedValue(mockDistributions);
+
+      mockAssetsService.findOne.mockResolvedValue(mockAsset);
+
+      const result = await service.findDistribution('TICKER', new BigNumber(1));
+
+      expect(result).toEqual(mockDistributions);
     });
 
-    afterAll(() => {
-      mockIsPolymeshError.mockReset();
-    });
-
-    describe('if the Dividend Distribution does not exist', () => {
-      it('should throw a NotFoundException', async () => {
+    describe('otherwise', () => {
+      it('should call the handleSdkError method and throw an error', async () => {
         const mockAsset = new MockAsset();
-        const mockError = {
-          code: ErrorCode.DataUnavailable,
-          message: 'The Dividend Distribution does not exist',
-        };
+        const mockError = new Error('Some Error');
         mockAsset.corporateActions.distributions.getOne.mockImplementation(() => {
           throw mockError;
         });
         mockAssetsService.findOne.mockResolvedValue(mockAsset);
 
-        mockIsPolymeshError.mockReturnValue(true);
+        const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-        let error;
-        try {
-          await service.findDistribution('TICKER', new BigNumber(1));
-        } catch (err) {
-          error = err;
-        }
+        await expect(() =>
+          service.findDistribution('TICKER', new BigNumber(1))
+        ).rejects.toThrowError();
 
-        expect(error).toBeInstanceOf(NotFoundException);
-      });
-    });
-    describe('if there is a different error', () => {
-      it('should pass the error along the chain', async () => {
-        const expectedError = new Error('foo');
-
-        const mockAsset = new MockAsset();
-        mockAsset.corporateActions.distributions.getOne.mockImplementation(() => {
-          throw expectedError;
-        });
-
-        mockAssetsService.findOne.mockResolvedValue(mockAsset);
-
-        let error;
-        try {
-          await service.findDistribution('TICKER', new BigNumber(1));
-        } catch (err) {
-          error = err;
-        }
-
-        expect(error).toEqual(expectedError);
-      });
-    });
-    describe('otherwise', () => {
-      it('should return a specific Dividend Distribution associated with an Asset', async () => {
-        const mockDistributions = new MockDistributionWithDetails();
-
-        const mockAsset = new MockAsset();
-        mockAsset.corporateActions.distributions.getOne.mockResolvedValue(mockDistributions);
-
-        mockAssetsService.findOne.mockResolvedValue(mockAsset);
-
-        const result = await service.findDistribution('TICKER', new BigNumber(1));
-
-        expect(result).toEqual(mockDistributions);
+        expect(handleSdkErrorSpy).toHaveBeenCalledWith(mockError);
       });
     });
   });
@@ -244,29 +173,27 @@ describe('CorporateActionsService', () => {
       mockAssetsService.findOne.mockResolvedValue(mockAsset);
     });
 
-    describe('otherwise', () => {
-      it('should run a configureDividendDistribution procedure and return the created Dividend Distribution', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.corporateAction.InitiateCorporateActionAndDistribute,
-        };
-        const mockTransaction = new MockTransaction(transaction);
-        const mockDistribution = new MockDistribution();
-        mockTransactionsService.submit.mockResolvedValue({
-          result: mockDistribution,
-          transactions: [mockTransaction],
-        });
-
-        const result = await service.createDividendDistribution(ticker, body);
-
-        expect(result).toEqual({
-          result: mockDistribution,
-          transactions: [mockTransaction],
-        });
-        expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
+    it('should run a configureDividendDistribution procedure and return the created Dividend Distribution', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.corporateAction.InitiateCorporateActionAndDistribute,
+      };
+      const mockTransaction = new MockTransaction(transaction);
+      const mockDistribution = new MockDistribution();
+      mockTransactionsService.submit.mockResolvedValue({
+        result: mockDistribution,
+        transactions: [mockTransaction],
       });
+
+      const result = await service.createDividendDistribution(ticker, body);
+
+      expect(result).toEqual({
+        result: mockDistribution,
+        transactions: [mockTransaction],
+      });
+      expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
     });
   });
 
@@ -279,92 +206,67 @@ describe('CorporateActionsService', () => {
       mockAssetsService.findOne.mockResolvedValue(mockAsset);
     });
 
-    describe('if there is an error while deleting a Corporate Action', () => {
-      it('should pass the error along the chain', async () => {
-        const expectedError = new Error("The Corporate Action doesn't exist");
+    it('should run a remove procedure and return the delete the Corporate Action', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.corporateAction.RemoveCa,
+      };
+      const mockTransaction = new MockTransaction(transaction);
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        mockTransactionsService.submit.mockImplementation(() => {
-          throw expectedError;
-        });
+      const result = await service.remove(ticker, new BigNumber(1), { signer });
 
-        mockIsPolymeshError.mockReturnValue(true);
-
-        let error = null;
-        try {
-          await service.remove(ticker, new BigNumber(1), { signer });
-        } catch (err) {
-          error = err;
-        }
-        expect(error).toEqual(expectedError);
-        expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
-        mockIsPolymeshError.mockReset();
+      expect(result).toEqual({
+        transactions: [mockTransaction],
       });
-    });
-    describe('otherwise', () => {
-      it('should run a remove procedure and return the delete the Corporate Action', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.corporateAction.RemoveCa,
-        };
-        const mockTransaction = new MockTransaction(transaction);
-        mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
-
-        const result = await service.remove(ticker, new BigNumber(1), { signer });
-
-        expect(result).toEqual({
-          transactions: [mockTransaction],
-        });
-        expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
-      });
+      expect(mockAssetsService.findOne).toHaveBeenCalledWith(ticker);
     });
   });
 
   describe('payDividends', () => {
-    const body = {
-      signer,
-      targets: ['0x6'.padEnd(66, '1')],
-    };
+    it('should call the pay procedure and return the transaction details', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.capitalDistribution.PushBenefit,
+      };
+      const mockTransaction = new MockTransaction(transaction);
 
-    describe('otherwise', () => {
-      it('should return the transaction details', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.capitalDistribution.PushBenefit,
-        };
-        const mockTransaction = new MockTransaction(transaction);
+      const distributionWithDetails = new MockDistributionWithDetails();
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        const distributionWithDetails = new MockDistributionWithDetails();
-        mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
+      const findDistributionSpy = jest.spyOn(service, 'findDistribution');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findDistributionSpy.mockResolvedValue(distributionWithDetails as any);
 
-        const findDistributionSpy = jest.spyOn(service, 'findDistribution');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findDistributionSpy.mockResolvedValue(distributionWithDetails as any);
+      const body = {
+        signer,
+        targets: ['0x6'.padEnd(66, '1')],
+      };
 
-        const result = await service.payDividends('TICKER', new BigNumber(1), body);
-        expect(result).toEqual({
-          result: undefined,
-          transactions: [mockTransaction],
-        });
-        expect(mockTransactionsService.submit).toHaveBeenCalledWith(
-          distributionWithDetails.distribution.pay,
-          {
-            targets: body.targets,
-          },
-          {
-            signer,
-          }
-        );
-        findDistributionSpy.mockRestore();
+      const result = await service.payDividends('TICKER', new BigNumber(1), body);
+      expect(result).toEqual({
+        result: undefined,
+        transactions: [mockTransaction],
       });
+
+      expect(mockTransactionsService.submit).toHaveBeenCalledWith(
+        distributionWithDetails.distribution.pay,
+        {
+          targets: body.targets,
+        },
+        {
+          signer,
+        }
+      );
+      findDistributionSpy.mockRestore();
     });
   });
 
   describe('linkDocuments', () => {
-    let mockDistributionWithDetails: MockDistributionWithDetails;
     const body = {
       documents: [
         new AssetDocumentDto({
@@ -376,38 +278,29 @@ describe('CorporateActionsService', () => {
       signer,
     };
 
-    beforeEach(() => {
-      mockIsPolymeshError.mockReturnValue(false);
-      mockDistributionWithDetails = new MockDistributionWithDetails();
-    });
+    it('should run the linkDocuments procedure and return the queue results', async () => {
+      const mockDistributionWithDetails = new MockDistributionWithDetails();
 
-    afterAll(() => {
-      mockIsPolymeshError.mockReset();
-    });
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.corporateAction.LinkCaDoc,
+      };
+      const mockTransaction = new MockTransaction(transaction);
+      mockDistributionWithDetails.distribution.linkDocuments.mockResolvedValue(mockTransaction);
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-    describe('otherwise', () => {
-      it('should run the linkDocuments procedure and return the queue results', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.corporateAction.LinkCaDoc,
-        };
-        const mockTransaction = new MockTransaction(transaction);
-        mockDistributionWithDetails.distribution.linkDocuments.mockResolvedValue(mockTransaction);
-        mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
+      const findDistributionSpy = jest.spyOn(service, 'findDistribution');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findDistributionSpy.mockResolvedValue(mockDistributionWithDetails as any);
 
-        const findDistributionSpy = jest.spyOn(service, 'findDistribution');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findDistributionSpy.mockResolvedValue(mockDistributionWithDetails as any);
-
-        const result = await service.linkDocuments('TICKER', new BigNumber(1), body);
-        expect(result).toEqual({
-          result: undefined,
-          transactions: [mockTransaction],
-        });
-        findDistributionSpy.mockRestore();
+      const result = await service.linkDocuments('TICKER', new BigNumber(1), body);
+      expect(result).toEqual({
+        result: undefined,
+        transactions: [mockTransaction],
       });
+      findDistributionSpy.mockRestore();
     });
   });
 
@@ -451,83 +344,70 @@ describe('CorporateActionsService', () => {
     const webhookUrl = 'http://example.com';
     const dryRun = false;
 
-    describe('otherwise', () => {
-      it('should return the transaction details', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.capitalDistribution.Reclaim,
-        };
-        const mockTransaction = new MockTransaction(transaction);
+    it('should call the reclaimFunds procedure and return the transaction details', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.capitalDistribution.Reclaim,
+      };
+      const mockTransaction = new MockTransaction(transaction);
 
-        const distributionWithDetails = new MockDistributionWithDetails();
-        mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
+      const distributionWithDetails = new MockDistributionWithDetails();
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-        const findDistributionSpy = jest.spyOn(service, 'findDistribution');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findDistributionSpy.mockResolvedValue(distributionWithDetails as any);
+      const findDistributionSpy = jest.spyOn(service, 'findDistribution');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findDistributionSpy.mockResolvedValue(distributionWithDetails as any);
 
-        const result = await service.reclaimRemainingFunds('TICKER', new BigNumber(1), {
-          signer,
-          webhookUrl,
-          dryRun,
-        });
-        expect(result).toEqual({
-          result: undefined,
-          transactions: [mockTransaction],
-        });
-        expect(mockTransactionsService.submit).toHaveBeenCalledWith(
-          distributionWithDetails.distribution.reclaimFunds,
-          undefined,
-          { signer, webhookUrl, dryRun }
-        );
-        findDistributionSpy.mockRestore();
+      const result = await service.reclaimRemainingFunds('TICKER', new BigNumber(1), {
+        signer,
+        webhookUrl,
+        dryRun,
       });
+      expect(result).toEqual({
+        result: undefined,
+        transactions: [mockTransaction],
+      });
+      expect(mockTransactionsService.submit).toHaveBeenCalledWith(
+        distributionWithDetails.distribution.reclaimFunds,
+        undefined,
+        { signer, webhookUrl, dryRun }
+      );
+      findDistributionSpy.mockRestore();
     });
   });
 
   describe('modifyCheckpoint', () => {
-    let mockDistributionWithDetails: MockDistributionWithDetails;
-    const body = {
-      checkpoint: {
-        id: new BigNumber(1),
-        type: CaCheckpointType.Existing,
-      },
-      signer,
-    };
+    it('should run the modifyCheckpoint procedure and return the queue results', async () => {
+      const mockDistributionWithDetails = new MockDistributionWithDetails();
 
-    beforeEach(() => {
-      mockIsPolymeshError.mockReturnValue(false);
-      mockDistributionWithDetails = new MockDistributionWithDetails();
-    });
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.corporateAction.ChangeRecordDate,
+      };
+      const mockTransaction = new MockTransaction(transaction);
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
 
-    afterEach(() => {
-      mockIsPolymeshError.mockReset();
-    });
+      const findDistributionSpy = jest.spyOn(service, 'findDistribution');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findDistributionSpy.mockResolvedValue(mockDistributionWithDetails as any);
 
-    describe('otherwise', () => {
-      it('should run the modifyCheckpoint procedure and return the queue results', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.corporateAction.ChangeRecordDate,
-        };
-        const mockTransaction = new MockTransaction(transaction);
-        mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
-
-        const findDistributionSpy = jest.spyOn(service, 'findDistribution');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findDistributionSpy.mockResolvedValue(mockDistributionWithDetails as any);
-
-        const result = await service.modifyCheckpoint('TICKER', new BigNumber(1), body);
-        expect(result).toEqual({
-          result: undefined,
-          transactions: [mockTransaction],
-        });
-        findDistributionSpy.mockRestore();
+      const body = {
+        checkpoint: {
+          id: new BigNumber(1),
+          type: CaCheckpointType.Existing,
+        },
+        signer,
+      };
+      const result = await service.modifyCheckpoint('TICKER', new BigNumber(1), body);
+      expect(result).toEqual({
+        result: undefined,
+        transactions: [mockTransaction],
       });
+      findDistributionSpy.mockRestore();
     });
   });
 });

--- a/src/corporate-actions/corporate-actions.service.spec.ts
+++ b/src/corporate-actions/corporate-actions.service.spec.ts
@@ -137,9 +137,7 @@ describe('CorporateActionsService', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockAsset = new MockAsset();
         const mockError = new Error('Some Error');
-        mockAsset.corporateActions.distributions.getOne.mockImplementation(() => {
-          throw mockError;
-        });
+        mockAsset.corporateActions.distributions.getOne.mockRejectedValue(mockError);
         mockAssetsService.findOne.mockResolvedValue(mockAsset);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');

--- a/src/corporate-actions/corporate-actions.service.ts
+++ b/src/corporate-actions/corporate-actions.service.ts
@@ -1,12 +1,10 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
   CorporateActionDefaultConfig,
   DistributionWithDetails,
   DividendDistribution,
-  ErrorCode,
 } from '@polymeshassociation/polymesh-sdk/types';
-import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { AssetsService } from '~/assets/assets.service';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
@@ -18,6 +16,7 @@ import { ModifyDistributionCheckpointDto } from '~/corporate-actions/dto/modify-
 import { PayDividendsDto } from '~/corporate-actions/dto/pay-dividends.dto';
 import { toPortfolioId } from '~/portfolios/portfolios.util';
 import { TransactionsService } from '~/transactions/transactions.service';
+import { handleSdkError } from '~/transactions/transactions.util';
 
 @Injectable()
 export class CorporateActionsService {
@@ -56,16 +55,7 @@ export class CorporateActionsService {
     try {
       return await asset.corporateActions.distributions.getOne({ id });
     } catch (err: unknown) {
-      if (isPolymeshError(err)) {
-        const { code } = err;
-        if (code === ErrorCode.DataUnavailable) {
-          throw new NotFoundException(
-            `The Dividend Distribution with id: "${id.toString()}" does not exist for ticker: "${ticker}"`
-          );
-        }
-      }
-
-      throw err;
+      handleSdkError(err);
     }
   }
 

--- a/src/corporate-actions/corporate-actions.service.ts
+++ b/src/corporate-actions/corporate-actions.service.ts
@@ -52,11 +52,7 @@ export class CorporateActionsService {
   public async findDistribution(ticker: string, id: BigNumber): Promise<DistributionWithDetails> {
     const asset = await this.assetsService.findOne(ticker);
 
-    try {
-      return await asset.corporateActions.distributions.getOne({ id });
-    } catch (err: unknown) {
-      handleSdkError(err);
-    }
+    return await asset.corporateActions.distributions.getOne({ id }).catch(handleSdkError);
   }
 
   public async createDividendDistribution(

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -487,7 +487,6 @@ describe('IdentitiesController', () => {
       const result = await controller.createMockCdd(params);
       expect(result).toEqual(fakeIdentityModel);
       expect(mockIdentitiesService.createMockCdd).toHaveBeenCalledWith(params);
-      createIdentityModelSpy.mockRestore();
     });
   });
 });

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -475,9 +475,7 @@ describe('IdentitiesController', () => {
     it('should call the service and return the Identity', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const fakeIdentityModel = 'fakeIdentityModel' as any;
-      const createIdentityModelSpy = jest
-        .spyOn(identityUtil, 'createIdentityModel')
-        .mockResolvedValue(fakeIdentityModel);
+      jest.spyOn(identityUtil, 'createIdentityModel').mockResolvedValue(fakeIdentityModel);
 
       const params = {
         address: '5abc',

--- a/src/identities/identities.service.spec.ts
+++ b/src/identities/identities.service.spec.ts
@@ -85,7 +85,7 @@ describe('IdentitiesService', () => {
     it('should return the Identity for a valid DID', async () => {
       const fakeResult = 'identity';
 
-      mockPolymeshApi.identities.getIdentity.mockReturnValue(fakeResult);
+      mockPolymeshApi.identities.getIdentity.mockResolvedValue(fakeResult);
 
       const result = await service.findOne('realDid');
 
@@ -95,9 +95,7 @@ describe('IdentitiesService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockPolymeshApi.identities.getIdentity.mockImplementation(() => {
-          throw mockError;
-        });
+        mockPolymeshApi.identities.getIdentity.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/identities/identities.service.spec.ts
+++ b/src/identities/identities.service.spec.ts
@@ -1,11 +1,9 @@
 /* eslint-disable import/first */
-const mockIsPolymeshError = jest.fn();
 const mockIsPolymeshTransaction = jest.fn();
 
-import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import { ErrorCode, TxTags } from '@polymeshassociation/polymesh-sdk/types';
+import { TxTags } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AccountsService } from '~/accounts/accounts.service';
 import { IdentitiesService } from '~/identities/identities.service';
@@ -21,12 +19,12 @@ import {
   mockTransactionsProvider,
   MockTransactionsService,
 } from '~/test-utils/service-mocks';
+import * as transactionsUtilModule from '~/transactions/transactions.util';
 
 const { signer } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
-  isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
 
@@ -84,38 +82,28 @@ describe('IdentitiesService', () => {
   });
 
   describe('findOne', () => {
-    describe('if the Identity does not exist', () => {
-      it('should throw a NotFoundException', async () => {
-        const mockError = {
-          code: ErrorCode.DataUnavailable,
-          message: 'The Identity does not exist',
-        };
+    it('should return the Identity for a valid DID', async () => {
+      const fakeResult = 'identity';
+
+      mockPolymeshApi.identities.getIdentity.mockReturnValue(fakeResult);
+
+      const result = await service.findOne('realDid');
+
+      expect(result).toBe(fakeResult);
+    });
+
+    describe('otherwise', () => {
+      it('should call the handleSdkError method and throw an error', async () => {
+        const mockError = new Error('Some Error');
         mockPolymeshApi.identities.getIdentity.mockImplementation(() => {
           throw mockError;
         });
 
-        mockIsPolymeshError.mockReturnValue(true);
+        const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-        let error;
-        try {
-          await service.findOne('falseDid');
-        } catch (err) {
-          error = err;
-        }
+        await expect(() => service.findOne('invalidDID')).rejects.toThrowError();
 
-        expect(error).toBeInstanceOf(NotFoundException);
-        mockIsPolymeshError.mockReset();
-      });
-    });
-    describe('otherwise', () => {
-      it('should return the Identity', async () => {
-        const fakeResult = 'identity';
-
-        mockPolymeshApi.identities.getIdentity.mockReturnValue(fakeResult);
-
-        const result = await service.findOne('realDid');
-
-        expect(result).toBe(fakeResult);
+        expect(handleSdkErrorSpy).toHaveBeenCalledWith(mockError);
       });
     });
   });

--- a/src/identities/identities.service.spec.ts
+++ b/src/identities/identities.service.spec.ts
@@ -125,8 +125,6 @@ describe('IdentitiesService', () => {
 
       const result = await service.findTrustingAssets('TICKER');
       expect(result).toEqual(mockAssets);
-
-      findOneSpy.mockRestore();
     });
   });
 

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -1,18 +1,7 @@
-import {
-  BadRequestException,
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { Keyring } from '@polkadot/keyring';
 import { KeyringPair } from '@polkadot/keyring/types';
-import {
-  Asset,
-  AuthorizationRequest,
-  ErrorCode,
-  Identity,
-} from '@polymeshassociation/polymesh-sdk/types';
-import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
+import { Asset, AuthorizationRequest, Identity } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AccountsService } from '~/accounts/accounts.service';
 import { extractTxBase, ServiceReturn } from '~/common/utils';
@@ -21,6 +10,7 @@ import { CreateMockIdentityDto } from '~/identities/dto/create-mock-identity.dto
 import { PolymeshLogger } from '~/logger/polymesh-logger.service';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { TransactionsService } from '~/transactions/transactions.service';
+import { handleSdkError } from '~/transactions/transactions.util';
 
 @Injectable()
 export class IdentitiesService {
@@ -45,14 +35,7 @@ export class IdentitiesService {
     try {
       return await polymeshApi.identities.getIdentity({ did });
     } catch (err: unknown) {
-      if (isPolymeshError(err)) {
-        const { code } = err;
-        if (code === ErrorCode.DataUnavailable) {
-          this.logger.error(`No valid identity found for did "${did}"`);
-          throw new NotFoundException(`There is no Identity with DID "${did}"`);
-        }
-      }
-      throw err;
+      handleSdkError(err);
     }
   }
 

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -32,11 +32,7 @@ export class IdentitiesService {
     const {
       polymeshService: { polymeshApi },
     } = this;
-    try {
-      return await polymeshApi.identities.getIdentity({ did });
-    } catch (err: unknown) {
-      handleSdkError(err);
-    }
+    return await polymeshApi.identities.getIdentity({ did }).catch(handleSdkError);
   }
 
   /**

--- a/src/metadata/metadata.service.spec.ts
+++ b/src/metadata/metadata.service.spec.ts
@@ -223,7 +223,6 @@ describe('MetadataService', () => {
         { value: body.value, details: body.details },
         { signer }
       );
-      findOneSpy.mockRestore();
     });
   });
 });

--- a/src/metadata/metadata.service.spec.ts
+++ b/src/metadata/metadata.service.spec.ts
@@ -121,7 +121,7 @@ describe('MetadataService', () => {
 
     it('should return the Metadata entry', async () => {
       const mockMetadataEntry = createMockMetadataEntry();
-      mockAsset.metadata.getOne.mockReturnValue(mockMetadataEntry);
+      mockAsset.metadata.getOne.mockResolvedValue(mockMetadataEntry);
 
       const result = await service.findOne({ ticker, type, id });
 
@@ -131,9 +131,7 @@ describe('MetadataService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockAsset.metadata.getOne.mockImplementation(() => {
-          throw mockError;
-        });
+        mockAsset.metadata.getOne.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/metadata/metadata.service.ts
+++ b/src/metadata/metadata.service.ts
@@ -35,11 +35,7 @@ export class MetadataService {
   public async findOne({ ticker, type, id }: MetadataParamsDto): Promise<MetadataEntry> {
     const { metadata } = await this.assetsService.findOne(ticker);
 
-    try {
-      return await metadata.getOne({ type, id });
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await metadata.getOne({ type, id }).catch(handleSdkError);
   }
 
   public async create(ticker: string, params: CreateMetadataDto): ServiceReturn<MetadataEntry> {

--- a/src/offerings/offerings.service.spec.ts
+++ b/src/offerings/offerings.service.spec.ts
@@ -77,7 +77,6 @@ describe('OfferingsService', () => {
         count: mockInvestments.count,
         next: mockInvestments.next,
       });
-      findSpy.mockRestore();
     });
   });
 
@@ -95,7 +94,6 @@ describe('OfferingsService', () => {
           error = err;
         }
         expect(error).toBeInstanceOf(NotFoundException);
-        findSpy.mockRestore();
       });
     });
     describe('otherwise', () => {
@@ -106,7 +104,6 @@ describe('OfferingsService', () => {
 
         const result = await service.findOne('TICKER', new BigNumber(1));
         expect(result).toEqual(mockOfferingWithDetails);
-        findSpy.mockRestore();
       });
     });
   });

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -176,7 +176,6 @@ describe('PortfoliosService', () => {
         },
         { signer: '0x6000' }
       );
-      findOneSpy.mockRestore();
     });
   });
 

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -1,11 +1,9 @@
 /* eslint-disable import/first */
-const mockIsPolymeshError = jest.fn();
 const mockIsPolymeshTransaction = jest.fn();
 
-import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import { ErrorCode, TxTags } from '@polymeshassociation/polymesh-sdk/types';
+import { TxTags } from '@polymeshassociation/polymesh-sdk/types';
 
 import { IdentitiesService } from '~/identities/identities.service';
 import { POLYMESH_API } from '~/polymesh/polymesh.consts';
@@ -20,12 +18,12 @@ import {
   mockTransactionsProvider,
   MockTransactionsService,
 } from '~/test-utils/service-mocks';
+import * as transactionsUtilModule from '~/transactions/transactions.util';
 
 const { signer, did } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
-  isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
 
@@ -59,7 +57,6 @@ describe('PortfoliosService', () => {
   });
 
   afterAll(() => {
-    mockIsPolymeshError.mockReset();
     mockIsPolymeshTransaction.mockReset();
   });
 
@@ -97,75 +94,40 @@ describe('PortfoliosService', () => {
   });
 
   describe('findOne', () => {
-    describe('if the Portfolio does not exist', () => {
-      it('should throw a NotFoundException', async () => {
+    it('should return the Portfolio if it exists', async () => {
+      const mockIdentity = new MockIdentity();
+      const mockPortfolio = {
+        name: 'Growth',
+        id: new BigNumber(1),
+        assetBalances: [],
+      };
+      const owner = '0x6000';
+      mockIdentity.portfolios.getPortfolio.mockResolvedValue(mockPortfolio);
+      mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
+      const result = await service.findOne(owner, new BigNumber(1));
+      expect(result).toEqual({
+        id: new BigNumber(1),
+        name: 'Growth',
+        assetBalances: [],
+      });
+    });
+
+    describe('otherwise', () => {
+      it('should call the handleSdkError method and throw an error', async () => {
+        const mockError = new Error('foo');
         const mockIdentity = new MockIdentity();
         const owner = '0x6000';
-
-        const mockError = {
-          code: ErrorCode.ValidationError,
-          message: "The Portfolio doesn't exist",
-        };
         mockIdentity.portfolios.getPortfolio.mockImplementation(() => {
           throw mockError;
         });
 
         mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
 
-        mockIsPolymeshError.mockReturnValue(true);
+        const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-        let error;
-        try {
-          await service.findOne(owner, new BigNumber(1));
-        } catch (err) {
-          error = err;
-        }
+        await expect(() => service.findOne(owner, new BigNumber(2))).rejects.toThrowError();
 
-        expect(error).toBeInstanceOf(NotFoundException);
-      });
-    });
-
-    describe('if there is a different error', () => {
-      it('should pass the error along the chain', async () => {
-        const expectedError = new Error('foo');
-        const mockIdentity = new MockIdentity();
-        const owner = '0x6000';
-        mockIdentity.portfolios.getPortfolio.mockImplementation(() => {
-          throw expectedError;
-        });
-
-        mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
-
-        mockIsPolymeshError.mockReturnValue(false);
-
-        let error;
-        try {
-          await service.findOne(owner, new BigNumber(2));
-        } catch (err) {
-          error = err;
-        }
-
-        expect(error).toEqual(expectedError);
-      });
-    });
-
-    describe('otherwise', () => {
-      it('should return the portfolio', async () => {
-        const mockIdentity = new MockIdentity();
-        const mockPortfolio = {
-          name: 'Growth',
-          id: new BigNumber(1),
-          assetBalances: [],
-        };
-        const owner = '0x6000';
-        mockIdentity.portfolios.getPortfolio.mockResolvedValue(mockPortfolio);
-        mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
-        const result = await service.findOne(owner, new BigNumber(1));
-        expect(result).toEqual({
-          id: new BigNumber(1),
-          name: 'Growth',
-          assetBalances: [],
-        });
+        expect(handleSdkErrorSpy).toHaveBeenCalledWith(mockError);
       });
     });
   });

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -117,9 +117,7 @@ describe('PortfoliosService', () => {
         const mockError = new Error('foo');
         const mockIdentity = new MockIdentity();
         const owner = '0x6000';
-        mockIdentity.portfolios.getPortfolio.mockImplementation(() => {
-          throw mockError;
-        });
+        mockIdentity.portfolios.getPortfolio.mockRejectedValue(mockError);
 
         mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
 

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -31,15 +31,10 @@ export class PortfoliosService {
     portfolioId?: BigNumber
   ): Promise<DefaultPortfolio | NumberedPortfolio> {
     const identity = await this.identitiesService.findOne(did);
-    try {
-      if (portfolioId) {
-        return await identity.portfolios.getPortfolio({ portfolioId });
-      } else {
-        return await identity.portfolios.getPortfolio();
-      }
-    } catch (err) {
-      handleSdkError(err);
+    if (portfolioId) {
+      return await identity.portfolios.getPortfolio({ portfolioId }).catch(handleSdkError);
     }
+    return await identity.portfolios.getPortfolio().catch(handleSdkError);
   }
 
   public async moveAssets(owner: string, params: AssetMovementDto): ServiceReturn<void> {

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -1,11 +1,6 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import {
-  DefaultPortfolio,
-  ErrorCode,
-  NumberedPortfolio,
-} from '@polymeshassociation/polymesh-sdk/types';
-import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
+import { DefaultPortfolio, NumberedPortfolio } from '@polymeshassociation/polymesh-sdk/types';
 
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { extractTxBase, ServiceReturn } from '~/common/utils';
@@ -16,6 +11,7 @@ import { CreatePortfolioDto } from '~/portfolios/dto/create-portfolio.dto';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
 import { toPortfolioId } from '~/portfolios/portfolios.util';
 import { TransactionsService } from '~/transactions/transactions.service';
+import { handleSdkError } from '~/transactions/transactions.util';
 
 @Injectable()
 export class PortfoliosService {
@@ -42,13 +38,7 @@ export class PortfoliosService {
         return await identity.portfolios.getPortfolio();
       }
     } catch (err) {
-      if (isPolymeshError(err)) {
-        const { code, message } = err;
-        if (code === ErrorCode.ValidationError && message.startsWith("The Portfolio doesn't")) {
-          throw new NotFoundException(`There is no portfolio with ID: "${portfolioId}"`);
-        }
-      }
-      throw err;
+      handleSdkError(err);
     }
   }
 

--- a/src/settlements/settlements.service.spec.ts
+++ b/src/settlements/settlements.service.spec.ts
@@ -111,9 +111,7 @@ describe('SettlementsService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockPolymeshApi.settlements.getInstruction.mockImplementation(() => {
-          throw mockError;
-        });
+        mockPolymeshApi.settlements.getInstruction.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
@@ -135,9 +133,7 @@ describe('SettlementsService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockPolymeshApi.settlements.getVenue.mockImplementation(() => {
-          throw mockError;
-        });
+        mockPolymeshApi.settlements.getVenue.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/settlements/settlements.service.spec.ts
+++ b/src/settlements/settlements.service.spec.ts
@@ -202,7 +202,6 @@ describe('SettlementsService', () => {
         },
         { signer }
       );
-      findVenueSpy.mockRestore();
     });
   });
 
@@ -277,7 +276,6 @@ describe('SettlementsService', () => {
         { description: body.description, type: body.type },
         { signer }
       );
-      findVenueSpy.mockRestore();
     });
   });
 
@@ -313,7 +311,6 @@ describe('SettlementsService', () => {
         {},
         { signer }
       );
-      findInstructionSpy.mockRestore();
     });
   });
 
@@ -346,7 +343,6 @@ describe('SettlementsService', () => {
         {},
         { signer }
       );
-      findInstructionSpy.mockRestore();
     });
   });
 
@@ -369,7 +365,6 @@ describe('SettlementsService', () => {
       const result = await service.findVenueDetails(new BigNumber(123));
 
       expect(result).toEqual(mockDetails);
-      findVenueSpy.mockRestore();
     });
   });
 
@@ -397,7 +392,6 @@ describe('SettlementsService', () => {
       const result = await service.findAffirmations(new BigNumber(123), new BigNumber(10));
 
       expect(result).toEqual(mockAffirmations);
-      findInstructionSpy.mockRestore();
     });
   });
 

--- a/src/settlements/settlements.service.ts
+++ b/src/settlements/settlements.service.ts
@@ -1,7 +1,6 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
-  ErrorCode,
   GroupedInstructions,
   Instruction,
   InstructionAffirmation,
@@ -11,7 +10,6 @@ import {
   Venue,
   VenueDetails,
 } from '@polymeshassociation/polymesh-sdk/types';
-import { isPolymeshError } from '@polymeshassociation/polymesh-sdk/utils';
 
 import { AssetsService } from '~/assets/assets.service';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
@@ -22,6 +20,7 @@ import { CreateInstructionDto } from '~/settlements/dto/create-instruction.dto';
 import { CreateVenueDto } from '~/settlements/dto/create-venue.dto';
 import { ModifyVenueDto } from '~/settlements/dto/modify-venue.dto';
 import { TransactionsService } from '~/transactions/transactions.service';
+import { handleSdkError } from '~/transactions/transactions.util';
 
 @Injectable()
 export class SettlementsService {
@@ -39,25 +38,13 @@ export class SettlementsService {
   }
 
   public async findInstruction(id: BigNumber): Promise<Instruction> {
-    let instruction: Instruction;
-
     try {
-      instruction = await this.polymeshService.polymeshApi.settlements.getInstruction({
+      return await this.polymeshService.polymeshApi.settlements.getInstruction({
         id,
       });
-    } catch (err: unknown) {
-      if (isPolymeshError(err)) {
-        const { code } = err;
-
-        if (code === ErrorCode.ValidationError) {
-          throw new NotFoundException(`There is no Instruction with ID ${id.toString()}`);
-        }
-      }
-
-      throw err;
+    } catch (err) {
+      handleSdkError(err);
     }
-
-    return instruction;
   }
 
   public async createInstruction(
@@ -104,23 +91,13 @@ export class SettlementsService {
   }
 
   public async findVenue(id: BigNumber): Promise<Venue> {
-    let venue: Venue;
     try {
-      venue = await this.polymeshService.polymeshApi.settlements.getVenue({
+      return await this.polymeshService.polymeshApi.settlements.getVenue({
         id,
       });
-    } catch (err: unknown) {
-      if (isPolymeshError(err)) {
-        const { code, message } = err;
-
-        if (code === ErrorCode.ValidationError && message.startsWith("The Venue doesn't")) {
-          throw new NotFoundException(`There is no Venue with ID "${id.toString()}"`);
-        }
-      }
-
-      throw err;
+    } catch (err) {
+      handleSdkError(err);
     }
-    return venue;
   }
 
   public async findVenueDetails(id: BigNumber): Promise<VenueDetails> {

--- a/src/settlements/settlements.service.ts
+++ b/src/settlements/settlements.service.ts
@@ -38,13 +38,11 @@ export class SettlementsService {
   }
 
   public async findInstruction(id: BigNumber): Promise<Instruction> {
-    try {
-      return await this.polymeshService.polymeshApi.settlements.getInstruction({
+    return await this.polymeshService.polymeshApi.settlements
+      .getInstruction({
         id,
-      });
-    } catch (err) {
-      handleSdkError(err);
-    }
+      })
+      .catch(handleSdkError);
   }
 
   public async createInstruction(
@@ -91,13 +89,11 @@ export class SettlementsService {
   }
 
   public async findVenue(id: BigNumber): Promise<Venue> {
-    try {
-      return await this.polymeshService.polymeshApi.settlements.getVenue({
+    return await this.polymeshService.polymeshApi.settlements
+      .getVenue({
         id,
-      });
-    } catch (err) {
-      handleSdkError(err);
-    }
+      })
+      .catch(handleSdkError);
   }
 
   public async findVenueDetails(id: BigNumber): Promise<VenueDetails> {

--- a/src/signing/signing.service.spec.ts
+++ b/src/signing/signing.service.spec.ts
@@ -52,7 +52,6 @@ describe('LocalSigningService', () => {
       await service.initialize({ Alice: '//Alice', Bob: '//Bob' });
       expect(spy).toHaveBeenCalledWith('Alice', '15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5');
       expect(spy).toHaveBeenCalledWith('Bob', '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3');
-      spy.mockRestore();
     });
   });
 
@@ -131,7 +130,6 @@ describe('VaultSigningService', () => {
       expect(logKeySpy).toHaveBeenCalledWith('alice-1', 'ABC');
       expect(logKeySpy).toHaveBeenCalledWith('bob-1', 'DEF');
       expect(logKeySpy).toHaveBeenCalledWith('bob-2', 'GHI');
-      logKeySpy.mockRestore();
     });
   });
 

--- a/src/subsidy/subsidy.service.spec.ts
+++ b/src/subsidy/subsidy.service.spec.ts
@@ -206,8 +206,6 @@ describe('SubsidyService', () => {
         {},
         { signer: beneficiary }
       );
-
-      findOneSpy.mockRestore();
     });
 
     it('should throw an error if no beneficiary or subsidizer is passed', () => {
@@ -268,8 +266,6 @@ describe('SubsidyService', () => {
         { allowance },
         { signer }
       );
-
-      findOneSpy.mockRestore();
     });
 
     it('should run a increaseAllowance procedure and return the queue results', async () => {
@@ -283,8 +279,6 @@ describe('SubsidyService', () => {
         { allowance },
         { signer }
       );
-
-      findOneSpy.mockRestore();
     });
 
     it('should run a decreaseAllowance procedure and return the queue results', async () => {
@@ -298,8 +292,6 @@ describe('SubsidyService', () => {
         { allowance },
         { signer }
       );
-
-      findOneSpy.mockRestore();
     });
   });
 
@@ -318,7 +310,6 @@ describe('SubsidyService', () => {
       const result = await service.getAllowance(beneficiary, subsidizer);
 
       expect(result).toEqual(allowance);
-      findOneSpy.mockRestore();
     });
 
     describe('otherwise', () => {

--- a/src/subsidy/subsidy.service.spec.ts
+++ b/src/subsidy/subsidy.service.spec.ts
@@ -324,9 +324,7 @@ describe('SubsidyService', () => {
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('Some Error');
-        mockSubsidy.getAllowance.mockImplementation(() => {
-          throw mockError;
-        });
+        mockSubsidy.getAllowance.mockRejectedValue(mockError);
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 

--- a/src/subsidy/subsidy.service.ts
+++ b/src/subsidy/subsidy.service.ts
@@ -94,10 +94,6 @@ export class SubsidyService {
   public async getAllowance(beneficiary: string, subsidizer: string): Promise<BigNumber> {
     const subsidy = this.findOne(beneficiary, subsidizer);
 
-    try {
-      return await subsidy.getAllowance();
-    } catch (err) {
-      handleSdkError(err);
-    }
+    return await subsidy.getAllowance().catch(handleSdkError);
   }
 }

--- a/src/ticker-reservations/ticker-reservations.service.spec.ts
+++ b/src/ticker-reservations/ticker-reservations.service.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/first */
-const mockIsPolymeshError = jest.fn();
 const mockIsPolymeshTransaction = jest.fn();
 
 import { Test, TestingModule } from '@nestjs/testing';
@@ -9,6 +8,7 @@ import { TxTags } from '@polymeshassociation/polymesh-sdk/types';
 import { POLYMESH_API } from '~/polymesh/polymesh.consts';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
+import { testValues } from '~/test-utils/consts';
 import {
   MockAuthorizationRequest,
   MockPolymesh,
@@ -20,7 +20,6 @@ import { TickerReservationsService } from '~/ticker-reservations/ticker-reservat
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
-  isPolymeshError: mockIsPolymeshError,
   isPolymeshTransaction: mockIsPolymeshTransaction,
 }));
 
@@ -29,6 +28,7 @@ describe('TickerReservationsService', () => {
   let polymeshService: PolymeshService;
   let mockPolymeshApi: MockPolymesh;
   let mockTransactionsService: MockTransactionsService;
+  const { signer } = testValues;
 
   beforeEach(async () => {
     mockPolymeshApi = new MockPolymesh();
@@ -72,48 +72,26 @@ describe('TickerReservationsService', () => {
 
   describe('reserve', () => {
     const ticker = 'TICKER';
-    const signer = '0x6000';
 
-    describe('if there is an error while reserving the ticker', () => {
-      it('should pass it up the chain', async () => {
-        const expectedError = new Error('Some error');
+    it('should run a reserveTicker procedure and return the queue data', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.asset.RegisterTicker,
+      };
+      const mockResult = new MockTickerReservation();
 
-        mockTransactionsService.submit.mockImplementation(() => {
-          throw expectedError;
-        });
-
-        let error;
-        try {
-          await service.reserve(ticker, { signer });
-        } catch (err) {
-          error = err;
-        }
-
-        expect(error).toEqual(expectedError);
+      const mockTransaction = new MockTransaction(transaction);
+      mockTransactionsService.submit.mockResolvedValue({
+        result: mockResult,
+        transactions: [mockTransaction],
       });
-    });
 
-    describe('otherwise', () => {
-      it('should run a reserveTicker procedure and return the queue data', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.asset.RegisterTicker,
-        };
-        const mockResult = new MockTickerReservation();
-
-        const mockTransaction = new MockTransaction(transaction);
-        mockTransactionsService.submit.mockResolvedValue({
-          result: mockResult,
-          transactions: [mockTransaction],
-        });
-
-        const result = await service.reserve(ticker, { signer });
-        expect(result).toEqual({
-          result: mockResult,
-          transactions: [mockTransaction],
-        });
+      const result = await service.reserve(ticker, { signer });
+      expect(result).toEqual({
+        result: mockResult,
+        transactions: [mockTransaction],
       });
     });
   });
@@ -131,122 +109,69 @@ describe('TickerReservationsService', () => {
       mockTickerReservation = new MockTickerReservation();
     });
 
-    describe('if there is an error while transferring the ownership of the ticker', () => {
-      it('should pass it up the chain', async () => {
-        const expectedError = new Error('Some error');
+    it('should run a transferOwnership procedure and return the queue data', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.identity.AddAuthorization,
+      };
+      const findOneSpy = jest.spyOn(service, 'findOne');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findOneSpy.mockResolvedValue(mockTickerReservation as any);
 
-        const findOneSpy = jest.spyOn(service, 'findOne');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findOneSpy.mockResolvedValue(mockTickerReservation as any);
+      const mockResult = new MockAuthorizationRequest();
 
-        mockTransactionsService.submit.mockImplementation(() => {
-          throw expectedError;
-        });
-
-        let error;
-        try {
-          await service.transferOwnership(ticker, body);
-        } catch (err) {
-          error = err;
-        }
-
-        expect(error).toEqual(expectedError);
-        findOneSpy.mockRestore();
+      const mockTransaction = new MockTransaction(transaction);
+      mockTransactionsService.submit.mockResolvedValue({
+        result: mockResult,
+        transactions: [mockTransaction],
       });
-    });
+      mockTickerReservation.transferOwnership.mockResolvedValue(mockTransaction);
 
-    describe('otherwise', () => {
-      it('should run a transferOwnership procedure and return the queue data', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.identity.AddAuthorization,
-        };
-        const findOneSpy = jest.spyOn(service, 'findOne');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findOneSpy.mockResolvedValue(mockTickerReservation as any);
-
-        const mockResult = new MockAuthorizationRequest();
-
-        const mockTransaction = new MockTransaction(transaction);
-        mockTransactionsService.submit.mockResolvedValue({
-          result: mockResult,
-          transactions: [mockTransaction],
-        });
-        mockTickerReservation.transferOwnership.mockResolvedValue(mockTransaction);
-
-        const result = await service.transferOwnership(ticker, body);
-        expect(result).toEqual({
-          result: mockResult,
-          transactions: [mockTransaction],
-        });
-        findOneSpy.mockRestore();
+      const result = await service.transferOwnership(ticker, body);
+      expect(result).toEqual({
+        result: mockResult,
+        transactions: [mockTransaction],
       });
+      findOneSpy.mockRestore();
     });
   });
 
   describe('extend', () => {
     const ticker = 'TICKER';
-    const signer = '0x6000';
     let mockTickerReservation: MockTickerReservation;
 
     beforeEach(() => {
       mockTickerReservation = new MockTickerReservation();
     });
 
-    describe('if there is an error while transferring the ownership of the ticker', () => {
-      it('should pass it up the chain', async () => {
-        const expectedError = new Error('Some error');
+    it('should run a extend procedure and return the queue data', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.asset.RegisterTicker,
+      };
 
-        const findOneSpy = jest.spyOn(service, 'findOne');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findOneSpy.mockResolvedValue(mockTickerReservation as any);
+      const findOneSpy = jest.spyOn(service, 'findOne');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findOneSpy.mockResolvedValue(mockTickerReservation as any);
 
-        mockTransactionsService.submit.mockImplementation(() => {
-          throw expectedError;
-        });
+      const mockResult = new MockTickerReservation();
 
-        let error;
-        try {
-          await service.extend(ticker, { signer });
-        } catch (err) {
-          error = err;
-        }
-
-        expect(error).toEqual(expectedError);
-        findOneSpy.mockRestore();
+      const mockTransaction = new MockTransaction(transaction);
+      mockTransactionsService.submit.mockResolvedValue({
+        result: mockResult,
+        transactions: [mockTransaction],
       });
-    });
 
-    describe('otherwise', () => {
-      it('should run a extend procedure and return the queue data', async () => {
-        const transaction = {
-          blockHash: '0x1',
-          txHash: '0x2',
-          blockNumber: new BigNumber(1),
-          tag: TxTags.asset.RegisterTicker,
-        };
-
-        const findOneSpy = jest.spyOn(service, 'findOne');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findOneSpy.mockResolvedValue(mockTickerReservation as any);
-
-        const mockResult = new MockTickerReservation();
-
-        const mockTransaction = new MockTransaction(transaction);
-        mockTransactionsService.submit.mockResolvedValue({
-          result: mockResult,
-          transactions: [mockTransaction],
-        });
-
-        const result = await service.extend(ticker, { signer });
-        expect(result).toEqual({
-          result: mockResult,
-          transactions: [mockTransaction],
-        });
-        findOneSpy.mockRestore();
+      const result = await service.extend(ticker, { signer });
+      expect(result).toEqual({
+        result: mockResult,
+        transactions: [mockTransaction],
       });
+      findOneSpy.mockRestore();
     });
   });
 

--- a/src/ticker-reservations/ticker-reservations.service.spec.ts
+++ b/src/ticker-reservations/ticker-reservations.service.spec.ts
@@ -134,7 +134,6 @@ describe('TickerReservationsService', () => {
         result: mockResult,
         transactions: [mockTransaction],
       });
-      findOneSpy.mockRestore();
     });
   });
 
@@ -171,7 +170,6 @@ describe('TickerReservationsService', () => {
         result: mockResult,
         transactions: [mockTransaction],
       });
-      findOneSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
### JIRA Link 

DA-468

### Changelog / Description 

Remove the repetitive handling of errors while fetching some storage values from SDK. Use generic `handleSdkError` to handle conversion of SDK errors to throw corresponding exceptions

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
