### PR TITLE
test: 💍 fix api key test + mock implementation

### DIFF
--- a/src/auth/repos/api-key.repo.suite.ts
+++ b/src/auth/repos/api-key.repo.suite.ts
@@ -26,7 +26,7 @@ export const testApiKeyRepo = async (repo: ApiKeyRepo): Promise<void> => {
 
     it('should throw NotFoundError if the API key does not exist', async () => {
       const unknownApiKey = 'unknownApiKey';
-      await expect(repo.getUserByApiKey(unknownApiKey)).rejects.toThrow(expectedNotFoundError);
+      return expect(repo.getUserByApiKey(unknownApiKey)).rejects.toThrow(expectedNotFoundError);
     });
   });
 
@@ -34,7 +34,7 @@ export const testApiKeyRepo = async (repo: ApiKeyRepo): Promise<void> => {
     it('should remove the API key', async () => {
       await repo.deleteApiKey(secret);
 
-      expect(repo.getUserByApiKey(secret)).rejects.toThrow(expectedNotFoundError);
+      return expect(repo.getUserByApiKey(secret)).rejects.toThrow(expectedNotFoundError);
     });
 
     it('should be a no-op on if the API key is not found', () => {

--- a/src/datastore/postgres/repos/api-key.repo.spec.ts
+++ b/src/datastore/postgres/repos/api-key.repo.spec.ts
@@ -21,7 +21,7 @@ describe(`PostgresApiKeyRepo does not meet ${ApiKeyRepo.type} requirements`, () 
     return { secret, user };
   });
 
-  mockRepository.delete.mockImplementation(secret => {
+  mockRepository.delete.mockImplementation(({ secret }) => {
     when(mockRepository.findOneBy).calledWith({ secret }).mockResolvedValue(null);
   });
 


### PR DESCRIPTION

### JIRA Link 

N/A

### Changelog / Description 

postgres api key test was failing async due to a error in the postgres mock. The spec did not fail due to not returning the expect

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [X] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
