### PR TITLE
fix: 🐛 finding default portfolio when id 0 is given

### DIFF
--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -121,6 +121,23 @@ describe('PortfoliosService', () => {
       });
     });
 
+    it('should return the default portfolio when given id of 0', async () => {
+      const mockIdentity = new MockIdentity();
+      const mockPortfolio = {
+        id: new BigNumber(0),
+        assetBalances: [],
+      };
+      const owner = '0x6000';
+      mockIdentity.portfolios.getPortfolio.mockResolvedValue(mockPortfolio);
+      mockIdentitiesService.findOne.mockReturnValue(mockIdentity);
+
+      const result = await service.findOne(owner, new BigNumber(0));
+      expect(result).toEqual({
+        id: new BigNumber(0),
+        assetBalances: [],
+      });
+    });
+
     describe('otherwise', () => {
       it('should call the handleSdkError method and throw an error', async () => {
         const mockError = new Error('foo');

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -44,7 +44,7 @@ export class PortfoliosService {
     portfolioId?: BigNumber
   ): Promise<DefaultPortfolio | NumberedPortfolio> {
     const identity = await this.identitiesService.findOne(did);
-    if (portfolioId && portfolioId.gt(0)) {
+    if (portfolioId?.gt(0)) {
       return await identity.portfolios.getPortfolio({ portfolioId }).catch(error => {
         throw handleSdkError(error);
       });

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -44,7 +44,7 @@ export class PortfoliosService {
     portfolioId?: BigNumber
   ): Promise<DefaultPortfolio | NumberedPortfolio> {
     const identity = await this.identitiesService.findOne(did);
-    if (portfolioId) {
+    if (portfolioId && portfolioId.gt(0)) {
       return await identity.portfolios.getPortfolio({ portfolioId }).catch(error => {
         throw handleSdkError(error);
       });


### PR DESCRIPTION
### JIRA Link 

N/A

### Changelog / Description 

Fix findOne when portfolio ID 0 is given

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [X] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
