### PR TITLE
fix: 🐛 Update commitlint ignore regex to suppport prereleases

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  ignores: [message => /^chore\(release\): \d+\.\d+\.\d+.*? \[skip ci\]/.test(message)],
+  ignores: [
+    message => /^chore\(release\): \d+\.\d+\.\d+(-alpha(\.\d+)*)? \[skip ci\]/.test(message),
+  ],
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  ignores: [message => /^chore\(release\): \d+\.\d+\.\d+ \[skip ci\]/.test(message)],
+  ignores: [message => /^chore\(release\): \d+\.\d+\.\d+.*? \[skip ci\]/.test(message)],
 };


### PR DESCRIPTION
### JIRA Link 

DA-501

### Changelog / Description 

Fixes the commitlint regex to work with long prereleases commit names such as `chore(release): 2.5.0-alpha.3.15 [skip ci]`

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
