### PR TITLE
feat: 🎸 handle when artemis is unconfigured

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,16 @@ NOTIFICATIONS_LEGITIMACY_SECRET=## A secret used to create HMAC signatures ##
 AUTH_STRATEGY=## list of comma separated auth strategies to use e.g. (`apiKey,open`) ##
 API_KEYS=## list of comma separated api keys to initialize the `apiKey` strategy with ##
 # Datastore:
-REST_POSTGRES_HOST=## Domain or IP indicating of the DB ##
+REST_POSTGRES_HOST=## Domain or IP of DB instance ##
 REST_POSTGRES_PORT=## Port the DB is listening (usually 5432) ##
 REST_POSTGRES_USER=## DB user to use##
 REST_POSTGRES_PASSWORD=## Password of the user ##
 REST_POSTGRES_DATABASE=## Database to use ##
+# Artemis:
+ARTEMIS_HOST=localhost## Domain or IP of artemis instance ##
+ARTEMIS_USERNAME=artemis ## Artemis user ##
+ARTEMIS_PASSWORD=artemis ## Artemis password ##
+ARTEMIS_PORT=5672 ## Port of AMQP acceptor ##
 ```
 
 ## Signing Transactions

--- a/src/artemis/artemis.service.spec.ts
+++ b/src/artemis/artemis.service.spec.ts
@@ -71,6 +71,7 @@ jest.mock('rhea-promise', () => {
 describe('ArtemisService', () => {
   let service: ArtemisService;
   let logger: DeepMocked<PolymeshLogger>;
+  let configSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -78,6 +79,8 @@ describe('ArtemisService', () => {
     }).compile();
 
     service = module.get<ArtemisService>(ArtemisService);
+    configSpy = jest.spyOn(service, 'isConfigured');
+    configSpy.mockReturnValue(true);
     logger = module.get<typeof logger>(PolymeshLogger);
   });
 
@@ -165,6 +168,15 @@ describe('ArtemisService', () => {
       await service.onApplicationShutdown();
 
       expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('should do no work if service is not configured', async () => {
+      configSpy.mockReturnValue(false);
+
+      const initialCallCount = mockConnectionClose.mock.calls.length;
+      await service.onApplicationShutdown();
+
+      expect(mockConnectionClose.mock.calls.length).toEqual(initialCallCount);
     });
   });
 });

--- a/src/artemis/artemis.service.ts
+++ b/src/artemis/artemis.service.ts
@@ -37,10 +37,18 @@ export class ArtemisService implements OnApplicationShutdown {
     this.logger.setContext(ArtemisService.name);
   }
 
+  public isConfigured(): boolean {
+    return !!process.env.ARTEMIS_HOST;
+  }
+
   public async onApplicationShutdown(signal?: string | undefined): Promise<void> {
     this.logger.debug(
       `artemis service received application shutdown request, sig: ${signal} - now closing connections`
     );
+
+    if (!this.isConfigured()) {
+      return;
+    }
 
     const closePromises = [
       ...this.receivers.map(receiver => receiver.close()),

--- a/src/offline-starter/models/offline-receipt.model.ts
+++ b/src/offline-starter/models/offline-receipt.model.ts
@@ -8,6 +8,11 @@ import { FromBigNumber } from '~/common/decorators/transformation';
 
 export class OfflineReceiptModel {
   @ApiProperty({
+    description: 'The internal ID of the transaction',
+  })
+  readonly id: string;
+
+  @ApiProperty({
     description: 'The AMQP delivery ID',
     type: BigNumber,
   })

--- a/src/offline-submitter/offline-submitter.service.ts
+++ b/src/offline-submitter/offline-submitter.service.ts
@@ -53,9 +53,16 @@ export class OfflineSubmitterService {
     );
     this.logger.log(`transaction finalized: ${id}`);
 
-    const msg = JSON.parse(JSON.stringify(result)); // make sure its serializes properly
+    const resultData = JSON.parse(JSON.stringify(result)); // make sure its serializes properly
 
-    await this.artemisService.sendMessage(AddressName.Finalizations, msg);
+    const finalizationMsg = {
+      ...resultData,
+      id,
+      address,
+      nonce,
+    };
+
+    await this.artemisService.sendMessage(AddressName.Finalizations, finalizationMsg);
 
     transaction.blockHash = result.blockHash as string;
     transaction.txIndex = result.txIndex as string;

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -223,6 +223,7 @@ describe('TransactionsService', () => {
 
   describe('submit (with AMQP)', () => {
     const fakeReceipt = new OfflineReceiptModel({
+      id: 'someId',
       deliveryId: new BigNumber(1),
       topicName: AddressName.Requests,
       payload: {} as SignerPayloadJSON,


### PR DESCRIPTION
### JIRA Link 

N/A

### Changelog / Description 

adds checks for when artemis is not configured + add some helpful fields to user exposed models

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [X] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated environment variables documentation for database and messaging configuration clarity.

- **New Features**
  - Added a method to check messaging service configuration.
  - Included a unique identifier for offline transaction receipts.

- **Bug Fixes**
  - Fixed a potential issue where transactions could proceed without active messaging service configuration.

- **Tests**
  - Enhanced test coverage for the messaging service configuration check.
  - Added tests to validate error handling in transaction initiation.

- **Refactor**
  - Improved data serialization and enriched transaction finalization messages in the submission process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->