### PR TITLE
feat: 🎸 add offline event recorder

### DIFF
--- a/postgres.dev.config
+++ b/postgres.dev.config
@@ -1,7 +1,7 @@
 # WARNING this file is committed and should only be used with development values!
 
 export REST_POSTGRES_HOST=localhost
-export REST_POSTGRES_PORT=4432
+export REST_POSTGRES_PORT=5432
 export REST_POSTGRES_USER=postgres
 export REST_POSTGRES_PASSWORD=postgres
-export REST_POSTGRES_DATABASE=postgres
+export REST_POSTGRES_DATABASE=rest

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,6 +37,8 @@ import { TickerReservationsModule } from '~/ticker-reservations/ticker-reservati
 import { TransactionsModule } from '~/transactions/transactions.module';
 import { UsersModule } from '~/users/users.module';
 
+import { OfflineRecorderModule } from './offline-recorder/offline-recorder.module';
+
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -100,6 +102,7 @@ import { UsersModule } from '~/users/users.module';
     OfflineSignerModule,
     OfflineSubmitterModule,
     OfflineStarterModule,
+    OfflineRecorderModule,
   ],
 })
 export class AppModule {}

--- a/src/common/utils/amqp.ts
+++ b/src/common/utils/amqp.ts
@@ -1,0 +1,6 @@
+export enum TopicName {
+  Requests = 'Requests',
+  Signatures = 'Signatures',
+  Submissions = 'Submissions',
+  Finalizations = 'Finalizations',
+}

--- a/src/datastore/local-store/local-store.module.ts
+++ b/src/datastore/local-store/local-store.module.ts
@@ -5,7 +5,9 @@ import { ConfigModule } from '@nestjs/config';
 
 import { ApiKeyRepo } from '~/auth/repos/api-key.repo';
 import { LocalApiKeysRepo } from '~/datastore/local-store/repos/api-key.repo';
+import { LocalOfflineRepo } from '~/datastore/local-store/repos/offline-event.repo';
 import { LocalUserRepo } from '~/datastore/local-store/repos/users.repo';
+import { OfflineRepo } from '~/offline-recorder/repo/offline.repo';
 import { UsersRepo } from '~/users/repo/user.repo';
 
 /**
@@ -19,7 +21,11 @@ import { UsersRepo } from '~/users/repo/user.repo';
       provide: UsersRepo,
       useClass: LocalUserRepo,
     },
+    {
+      provide: OfflineRepo,
+      useClass: LocalOfflineRepo,
+    },
   ],
-  exports: [ApiKeyRepo, UsersRepo],
+  exports: [ApiKeyRepo, UsersRepo, OfflineRepo],
 })
 export class LocalStoreModule {}

--- a/src/datastore/local-store/repos/offline-event.repo.spec.ts
+++ b/src/datastore/local-store/repos/offline-event.repo.spec.ts
@@ -1,0 +1,8 @@
+import { LocalOfflineRepo } from '~/datastore/local-store/repos/offline-event.repo';
+import { OfflineRepo } from '~/offline-recorder/repo/offline.repo';
+
+describe(`LocalOfflineRepo does not meet ${OfflineRepo.type} test suite requirements`, () => {
+  const repo = new LocalOfflineRepo();
+
+  OfflineRepo.test(repo);
+});

--- a/src/datastore/local-store/repos/offline-event.repo.ts
+++ b/src/datastore/local-store/repos/offline-event.repo.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+
+import { TopicName } from '~/common/utils/amqp';
+import { OfflineEventModel } from '~/offline-recorder/model/event.model';
+import { OfflineRepo } from '~/offline-recorder/repo/offline.repo';
+
+@Injectable()
+export class LocalOfflineRepo implements OfflineRepo {
+  private events: Record<string, unknown> = {};
+  private _id: number = 1;
+
+  public async recordEvent(
+    name: TopicName,
+    body: Record<string, unknown>
+  ): Promise<OfflineEventModel> {
+    const id = this.nextId();
+    const model = { id, name, body };
+    this.events[id] = model;
+
+    return model;
+  }
+
+  private nextId(): string {
+    return (this._id++).toString();
+  }
+}

--- a/src/datastore/postgres/entities/offline-event.entity.ts
+++ b/src/datastore/postgres/entities/offline-event.entity.ts
@@ -1,0 +1,37 @@
+/* istanbul ignore file */
+
+import { FactoryProvider } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  DataSource,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  Repository,
+} from 'typeorm';
+
+@Entity()
+export class OfflineEvent {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  createDateTime: Date;
+
+  @Index()
+  @Column({ type: 'text' })
+  name: string;
+
+  @Column({ type: 'json' })
+  body: Record<string, unknown>;
+}
+
+export const offlineEventRepoProvider: FactoryProvider = {
+  provide: getRepositoryToken(OfflineEvent),
+  useFactory: async (dataSource: DataSource): Promise<Repository<OfflineEvent>> => {
+    return dataSource.getRepository(OfflineEvent);
+  },
+  inject: [DataSource],
+};

--- a/src/datastore/postgres/migrations/1703257522434-offline.ts
+++ b/src/datastore/postgres/migrations/1703257522434-offline.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Offline1703257522434 implements MigrationInterface {
+  name = 'Offline1703257522434';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE "offline_event" ("id" SERIAL NOT NULL, "createDateTime" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "name" text NOT NULL, "body" json NOT NULL, CONSTRAINT "PK_b1a60a8a09498bfa4d195196211" PRIMARY KEY ("id"))'
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_af766de01b16222c89464aeda8" ON "offline_event" ("name") '
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX "public"."IDX_af766de01b16222c89464aeda8"');
+    await queryRunner.query('DROP TABLE "offline_event"');
+  }
+}

--- a/src/datastore/postgres/postgres.module.ts
+++ b/src/datastore/postgres/postgres.module.ts
@@ -4,9 +4,12 @@ import { Module } from '@nestjs/common';
 
 import { ApiKeyRepo } from '~/auth/repos/api-key.repo';
 import { apiKeyRepoProvider } from '~/datastore/postgres/entities/api-key.entity';
+import { offlineEventRepoProvider } from '~/datastore/postgres/entities/offline-event.entity';
 import { userRepoProvider } from '~/datastore/postgres/entities/user.entity';
 import { PostgresApiKeyRepo } from '~/datastore/postgres/repos/api-keys.repo';
+import { PostgresOfflineRepo } from '~/datastore/postgres/repos/offline.repo';
 import { PostgresUsersRepo } from '~/datastore/postgres/repos/users.repo';
+import { OfflineRepo } from '~/offline-recorder/repo/offline.repo';
 import { UsersRepo } from '~/users/repo/user.repo';
 
 /**
@@ -16,9 +19,11 @@ import { UsersRepo } from '~/users/repo/user.repo';
   providers: [
     apiKeyRepoProvider,
     userRepoProvider,
+    offlineEventRepoProvider,
     { provide: UsersRepo, useClass: PostgresUsersRepo },
     { provide: ApiKeyRepo, useClass: PostgresApiKeyRepo },
+    { provide: OfflineRepo, useClass: PostgresOfflineRepo },
   ],
-  exports: [ApiKeyRepo, UsersRepo],
+  exports: [ApiKeyRepo, UsersRepo, OfflineRepo],
 })
 export class PostgresModule {}

--- a/src/datastore/postgres/repos/offline.repo.ts
+++ b/src/datastore/postgres/repos/offline.repo.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { TopicName } from '~/common/utils/amqp';
+import { OfflineEvent } from '~/datastore/postgres/entities/offline-event.entity';
+import { convertTypeOrmErrorToAppError } from '~/datastore/postgres/repos/utils';
+import { OfflineEventModel } from '~/offline-recorder/model/event.model';
+import { OfflineRepo } from '~/offline-recorder/repo/offline.repo';
+
+@Injectable()
+export class PostgresOfflineRepo implements OfflineRepo {
+  constructor(
+    @InjectRepository(OfflineEvent) private readonly offlineEventRepo: Repository<OfflineEvent>
+  ) {}
+
+  public async recordEvent(
+    name: string,
+    body: Record<string, unknown>
+  ): Promise<OfflineEventModel> {
+    const model = { name, body };
+    const entity = this.offlineEventRepo.create(model);
+
+    await this.offlineEventRepo
+      .save(entity)
+      .catch(convertTypeOrmErrorToAppError(name, OfflineRepo.type));
+
+    return this.toModel(entity);
+  }
+
+  private toModel(event: OfflineEvent): OfflineEventModel {
+    const { id, name, body } = event;
+
+    return new OfflineEventModel({
+      id: id.toString(),
+      name: name as TopicName,
+      body,
+    });
+  }
+}

--- a/src/offline-recorder/model/event.model.ts
+++ b/src/offline-recorder/model/event.model.ts
@@ -1,0 +1,34 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+
+import { TopicName } from '~/common/utils/amqp';
+
+export class OfflineEventModel {
+  @ApiProperty({
+    type: 'string',
+    description: 'Queue name this event was published on',
+    example: 'Alice',
+    enum: TopicName,
+  })
+  readonly name: TopicName;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'The event body',
+    example: '{ "id": 1, "transaction": {} }',
+  })
+  readonly body: Record<string, unknown>;
+
+  @ApiProperty({
+    type: 'string',
+    description:
+      'The internal ID of the message. The exact format depends on the Datastore being used',
+    example: '1',
+  })
+  readonly id: string;
+
+  constructor(model: OfflineEventModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/offline-recorder/offline-recorder.module.ts
+++ b/src/offline-recorder/offline-recorder.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { ArtemisModule } from '~/artemis/artemis.module';
+import { DatastoreModule } from '~/datastore/datastore.module';
+import { OfflineRecorderService } from '~/offline-recorder/offline-recorder.service';
+
+@Module({
+  imports: [ArtemisModule, DatastoreModule.registerAsync()],
+  providers: [OfflineRecorderService],
+})
+export class OfflineRecorderModule {}

--- a/src/offline-recorder/offline-recorder.service.spec.ts
+++ b/src/offline-recorder/offline-recorder.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { OfflineRecorderService } from '~/offline-recorder/offline-recorder.service';
+
+describe('OfflineRecorderService', () => {
+  let service: OfflineRecorderService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OfflineRecorderService],
+    }).compile();
+
+    service = module.get<OfflineRecorderService>(OfflineRecorderService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/offline-recorder/offline-recorder.service.ts
+++ b/src/offline-recorder/offline-recorder.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+
+import { ArtemisService } from '~/artemis/artemis.service';
+import { TopicName } from '~/common/utils/amqp';
+import { OfflineRepo } from '~/offline-recorder/repo/offline.repo';
+
+@Injectable()
+export class OfflineRecorderService {
+  constructor(
+    private readonly artemisService: ArtemisService,
+    private readonly offlineRepo: OfflineRepo
+  ) {
+    this.artemisService.registerListener(TopicName.Requests, msg =>
+      this.recordEvent(TopicName.Requests, msg)
+    );
+    this.artemisService.registerListener(TopicName.Submissions, msg =>
+      this.recordEvent(TopicName.Submissions, msg)
+    );
+    this.artemisService.registerListener(TopicName.Signatures, msg =>
+      this.recordEvent(TopicName.Signatures, msg)
+    );
+    this.artemisService.registerListener(TopicName.Finalizations, msg =>
+      this.recordEvent(TopicName.Finalizations, msg)
+    );
+  }
+
+  private async recordEvent(topicName: TopicName, msg: Record<string, unknown>): Promise<void> {
+    await this.offlineRepo.recordEvent(topicName, msg);
+  }
+}

--- a/src/offline-recorder/repo/offline.repo.suite.ts
+++ b/src/offline-recorder/repo/offline.repo.suite.ts
@@ -1,0 +1,17 @@
+import { TopicName } from '~/common/utils/amqp';
+import { OfflineEventModel } from '~/offline-recorder/model/event.model';
+import { OfflineRepo } from '~/offline-recorder/repo/offline.repo';
+
+const name = TopicName.Submissions;
+const body = { id: 'abc' };
+
+export const testOfflineRepo = async (offlineRepo: OfflineRepo): Promise<void> => {
+  let event: OfflineEventModel;
+
+  describe('method: recordEvent', () => {
+    it('should create a user', async () => {
+      event = await offlineRepo.recordEvent(name, body);
+      expect(event).toMatchSnapshot();
+    });
+  });
+};

--- a/src/offline-recorder/repo/offline.repo.ts
+++ b/src/offline-recorder/repo/offline.repo.ts
@@ -1,0 +1,18 @@
+import { OfflineEventModel } from '~/offline-recorder/model/event.model';
+import { testOfflineRepo } from '~/offline-recorder/repo/offline.repo.suite';
+
+export abstract class OfflineRepo {
+  public static type = 'Offline';
+
+  public abstract recordEvent(
+    name: string,
+    body: Record<string, unknown>
+  ): Promise<OfflineEventModel>;
+
+  /**
+   * a set of tests implementers should pass
+   */
+  public static async test(repo: OfflineRepo): Promise<void> {
+    return testOfflineRepo(repo);
+  }
+}

--- a/src/offline-signer/offline-signer.service.ts
+++ b/src/offline-signer/offline-signer.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { TransactionPayload } from '@polymeshassociation/polymesh-sdk/types';
 
 import { ArtemisService } from '~/artemis/artemis.service';
+import { TopicName } from '~/common/utils/amqp';
 import { SigningService } from '~/signing/services';
 
 /**
@@ -13,21 +14,18 @@ export class OfflineSignerService {
     private readonly artemisService: ArtemisService,
     private readonly signingService: SigningService
   ) {
-    this.artemisService.registerListener('started', msg => this.sign(msg));
+    this.artemisService.registerListener(TopicName.Requests, msg => this.sign(msg));
   }
 
   private async sign(body: Record<string, unknown>): Promise<void> {
     const transaction = body as unknown as TransactionPayload;
-    if (body.signature) {
-      // TODO we should only be subscribed to pending transactions
-      return;
-    }
+
     const signer = this.signingService.getSigningManager().getExternalSigner();
 
     const { signature } = await signer.signPayload(transaction.payload);
 
     const message = { signature, transaction };
 
-    this.artemisService.sendMessage('signed', message);
+    await this.artemisService.sendMessage(TopicName.Submissions, message);
   }
 }

--- a/src/offline-starter/offline-starter.service.ts
+++ b/src/offline-starter/offline-starter.service.ts
@@ -3,6 +3,7 @@ import { GenericPolymeshTransaction } from '@polymeshassociation/polymesh-sdk/ty
 import { randomUUID } from 'crypto';
 
 import { ArtemisService } from '~/artemis/artemis.service';
+import { TopicName } from '~/common/utils/amqp';
 
 @Injectable()
 export class OfflineStarterService {
@@ -18,7 +19,10 @@ export class OfflineStarterService {
     const internalMeta = this.generateMeta();
     const payload = await transaction.toSignablePayload({ ...internalMeta, ...metadata });
 
-    await this.artemisService.sendMessage('started', payload as unknown as Record<string, unknown>);
+    await this.artemisService.sendMessage(
+      TopicName.Requests,
+      payload as unknown as Record<string, unknown>
+    );
   }
 
   /**


### PR DESCRIPTION
### Changelog / Description 

add listener to record all messages echanged in a data store

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a new offline event recording system with a dedicated PostgreSQL table.
  - Added `OfflineRecorderModule` for handling offline events within the application.
  - Created `OfflineEventModel` for standardized event representation.

- **Enhancements**
  - Improved message queuing and handling logic in `ArtemisService` by introducing structured queue management.
  - Standardized message topics using the `TopicName` enum to streamline communication across services.

- **Bug Fixes**
  - Adjusted database port configuration to the default PostgreSQL port for consistency and compatibility.

- **Documentation**
  - Enhanced API documentation with Swagger annotations for offline event properties.

- **Tests**
  - Added test suites for `LocalOfflineRepo` and `OfflineRecorderService` to ensure functionality.
  - Introduced `testOfflineRepo` function to validate the `recordEvent` method of `OfflineRepo` implementations.

- **Refactor**
  - Refactored offline event handling across various services to use the new `TopicName` enum for clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->