### PR TITLE
chore: 🤖 remove external chain dep for build

### DIFF
--- a/chain-entry.sh
+++ b/chain-entry.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/usr/local/bin/polymesh \
+-d /var/lib/polymesh \
+--unsafe-ws-external --unsafe-rpc-external --wasm-execution=compiled \
+--no-prometheus --no-telemetry --pruning=archive --no-mdns \
+--validator --rpc-cors=all --rpc-methods=unsafe --force-authoring \
+--port 30333 $1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  chain:
+    image: ${CHAIN_IMAGE}
+    init: true # Faster shutdown by container process not be PID 1
+    restart: unless-stopped
+    ports:
+      # expose ports to localhost
+      - '9944:9944' # ws://
+      - '9933:9933' # http://
+      - '30333:30333' # for other nodes
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    volumes:
+      - './chain-entry.sh:/chain-entry.sh'
+    entrypoint: '/chain-entry.sh'
+    command: [ '--alice --chain dev' ]
+
   postgres:
     image: postgres:15
     ports:
@@ -9,7 +25,7 @@ services:
       POSTGRES_USER: $REST_POSTGRES_USER
       POSTGRES_PASSWORD: $REST_POSTGRES_PASSWORD
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/prepareRelease.sh
+++ b/prepareRelease.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
 
+set -exu -o pipefail
+
 declare nextVersion=$1
+
+# This needs to be set to and SDK compatible value
+CHAIN_TAG='6.0.0-develop-debian'
+
+# This lets it work on arm64, like Mac Books
+ARCHITECTURE=$(uname -m)
+CHAIN_REPO=polymeshassociation/polymesh
+if [ "$ARCHITECTURE" = "arm64" ]; then
+    CHAIN_REPO="polymeshassociation/polymesh-arm64"
+fi
 
 sed -i.bak -e "s/.setVersion('.*')/.setVersion('$nextVersion')/g" src/main.ts
 rm src/main.ts.bak
 
-SWAGGER_VERSION=$nextVersion POLYMESH_NODE_URL='wss://testnet-rpc.polymesh.live' yarn generate:swagger > /dev/null 2>&1
+export CHAIN_IMAGE="$CHAIN_REPO:$CHAIN_TAG"
+
+docker compose up -d chain
+
+SWAGGER_VERSION=$nextVersion POLYMESH_NODE_URL='ws://localhost:9944' yarn generate:swagger > /dev/null 2>&1
+
+docker compose down chain

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ async function bootstrap(): Promise<void> {
   const options = new DocumentBuilder()
     .setTitle(swaggerTitle)
     .setDescription(swaggerDescription)
-    .setVersion('3.0.0-alpha.4');
+    .setVersion('3.0.0-alpha.5');
 
   const configService = app.get<ConfigService>(ConfigService);
 


### PR DESCRIPTION
### JIRA Link 

N/A

### Changelog / Description 

generate swagger was failing due to testnet being on 5.x. This change modifes the prepareRelease.sh script to start up a docker image to use instead

e.g: https://github.com/PolymeshAssociation/polymesh-rest-api/actions/runs/5726853573/job/15521667477

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
