### PR TITLE
fix: 🐛 Ignore release commit from commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  ignores: [message => /^chore\(release\): \d+\.\d+\.\d+ \[skip ci\]/.test(message)],
 };


### PR DESCRIPTION
### JIRA Link 

DA-501

### Changelog / Description 

While creating the commit with changes in package.json, src/main.ts with version updates, the commit message was too long and failed in commitlint step as shown [here](https://github.com/PolymeshAssociation/polymesh-rest-api/actions/runs/4384800680). 

This PR excludes such commits from commitlint

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
