### PR TITLE
chore: 🤖 smaller docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,33 @@
-FROM node:18
+FROM node:lts-alpine3.17 AS builder
+
+RUN apk add --no-cache \
+  python3 \
+  make \
+  cmake \
+  g++ \
+  jq
+
+WORKDIR /app/builder
+RUN chown -R node: /app
+
+USER node
+
+COPY --chown=node:node . .
+
+RUN yarn install \
+  --frozen-lockfile \
+  --no-progress && \
+  yarn build && \
+  yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') && \
+  rm -r /home/node/.cache/
+
+FROM node:lts-alpine3.17
 WORKDIR /home/node
 
-# cache yarn install step
-COPY --chown=node:node package.json /home/node
-COPY --chown=node:node yarn.lock /home/node
-RUN yarn --frozen-lockfile
+COPY --from=builder --chown=root:root /app/builder/node_modules ./node_modules
+COPY --from=builder --chown=root:root /app/builder/dist/ ./dist
 
 COPY --chown=node:node . /home/node
 
 USER node
-RUN yarn build
-ENTRYPOINT ["/bin/bash", "./docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/sh", "./docker-entrypoint.sh"]


### PR DESCRIPTION
### JIRA Link 

N/A

### Changelog / Description 

removes dev dependency + use alpine as base to create significantly smaller docker images.

Previous images were 2.4GB images, this change brings them to a more reasonable 367 MB.

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
