### PR TITLE
fix: 🐛 error when optional arg methods given no args

### DIFF
--- a/src/transactions/transactions.util.spec.ts
+++ b/src/transactions/transactions.util.spec.ts
@@ -9,6 +9,7 @@ import {
   AppError,
   AppInternalError,
   AppNotFoundError,
+  AppUnauthorizedError,
   AppUnprocessableError,
   AppValidationError,
 } from '~/common/errors';
@@ -29,6 +30,7 @@ describe('processTransaction', () => {
   describe('it should handle Polymesh errors', () => {
     type Case = [ErrorCode, Class<AppError>];
     const cases: Case[] = [
+      [ErrorCode.NotAuthorized, AppUnauthorizedError],
       [ErrorCode.ValidationError, AppValidationError],
       [ErrorCode.UnmetPrerequisite, AppUnprocessableError],
       [ErrorCode.InsufficientBalance, AppUnprocessableError],
@@ -78,8 +80,10 @@ describe('processTransaction', () => {
 
 describe('prepareProcedure', () => {
   const signingAccount = 'someAddress';
-  it('should call the method with args when they are given', () => {
+  it('should call the method with args when they are required', () => {
     const mockMethod = jest.fn();
+    // define length so mock method appears to require args
+    Object.defineProperty(mockMethod, 'length', { value: 1, writable: false });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     prepareProcedure(mockMethod as any, { arg1: 'someValue' }, { signingAccount });
@@ -87,7 +91,7 @@ describe('prepareProcedure', () => {
     expect(mockMethod).toHaveBeenCalledWith({ arg1: 'someValue' }, { signingAccount });
   });
 
-  it('should call the method with only opts when args are not given', () => {
+  it('should call the method with only opts when args are not required', () => {
     const mockMethod = jest.fn();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -19,6 +19,7 @@ import {
   AppError,
   AppInternalError,
   AppNotFoundError,
+  AppUnauthorizedError,
   AppUnprocessableError,
   AppValidationError,
   isAppError,
@@ -56,7 +57,7 @@ export async function prepareProcedure<MethodArgs, ReturnType, TransformedReturn
   opts: ProcedureOpts
 ): Promise<GenericPolymeshTransaction<ReturnType, TransformedReturnType>> {
   try {
-    if (!args || Object.keys(args).length === 0) {
+    if (method.length === 0) {
       return await method(opts as MethodArgs);
     } else {
       return await method(args, opts);
@@ -168,6 +169,8 @@ export function handleSdkError(err: unknown): AppError {
         return new AppUnprocessableError(message);
       case ErrorCode.DataUnavailable:
         return new AppNotFoundError(message, '');
+      case ErrorCode.NotAuthorized:
+        return new AppUnauthorizedError(message);
       default:
         return new AppInternalError(message);
     }


### PR DESCRIPTION
### JIRA Link 

✅ Closes: [DA-932](https://polymesh.atlassian.net/browse/DA-932)

### Changelog / Description 

use method.length to check if args should be given or not in `prepareProcedure`

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-932]: https://polymesh.atlassian.net/browse/DA-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ