### PR TITLE
feat: 🎸 Add endpoint to get Portfolio creation event details and Middleware V2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ $ yarn test:cov
 ```bash
 PORT=## port in which the server will listen. Defaults to 3000 ##
 POLYMESH_NODE_URL=## websocket URL for a Polymesh node ##
-POLYMESH_MIDDLEWARE_URL=## URL for an instance of the Polymesh GraphQL Middleware service ##
+POLYMESH_MIDDLEWARE_V2_URL=## URL for an instance of the Polymesh GraphQL Middleware Native SubQuery service ##
+POLYMESH_MIDDLEWARE_URL=## URL for an instance of the Polymesh GraphQL Middleware service @deprecated in favour of POLYMESH_MIDDLEWARE_V2_URL##
 POLYMESH_MIDDLEWARE_API_KEY=## API key for the Middleware GraphQL service ##
 LOCAL_SIGNERS=## list of comma separated IDs to refer to the corresponding mnemonic ##
 LOCAL_MNEMONICS=## list of comma separated mnemonics for the signer service (each mnemonic corresponds to a signer in LOCAL_SIGNERS) ##

--- a/src/polymesh/config/polymesh.config.ts
+++ b/src/polymesh/config/polymesh.config.ts
@@ -2,22 +2,34 @@
 
 import { registerAs } from '@nestjs/config';
 
+interface MiddlewareConfig {
+  link: string;
+  key: string;
+}
+
 interface Config {
   nodeUrl: string;
-  middleware?: {
-    link: string;
-    key: string;
-  };
+  middleware?: MiddlewareConfig;
+  middlewareV2?: MiddlewareConfig;
 }
 
 export default registerAs('polymesh', () => {
-  const { POLYMESH_NODE_URL, POLYMESH_MIDDLEWARE_URL, POLYMESH_MIDDLEWARE_API_KEY } = process.env;
+  const {
+    POLYMESH_NODE_URL,
+    POLYMESH_MIDDLEWARE_URL,
+    POLYMESH_MIDDLEWARE_API_KEY,
+    POLYMESH_MIDDLEWARE_V2_URL,
+  } = process.env;
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const config: Config = { nodeUrl: POLYMESH_NODE_URL || '' };
 
   if (POLYMESH_MIDDLEWARE_URL && POLYMESH_MIDDLEWARE_API_KEY) {
     config.middleware = { link: POLYMESH_MIDDLEWARE_URL, key: POLYMESH_MIDDLEWARE_API_KEY };
+  }
+
+  if (POLYMESH_MIDDLEWARE_V2_URL) {
+    config.middlewareV2 = { link: POLYMESH_MIDDLEWARE_V2_URL, key: '' };
   }
 
   return config;

--- a/src/portfolios/portfolios.controller.ts
+++ b/src/portfolios/portfolios.controller.ts
@@ -34,7 +34,6 @@ import { PortfolioIdentifierModel } from '~/portfolios/models/portfolio-identifi
 import { PortfolioModel } from '~/portfolios/models/portfolio.model';
 import { PortfoliosService } from '~/portfolios/portfolios.service';
 import { createPortfolioIdentifierModel, createPortfolioModel } from '~/portfolios/portfolios.util';
-import { SubsidyModel } from '~/subsidy/models/subsidy.model';
 
 @ApiTags('portfolios')
 @Controller()
@@ -279,7 +278,7 @@ export class PortfoliosController {
   })
   @ApiOkResponse({
     description: 'Details of event where the Numbered Portfolio was created',
-    type: SubsidyModel,
+    type: EventIdentifierModel,
   })
   @ApiBadRequestResponse({
     description: 'Event details for default Portfolio is requested',

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -423,8 +423,9 @@ describe('PortfoliosService', () => {
   });
 
   describe('createdAt', () => {
-    it('should throw an error if default Portfolio details are requested', () =>
-      expect(() => service.createdAt(did, new BigNumber(0))).rejects.toThrowError());
+    it('should throw an error if default Portfolio details are requested', () => {
+      return expect(() => service.createdAt(did, new BigNumber(0))).rejects.toThrowError();
+    });
 
     describe('otherwise', () => {
       it('should return the EventIdentifier details for a Portfolio', async () => {

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -317,7 +317,7 @@ describe('PortfoliosService', () => {
 
   describe('createdAt', () => {
     it('should throw an error if default Portfolio details are requested', () =>
-      expect(() => service.findOne(did, new BigNumber(0))).rejects.toThrowError());
+      expect(() => service.createdAt(did, new BigNumber(0))).rejects.toThrowError());
 
     describe('otherwise', () => {
       it('should return the EventIdentifier details for a Portfolio', async () => {

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -242,4 +242,27 @@ describe('PortfoliosService', () => {
       });
     });
   });
+
+  describe('createdAt', () => {
+    it('should throw an error if default Portfolio details are requested', () =>
+      expect(() => service.findOne(did, new BigNumber(0))).rejects.toThrowError());
+
+    describe('otherwise', () => {
+      it('should return the EventIdentifier details for a Portfolio', async () => {
+        const mockResult = {
+          blockNumber: new BigNumber('2719172'),
+          blockHash: 'someHash',
+          blockDate: new Date('2021-06-26T01:47:45.000Z'),
+          eventIndex: new BigNumber(1),
+        };
+        const mockPortfolio = new MockPortfolio();
+        mockPortfolio.createdAt.mockResolvedValue(mockResult);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        jest.spyOn(service, 'findOne').mockResolvedValue(mockPortfolio as any);
+        const result = await service.createdAt(did, new BigNumber(1));
+        expect(result).toEqual(mockResult);
+      });
+    });
+  });
 });

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -124,6 +124,6 @@ export class PortfoliosService {
       throw new AppValidationError('Cannot get event details for Default Portfolio');
     }
     const portfolio = await this.findOne(did, portfolioId);
-    return (portfolio as NumberedPortfolio).createdAt();
+    return portfolio.createdAt();
   }
 }

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -1,8 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import { DefaultPortfolio, NumberedPortfolio } from '@polymeshassociation/polymesh-sdk/types';
+import {
+  DefaultPortfolio,
+  EventIdentifier,
+  NumberedPortfolio,
+} from '@polymeshassociation/polymesh-sdk/types';
 
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
+import { AppValidationError } from '~/common/errors';
 import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { IdentitiesService } from '~/identities/identities.service';
 import { PolymeshService } from '~/polymesh/polymesh.service';
@@ -77,5 +82,13 @@ export class PortfoliosService {
       { portfolio: portfolio.id },
       transactionBaseDto
     );
+  }
+
+  public async createdAt(did: string, portfolioId: BigNumber): Promise<EventIdentifier | null> {
+    if (portfolioId.isZero()) {
+      throw new AppValidationError('Cannot get event details for Default Portfolio');
+    }
+    const portfolio = await this.findOne(did, portfolioId);
+    return (portfolio as NumberedPortfolio).createdAt();
   }
 }

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -270,6 +270,7 @@ export class MockPortfolio {
   id = new BigNumber(1);
   owner = new MockIdentity();
   public getName = jest.fn();
+  public createdAt = jest.fn();
   public getAssetBalances = jest.fn();
   public isCustodiedBy = jest.fn();
   public getCustodian = jest.fn();

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -159,6 +159,7 @@ export class MockPortfoliosService {
   createPortfolio = jest.fn();
   deletePortfolio = jest.fn();
   findOne = jest.fn();
+  createdAt = jest.fn();
 }
 
 export class MockOfferingsService {


### PR DESCRIPTION
### JIRA Link 

DA-80

### Changelog / Description 

* Adds endpoint `GET /identities/:did/portfolios/:id/created-at` to get event details when the specified portfolio was created
* Add support for middleware V2

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [x] Updated the Readme.md (if required) ?
