### PR TITLE
chore: 🤖 publish all releases, not just "published" ones

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v*
-  release:
-    type: [published]
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
### Changelog / Description 

this was introduced quite a while ago when we made releases manually: https://github.com/PolymeshAssociation/polymesh-rest-api/pull/42

The SDK doesn't use this filter and works like I would expect: https://github.com/PolymathNetwork/polymesh-sdk/blob/8ecfeac01e146a4b1dfa560488674011308aab69/.github/workflows/main.yml#L74

I was able to trigger the docker push of https://github.com/PolymeshAssociation/polymesh-rest-api/releases/tag/v2.5.0-alpha.1 by marking it as not a pre-release, so there is another potential solution there.

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
