### PR TITLE
Revert "chore: 🤖 publish all releases, not just "published" ones"

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v*
+  release:
+    type: [published]
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
Reverts PolymeshAssociation/polymesh-rest-api#164

It seems like this didn't work, and made it so unmarking the release didn't trigger the pipeline.

I think unchecking the box for alpha isn't too bad, so I think this reversion will be OK for now.