### PR TITLE
chore: 🤖 upgrade to node V18 runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:18
 WORKDIR /home/node
 
 # cache yarn install step

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -28,7 +28,9 @@ export class AccountsService {
     const {
       polymeshService: { polymeshApi },
     } = this;
-    return await polymeshApi.accountManagement.getAccount({ address }).catch(handleSdkError);
+    return await polymeshApi.accountManagement.getAccount({ address }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async getAccountBalance(account: string): Promise<AccountBalance> {
@@ -64,7 +66,9 @@ export class AccountsService {
 
   public async getPermissions(address: string): Promise<Permissions> {
     const account = await this.findOne(address);
-    return await account.getPermissions().catch(handleSdkError);
+    return await account.getPermissions().catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async freezeSecondaryAccounts(

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -31,7 +31,9 @@ export class AssetsService {
   ) {}
 
   public async findOne(ticker: string): Promise<Asset> {
-    return await this.polymeshService.polymeshApi.assets.getAsset({ ticker }).catch(handleSdkError);
+    return await this.polymeshService.polymeshApi.assets.getAsset({ ticker }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async findAllByOwner(owner: string): Promise<Asset[]> {

--- a/src/authorizations/authorizations.service.ts
+++ b/src/authorizations/authorizations.service.ts
@@ -47,7 +47,9 @@ export class AuthorizationsService {
     signatory: Identity | Account,
     id: BigNumber
   ): Promise<AuthorizationRequest> {
-    return await signatory.authorizations.getOne({ id }).catch(handleSdkError);
+    return await signatory.authorizations.getOne({ id }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async findOneByDid(did: string, id: BigNumber): Promise<AuthorizationRequest> {

--- a/src/checkpoints/checkpoints.service.ts
+++ b/src/checkpoints/checkpoints.service.ts
@@ -39,7 +39,9 @@ export class CheckpointsService {
 
   public async findOne(ticker: string, id: BigNumber): Promise<Checkpoint> {
     const asset = await this.assetsService.findOne(ticker);
-    return await asset.checkpoints.getOne({ id }).catch(handleSdkError);
+    return await asset.checkpoints.getOne({ id }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async findSchedulesByTicker(ticker: string): Promise<ScheduleWithDetails[]> {
@@ -49,7 +51,9 @@ export class CheckpointsService {
 
   public async findScheduleById(ticker: string, id: BigNumber): Promise<ScheduleWithDetails> {
     const asset = await this.assetsService.findOne(ticker);
-    return await asset.checkpoints.schedules.getOne({ id }).catch(handleSdkError);
+    return await asset.checkpoints.schedules.getOne({ id }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async createByTicker(

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -71,6 +71,6 @@ export class AppInternalError extends AppError {
   }
 }
 
-export function isAppError(err: Error): err is AppError {
+export function isAppError(err: unknown): err is AppError {
   return err instanceof AppError;
 }

--- a/src/corporate-actions/corporate-actions.service.ts
+++ b/src/corporate-actions/corporate-actions.service.ts
@@ -52,7 +52,9 @@ export class CorporateActionsService {
   public async findDistribution(ticker: string, id: BigNumber): Promise<DistributionWithDetails> {
     const asset = await this.assetsService.findOne(ticker);
 
-    return await asset.corporateActions.distributions.getOne({ id }).catch(handleSdkError);
+    return await asset.corporateActions.distributions.getOne({ id }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async createDividendDistribution(

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -30,7 +30,9 @@ export class IdentitiesService {
     const {
       polymeshService: { polymeshApi },
     } = this;
-    return await polymeshApi.identities.getIdentity({ did }).catch(handleSdkError);
+    return await polymeshApi.identities.getIdentity({ did }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
+import { ClassSerializerInterceptor, Logger, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { HttpAdapterHost, NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -12,6 +12,13 @@ import { AppErrorToHttpResponseFilter } from '~/common/filters/app-error-to-http
 import { LoggingInterceptor } from '~/common/interceptors/logging.interceptor';
 import { WebhookResponseCodeInterceptor } from '~/common/interceptors/webhook-response-code.interceptor';
 import { PolymeshLogger } from '~/logger/polymesh-logger.service';
+
+// This service was originally designed with node v14, this ensures a backwards compatible run time
+// Ideally we wouldn't need this function, but I am unable to find the cause when submitting SDK transactions that fail validation
+const unhandledRejectionLogger = new Logger('UnhandledPromise');
+process.on('unhandledRejection', reason => {
+  unhandledRejectionLogger.warn(`unhandled rejection, reason: ${reason}`);
+});
 
 async function bootstrap(): Promise<void> {
   // App setup

--- a/src/metadata/metadata.service.ts
+++ b/src/metadata/metadata.service.ts
@@ -35,7 +35,9 @@ export class MetadataService {
   public async findOne({ ticker, type, id }: MetadataParamsDto): Promise<MetadataEntry> {
     const { metadata } = await this.assetsService.findOne(ticker);
 
-    return await metadata.getOne({ type, id }).catch(handleSdkError);
+    return await metadata.getOne({ type, id }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async create(ticker: string, params: CreateMetadataDto): ServiceReturn<MetadataEntry> {

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -45,9 +45,13 @@ export class PortfoliosService {
   ): Promise<DefaultPortfolio | NumberedPortfolio> {
     const identity = await this.identitiesService.findOne(did);
     if (portfolioId) {
-      return await identity.portfolios.getPortfolio({ portfolioId }).catch(handleSdkError);
+      return await identity.portfolios.getPortfolio({ portfolioId }).catch(error => {
+        throw handleSdkError(error);
+      });
     }
-    return await identity.portfolios.getPortfolio().catch(handleSdkError);
+    return await identity.portfolios.getPortfolio().catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async moveAssets(owner: string, params: AssetMovementDto): ServiceReturn<void> {

--- a/src/settlements/settlements.service.ts
+++ b/src/settlements/settlements.service.ts
@@ -42,7 +42,9 @@ export class SettlementsService {
       .getInstruction({
         id,
       })
-      .catch(handleSdkError);
+      .catch(error => {
+        throw handleSdkError(error);
+      });
   }
 
   public async createInstruction(
@@ -93,7 +95,9 @@ export class SettlementsService {
       .getVenue({
         id,
       })
-      .catch(handleSdkError);
+      .catch(error => {
+        throw handleSdkError(error);
+      });
   }
 
   public async findVenueDetails(id: BigNumber): Promise<VenueDetails> {

--- a/src/subsidy/subsidy.service.ts
+++ b/src/subsidy/subsidy.service.ts
@@ -95,6 +95,8 @@ export class SubsidyService {
   public async getAllowance(beneficiary: string, subsidizer: string): Promise<BigNumber> {
     const subsidy = this.findOne(beneficiary, subsidizer);
 
-    return await subsidy.getAllowance().catch(handleSdkError);
+    return await subsidy.getAllowance().catch(error => {
+      throw handleSdkError(error);
+    });
   }
 }

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -87,7 +87,7 @@ export class TransactionsService {
         );
       }
     } catch (error) {
-      handleSdkError(error);
+      throw handleSdkError(error);
     }
   }
 


### PR DESCRIPTION
makes handleSdkError return an error and have the caller throw to provide more flexibility. Adds in global unhandledPromiseRejection handler to ensure compatibility with V18

✅ Closes: [DA-546](https://polymesh.atlassian.net/browse/DA-546)

[DA-546]: https://polymesh.atlassian.net/browse/DA-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ