### PR TITLE
chore: 🤖 fix prepare release script in CI env

### DIFF
--- a/prepareRelease.sh
+++ b/prepareRelease.sh
@@ -18,6 +18,7 @@ sed -i.bak -e "s/.setVersion('.*')/.setVersion('$nextVersion')/g" src/main.ts
 rm src/main.ts.bak
 
 export CHAIN_IMAGE="$CHAIN_REPO:$CHAIN_TAG"
+export SUBQUERY_IMAGE="polymeshassociation/polymesh-subquery:v12.1.0"
 
 docker compose up -d chain
 


### PR DESCRIPTION
### JIRA Link 

None

Failure was spotted in this run: https://github.com/PolymeshAssociation/polymesh-rest-api/actions/runs/7504711975

### Changelog / Description 

subquery image needs to be set for the compose file to be valid

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `SUBQUERY_IMAGE` environment variable to use a new version: "polymeshassociation/polymesh-subquery:v12.1.0".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->