### PR TITLE
feat: 🎸 Add APIs to freeze/unfreeze confidential asset/account

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@polymeshassociation/fireblocks-signing-manager": "^2.3.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "^3.1.0",
     "@polymeshassociation/local-signing-manager": "^3.1.0",
-    "@polymeshassociation/polymesh-sdk": "^24.0.0-confidential-assets.7",
+    "@polymeshassociation/polymesh-sdk": "^24.0.0-confidential-assets.11",
     "@polymeshassociation/signing-manager-types": "^3.1.0",
     "class-transformer": "0.5.1",
     "class-validator": "^0.14.0",

--- a/src/confidential-accounts/confidential-accounts.controller.spec.ts
+++ b/src/confidential-accounts/confidential-accounts.controller.spec.ts
@@ -110,4 +110,18 @@ describe('ConfidentialAccountsController', () => {
       expect(result).toEqual(balance);
     });
   });
+
+  describe('applyAllIncomingAssetBalances', () => {
+    it('should call the service and return the results', async () => {
+      const input = {
+        signer,
+      };
+      mockConfidentialAccountsService.applyAllIncomingAssetBalances.mockResolvedValue(
+        txResult as unknown as ServiceReturn<ConfidentialAccount>
+      );
+
+      const result = await controller.applyAllIncomingAssetBalances({ confidentialAccount }, input);
+      expect(result).toEqual(txResult);
+    });
+  });
 });

--- a/src/confidential-accounts/confidential-accounts.controller.spec.ts
+++ b/src/confidential-accounts/confidential-accounts.controller.spec.ts
@@ -6,7 +6,7 @@ import { ServiceReturn } from '~/common/utils';
 import { ConfidentialAccountsController } from '~/confidential-accounts/confidential-accounts.controller';
 import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
 import { testValues } from '~/test-utils/consts';
-import { createMockIdentity } from '~/test-utils/mocks';
+import { createMockConfidentialAsset, createMockIdentity } from '~/test-utils/mocks';
 import { mockConfidentialAccountsServiceProvider } from '~/test-utils/service-mocks';
 
 const { signer, txResult } = testValues;
@@ -56,6 +56,58 @@ describe('ConfidentialAccountsController', () => {
       const result = await controller.getOwner({ confidentialAccount });
 
       expect(result).toEqual(expect.objectContaining({ did: 'OWNER_DID' }));
+    });
+  });
+
+  describe('getAllBalances and getAllIncomingBalances', () => {
+    it('should get all confidential asset balances', async () => {
+      const confidentialAsset = createMockConfidentialAsset();
+      const balance = '0xsomebalance';
+      const mockResult = [
+        {
+          confidentialAsset,
+          balance,
+        },
+      ];
+      mockConfidentialAccountsService.getAllBalances.mockResolvedValue(mockResult);
+
+      let result = await controller.getAllBalances({ confidentialAccount });
+
+      expect(result).toEqual(
+        expect.arrayContaining([{ confidentialAsset: confidentialAsset.id, balance }])
+      );
+
+      mockConfidentialAccountsService.getAllIncomingBalances.mockResolvedValue(mockResult);
+
+      result = await controller.getAllIncomingBalances({ confidentialAccount });
+
+      expect(result).toEqual(
+        expect.arrayContaining([{ confidentialAsset: confidentialAsset.id, balance }])
+      );
+    });
+  });
+
+  describe('getConfidentialAssetBalance and getIncomingConfidentialAssetBalance', () => {
+    it('should get all confidential asset balances', async () => {
+      const confidentialAssetId = 'SOME_ASSET_ID';
+      const balance = '0xsomebalance';
+      mockConfidentialAccountsService.getAssetBalance.mockResolvedValue(balance);
+
+      let result = await controller.getConfidentialAssetBalance({
+        confidentialAccount,
+        confidentialAssetId,
+      });
+
+      expect(result).toEqual(balance);
+
+      mockConfidentialAccountsService.getIncomingAssetBalance.mockResolvedValue(balance);
+
+      result = await controller.getIncomingConfidentialAssetBalance({
+        confidentialAccount,
+        confidentialAssetId,
+      });
+
+      expect(result).toEqual(balance);
     });
   });
 });

--- a/src/confidential-accounts/confidential-accounts.controller.ts
+++ b/src/confidential-accounts/confidential-accounts.controller.ts
@@ -183,16 +183,16 @@ export class ConfidentialAccountsController {
       'This endpoint retrieves the incoming balance of a specific Confidential Asset in the given Confidential Account',
   })
   @ApiParam({
-    name: 'confidentialAccount',
-    description: 'The public key of the Confidential Account',
-    type: 'string',
-    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
-  })
-  @ApiParam({
     name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset for which the incoming balance is to be fetched',
-    type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
+    type: 'string',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+    type: 'string',
   })
   @ApiOkResponse({
     description: 'Encrypted incoming balance of the Confidential Asset',

--- a/src/confidential-accounts/confidential-accounts.controller.ts
+++ b/src/confidential-accounts/confidential-accounts.controller.ts
@@ -214,4 +214,37 @@ export class ConfidentialAccountsController {
       confidentialAssetId
     );
   }
+
+  @Post(':confidentialAccount/incoming-balances/apply')
+  @ApiOperation({
+    summary: 'Deposit all incoming balances for a Confidential Account',
+    description: 'This endpoint deposit all the incoming balances for a Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiTransactionResponse({
+    description: 'Details about the transaction',
+    type: TransactionQueueModel,
+  })
+  @ApiTransactionFailedResponse({
+    [HttpStatus.UNPROCESSABLE_ENTITY]: [
+      'The Signing Identity cannot apply incoming balances in the specified Confidential Account',
+    ],
+    [HttpStatus.NOT_FOUND]: ['No incoming balance for the given the Confidential Account'],
+  })
+  public async applyAllIncomingAssetBalances(
+    @Param() { confidentialAccount }: ConfidentialAccountParamsDto,
+    @Body() params: TransactionBaseDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.confidentialAccountsService.applyAllIncomingAssetBalances(
+      confidentialAccount,
+      params
+    );
+
+    return handleServiceResult(result);
+  }
 }

--- a/src/confidential-accounts/confidential-accounts.controller.ts
+++ b/src/confidential-accounts/confidential-accounts.controller.ts
@@ -13,6 +13,8 @@ import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';
 import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
 import { ConfidentialAccountParamsDto } from '~/confidential-accounts/dto/confidential-account-params.dto';
+import { ConfidentialAssetBalanceModel } from '~/confidential-accounts/models/confidential-asset-balance.model';
+import { ConfidentialAssetIdParamsDto } from '~/confidential-assets/dto/confidential-asset-id-params.dto';
 import { IdentityModel } from '~/identities/models/identity.model';
 
 @ApiTags('confidential-accounts')
@@ -77,5 +79,139 @@ export class ConfidentialAccountsController {
     const { did } = await this.confidentialAccountsService.fetchOwner(confidentialAccount);
 
     return new IdentityModel({ did });
+  }
+
+  @ApiOperation({
+    summary: 'Get all Confidential Asset balances',
+    description:
+      'This endpoint retrieves the balances of all the Confidential Assets held by a Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiOkResponse({
+    description: 'List of all incoming Confidential Asset balances',
+    type: ConfidentialAssetBalanceModel,
+    isArray: true,
+  })
+  @Get(':confidentialAccount/balances')
+  public async getAllBalances(
+    @Param() { confidentialAccount }: ConfidentialAccountParamsDto
+  ): Promise<ConfidentialAssetBalanceModel[]> {
+    const results = await this.confidentialAccountsService.getAllBalances(confidentialAccount);
+
+    return results.map(
+      ({ confidentialAsset: { id: confidentialAsset }, balance }) =>
+        new ConfidentialAssetBalanceModel({ confidentialAsset, balance })
+    );
+  }
+
+  @ApiOperation({
+    summary: 'Get balance of a specific Confidential Asset',
+    description:
+      'This endpoint retrieves the existing balance of a specific Confidential Asset in the given Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiParam({
+    name: 'confidentialAssetId',
+    description: 'The ID of the Confidential Asset whose balance is to be fetched',
+    type: 'string',
+    example: '76702175-d8cb-e3a5-5a19-734433351e25',
+  })
+  @ApiOkResponse({
+    description: 'Encrypted balance of the Confidential Asset',
+    type: 'string',
+  })
+  @ApiNotFoundResponse({
+    description: 'No balance is found for the given Confidential Asset',
+  })
+  @Get(':confidentialAccount/balances/:confidentialAssetId')
+  public async getConfidentialAssetBalance(
+    @Param()
+    {
+      confidentialAccount,
+      confidentialAssetId,
+    }: ConfidentialAccountParamsDto & ConfidentialAssetIdParamsDto
+  ): Promise<string> {
+    return this.confidentialAccountsService.getAssetBalance(
+      confidentialAccount,
+      confidentialAssetId
+    );
+  }
+
+  @ApiOperation({
+    summary: 'Get all incoming Confidential Asset balances',
+    description:
+      'This endpoint retrieves the incoming balances of all the Confidential Assets held by a Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiOkResponse({
+    description: 'List of all incoming Confidential Asset balances',
+    type: ConfidentialAssetBalanceModel,
+    isArray: true,
+  })
+  @Get(':confidentialAccount/incoming-balances')
+  public async getAllIncomingBalances(
+    @Param() { confidentialAccount }: ConfidentialAccountParamsDto
+  ): Promise<ConfidentialAssetBalanceModel[]> {
+    const results = await this.confidentialAccountsService.getAllIncomingBalances(
+      confidentialAccount
+    );
+
+    return results.map(
+      ({ confidentialAsset: { id: confidentialAsset }, balance }) =>
+        new ConfidentialAssetBalanceModel({ confidentialAsset, balance })
+    );
+  }
+
+  @ApiOperation({
+    summary: 'Get incoming balance of a specific Confidential Asset',
+    description:
+      'This endpoint retrieves the incoming balance of a specific Confidential Asset in the given Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiParam({
+    name: 'confidentialAssetId',
+    description: 'The ID of the Confidential Asset for which the incoming balance is to be fetched',
+    type: 'string',
+    example: '76702175-d8cb-e3a5-5a19-734433351e25',
+  })
+  @ApiOkResponse({
+    description: 'Encrypted incoming balance of the Confidential Asset',
+    type: 'string',
+  })
+  @ApiNotFoundResponse({
+    description: 'No incoming balance is found for the given Confidential Asset',
+  })
+  @Get(':confidentialAccount/incoming-balances/:confidentialAssetId')
+  public async getIncomingConfidentialAssetBalance(
+    @Param()
+    {
+      confidentialAccount,
+      confidentialAssetId,
+    }: ConfidentialAccountParamsDto & ConfidentialAssetIdParamsDto
+  ): Promise<string> {
+    return this.confidentialAccountsService.getIncomingAssetBalance(
+      confidentialAccount,
+      confidentialAssetId
+    );
   }
 }

--- a/src/confidential-accounts/confidential-accounts.service.spec.ts
+++ b/src/confidential-accounts/confidential-accounts.service.spec.ts
@@ -73,7 +73,7 @@ describe('ConfidentialAccountsService', () => {
 
       const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-      await expect(() => service.findOne(confidentialAccount)).rejects.toThrowError();
+      await expect(service.findOne(confidentialAccount)).rejects.toThrowError();
 
       expect(handleSdkErrorSpy).toHaveBeenCalledWith(mockError);
     });
@@ -200,7 +200,7 @@ describe('ConfidentialAccountsService', () => {
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-        await expect(() =>
+        await expect(
           service.getAssetBalance(confidentialAccount, confidentialAssetId)
         ).rejects.toThrowError();
 
@@ -227,7 +227,7 @@ describe('ConfidentialAccountsService', () => {
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-        await expect(() =>
+        await expect(
           service.getIncomingAssetBalance(confidentialAccount, confidentialAssetId)
         ).rejects.toThrowError();
 

--- a/src/confidential-accounts/confidential-accounts.service.spec.ts
+++ b/src/confidential-accounts/confidential-accounts.service.spec.ts
@@ -235,4 +235,32 @@ describe('ConfidentialAccountsService', () => {
       });
     });
   });
+
+  describe('applyAllIncomingAssetBalances', () => {
+    it('should deposit all incoming balances for a Confidential Account', async () => {
+      const input = {
+        signer,
+      };
+      const mockTransactions = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.confidentialAsset.ApplyIncomingBalances,
+      };
+      const mockTransaction = new MockTransaction(mockTransactions);
+      const mockAccount = createMockConfidentialAccount();
+
+      mockTransactionsService.submit.mockResolvedValue({
+        result: mockAccount,
+        transactions: [mockTransaction],
+      });
+
+      const result = await service.applyAllIncomingAssetBalances(confidentialAccount, input);
+
+      expect(result).toEqual({
+        result: mockAccount,
+        transactions: [mockTransaction],
+      });
+    });
+  });
 });

--- a/src/confidential-accounts/confidential-accounts.service.ts
+++ b/src/confidential-accounts/confidential-accounts.service.ts
@@ -80,4 +80,14 @@ export class ConfidentialAccountsService {
       throw handleSdkError(error);
     });
   }
+
+  public async applyAllIncomingAssetBalances(
+    confidentialAccount: string,
+    base: TransactionBaseDto
+  ): ServiceReturn<ConfidentialAccount> {
+    const applyIncomingBalances =
+      this.polymeshService.polymeshApi.confidentialAccounts.applyIncomingBalances;
+
+    return this.transactionsService.submit(applyIncomingBalances, { confidentialAccount }, base);
+  }
 }

--- a/src/confidential-accounts/confidential-accounts.service.ts
+++ b/src/confidential-accounts/confidential-accounts.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { ConfidentialAccount, Identity } from '@polymeshassociation/polymesh-sdk/types';
+import {
+  ConfidentialAccount,
+  ConfidentialAssetBalance,
+  Identity,
+} from '@polymeshassociation/polymesh-sdk/types';
 
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { ServiceReturn } from '~/common/utils';
@@ -42,5 +46,38 @@ export class ConfidentialAccountsService {
       this.polymeshService.polymeshApi.confidentialAccounts.createConfidentialAccount;
 
     return this.transactionsService.submit(createConfidentialAccount, { publicKey }, base);
+  }
+
+  public async getAllBalances(confidentialAccount: string): Promise<ConfidentialAssetBalance[]> {
+    const account = await this.findOne(confidentialAccount);
+
+    return account.getBalances();
+  }
+
+  public async getAssetBalance(confidentialAccount: string, asset: string): Promise<string> {
+    const account = await this.findOne(confidentialAccount);
+
+    return await account.getBalance({ asset }).catch(error => {
+      throw handleSdkError(error);
+    });
+  }
+
+  public async getAllIncomingBalances(
+    confidentialAccount: string
+  ): Promise<ConfidentialAssetBalance[]> {
+    const account = await this.findOne(confidentialAccount);
+
+    return account.getIncomingBalances();
+  }
+
+  public async getIncomingAssetBalance(
+    confidentialAccount: string,
+    asset: string
+  ): Promise<string> {
+    const account = await this.findOne(confidentialAccount);
+
+    return await account.getIncomingBalance({ asset }).catch(error => {
+      throw handleSdkError(error);
+    });
   }
 }

--- a/src/confidential-accounts/models/confidential-asset-balance.model.ts
+++ b/src/confidential-accounts/models/confidential-asset-balance.model.ts
@@ -1,0 +1,23 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ConfidentialAssetBalanceModel {
+  @ApiProperty({
+    description: 'The ID of the Confidential Asset',
+    type: 'string',
+    example: '76702175-d8cb-e3a5-5a19-734433351e25',
+  })
+  readonly confidentialAsset: string;
+
+  @ApiProperty({
+    description: 'Encrypted balance of the Confidential Asset',
+    type: 'string',
+    example: '0xbalance',
+  })
+  readonly balance: string;
+
+  constructor(model: ConfidentialAssetBalanceModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/confidential-accounts/models/confidential-asset-balance.model.ts
+++ b/src/confidential-accounts/models/confidential-asset-balance.model.ts
@@ -13,7 +13,8 @@ export class ConfidentialAssetBalanceModel {
   @ApiProperty({
     description: 'Encrypted balance of the Confidential Asset',
     type: 'string',
-    example: '0xbalance',
+    example:
+      '0x289ebc384a263acd5820e03988dd17a3cd49ee57d572f4131e116b6bf4c70a1594447bb5d1e2d9cc62f083d8552dd90ec09b23a519b361e458d7fe1e48882261',
   })
   readonly balance: string;
 

--- a/src/confidential-assets/confidential-assets.controller.spec.ts
+++ b/src/confidential-assets/confidential-assets.controller.spec.ts
@@ -65,7 +65,7 @@ describe('ConfidentialAssetsController', () => {
 
       mockConfidentialAssetsService.findOne.mockResolvedValue(mockConfidentialAsset);
 
-      const result = await controller.getDetails({ id });
+      const result = await controller.getDetails({ confidentialAssetId: id });
 
       expect(result).toEqual({
         ...mockAssetDetails,
@@ -120,7 +120,7 @@ describe('ConfidentialAssetsController', () => {
         txResult as unknown as ServiceReturn<ConfidentialAsset>
       );
 
-      const result = await controller.issueConfidentialAsset({ id }, input);
+      const result = await controller.issueConfidentialAsset({ confidentialAssetId: id }, input);
       expect(result).toEqual(txResult);
     });
   });
@@ -131,7 +131,7 @@ describe('ConfidentialAssetsController', () => {
         enabled: false,
       });
 
-      let result = await controller.getVenueFilteringDetails({ id });
+      let result = await controller.getVenueFilteringDetails({ confidentialAssetId: id });
 
       expect(result).toEqual(expect.objectContaining({ enabled: false }));
 
@@ -140,7 +140,7 @@ describe('ConfidentialAssetsController', () => {
         allowedConfidentialVenues: [createMockConfidentialVenue({ id: new BigNumber(1) })],
       });
 
-      result = await controller.getVenueFilteringDetails({ id });
+      result = await controller.getVenueFilteringDetails({ confidentialAssetId: id });
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -161,7 +161,10 @@ describe('ConfidentialAssetsController', () => {
         txResult as unknown as ServiceReturn<void>
       );
 
-      const result = await controller.toggleConfidentialVenueFiltering({ id }, input);
+      const result = await controller.toggleConfidentialVenueFiltering(
+        { confidentialAssetId: id },
+        input
+      );
       expect(result).toEqual(txResult);
     });
   });
@@ -176,10 +179,10 @@ describe('ConfidentialAssetsController', () => {
         txResult as unknown as ServiceReturn<void>
       );
 
-      let result = await controller.addAllowedVenues({ id }, input);
+      let result = await controller.addAllowedVenues({ confidentialAssetId: id }, input);
       expect(result).toEqual(txResult);
 
-      result = await controller.removeAllowedVenues({ id }, input);
+      result = await controller.removeAllowedVenues({ confidentialAssetId: id }, input);
       expect(result).toEqual(txResult);
     });
   });
@@ -193,10 +196,10 @@ describe('ConfidentialAssetsController', () => {
         txResult as unknown as ServiceReturn<void>
       );
 
-      let result = await controller.freezeConfidentialAsset({ id }, input);
+      let result = await controller.freezeConfidentialAsset({ confidentialAssetId: id }, input);
       expect(result).toEqual(txResult);
 
-      result = await controller.unfreezeConfidentialAsset({ id }, input);
+      result = await controller.unfreezeConfidentialAsset({ confidentialAssetId: id }, input);
       expect(result).toEqual(txResult);
     });
   });
@@ -211,10 +214,10 @@ describe('ConfidentialAssetsController', () => {
         txResult as unknown as ServiceReturn<void>
       );
 
-      let result = await controller.freezeConfidentialAccount({ id }, input);
+      let result = await controller.freezeConfidentialAccount({ confidentialAssetId: id }, input);
       expect(result).toEqual(txResult);
 
-      result = await controller.unfreezeConfidentialAccount({ id }, input);
+      result = await controller.unfreezeConfidentialAccount({ confidentialAssetId: id }, input);
       expect(result).toEqual(txResult);
     });
   });
@@ -224,7 +227,7 @@ describe('ConfidentialAssetsController', () => {
       mockConfidentialAssetsService.isConfidentialAccountFrozen.mockResolvedValue(true);
 
       const result = await controller.isConfidentialAccountFrozen({
-        id: 'SOME_ASSET_ID',
+        confidentialAssetId: 'SOME_ASSET_ID',
         confidentialAccount: 'SOME_PUBLIC_KEY',
       });
       expect(result).toEqual(true);

--- a/src/confidential-assets/confidential-assets.controller.spec.ts
+++ b/src/confidential-assets/confidential-assets.controller.spec.ts
@@ -218,4 +218,16 @@ describe('ConfidentialAssetsController', () => {
       expect(result).toEqual(txResult);
     });
   });
+
+  describe('isConfidentialAccountFrozen', () => {
+    it('should call the service and return the results', async () => {
+      mockConfidentialAssetsService.isConfidentialAccountFrozen.mockResolvedValue(true);
+
+      const result = await controller.isConfidentialAccountFrozen({
+        id: 'SOME_ASSET_ID',
+        confidentialAccount: 'SOME_PUBLIC_KEY',
+      });
+      expect(result).toEqual(true);
+    });
+  });
 });

--- a/src/confidential-assets/confidential-assets.controller.spec.ts
+++ b/src/confidential-assets/confidential-assets.controller.spec.ts
@@ -61,6 +61,7 @@ describe('ConfidentialAssetsController', () => {
 
       mockConfidentialAsset.details.mockResolvedValue(mockAssetDetails);
       mockConfidentialAsset.getAuditors.mockResolvedValue(mockAuditorInfo);
+      mockConfidentialAsset.isFrozen.mockResolvedValue(false);
 
       mockConfidentialAssetsService.findOne.mockResolvedValue(mockConfidentialAsset);
 
@@ -68,6 +69,7 @@ describe('ConfidentialAssetsController', () => {
 
       expect(result).toEqual({
         ...mockAssetDetails,
+        isFrozen: false,
         auditors: expect.arrayContaining([expect.objectContaining({ publicKey: 'SOME_AUDITOR' })]),
         mediators: expect.arrayContaining([expect.objectContaining({ did: 'MEDIATOR_DID' })]),
       });
@@ -178,6 +180,41 @@ describe('ConfidentialAssetsController', () => {
       expect(result).toEqual(txResult);
 
       result = await controller.removeAllowedVenues({ id }, input);
+      expect(result).toEqual(txResult);
+    });
+  });
+
+  describe('freezeConfidentialAsset and unfreezeConfidentialAsset', () => {
+    it('should call the service and return the results', async () => {
+      const input = {
+        signer,
+      };
+      mockConfidentialAssetsService.toggleFreezeConfidentialAsset.mockResolvedValue(
+        txResult as unknown as ServiceReturn<void>
+      );
+
+      let result = await controller.freezeConfidentialAsset({ id }, input);
+      expect(result).toEqual(txResult);
+
+      result = await controller.unfreezeConfidentialAsset({ id }, input);
+      expect(result).toEqual(txResult);
+    });
+  });
+
+  describe('freezeConfidentialAccount and unfreezeConfidentialAccount', () => {
+    it('should call the service and return the results', async () => {
+      const input = {
+        signer,
+        confidentialAccount: 'SOME_PUBLIC_KEY',
+      };
+      mockConfidentialAssetsService.toggleFreezeConfidentialAccountAsset.mockResolvedValue(
+        txResult as unknown as ServiceReturn<void>
+      );
+
+      let result = await controller.freezeConfidentialAccount({ id }, input);
+      expect(result).toEqual(txResult);
+
+      result = await controller.unfreezeConfidentialAccount({ id }, input);
       expect(result).toEqual(txResult);
     });
   });

--- a/src/confidential-assets/confidential-assets.controller.ts
+++ b/src/confidential-assets/confidential-assets.controller.ts
@@ -37,7 +37,7 @@ export class ConfidentialAssetsController {
       'This endpoint will provide the basic details of an Confidential Asset along with the auditors information',
   })
   @ApiParam({
-    name: 'id',
+    name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset whose details are to be fetched',
     type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
@@ -46,11 +46,11 @@ export class ConfidentialAssetsController {
     description: 'Basic details of the Asset',
     type: ConfidentialAssetDetailsModel,
   })
-  @Get(':id')
+  @Get(':confidentialAssetId')
   public async getDetails(
-    @Param() { id }: ConfidentialAssetIdParamsDto
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto
   ): Promise<ConfidentialAssetDetailsModel> {
-    const asset = await this.confidentialAssetsService.findOne(id);
+    const asset = await this.confidentialAssetsService.findOne(confidentialAssetId);
 
     return createConfidentialAssetDetailsModel(asset);
   }
@@ -92,7 +92,7 @@ export class ConfidentialAssetsController {
       'This endpoint issues more of a given Confidential Asset into a specified Confidential Account',
   })
   @ApiParam({
-    name: 'id',
+    name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset to be issued',
     type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
@@ -105,12 +105,12 @@ export class ConfidentialAssetsController {
     ],
     [HttpStatus.NOT_FOUND]: ['The Confidential Asset does not exists'],
   })
-  @Post(':id/issue')
+  @Post(':confidentialAssetId/issue')
   public async issueConfidentialAsset(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() params: IssueConfidentialAssetDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.confidentialAssetsService.issue(id, params);
+    const result = await this.confidentialAssetsService.issue(confidentialAssetId, params);
     return handleServiceResult(result);
   }
 
@@ -119,7 +119,7 @@ export class ConfidentialAssetsController {
     description: 'This endpoint will return the venue filtering details for a Confidential Asset',
   })
   @ApiParam({
-    name: 'id',
+    name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset',
     type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
@@ -128,11 +128,13 @@ export class ConfidentialAssetsController {
     description: 'Venue filtering details',
     type: ConfidentialVenueFilteringDetailsModel,
   })
-  @Get(':id/venue-filtering')
+  @Get(':confidentialAssetId/venue-filtering')
   public async getVenueFilteringDetails(
-    @Param() { id }: ConfidentialAssetIdParamsDto
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto
   ): Promise<ConfidentialVenueFilteringDetailsModel> {
-    const details = await this.confidentialAssetsService.getVenueFilteringDetails(id);
+    const details = await this.confidentialAssetsService.getVenueFilteringDetails(
+      confidentialAssetId
+    );
 
     const { enabled, allowedConfidentialVenues } = {
       allowedConfidentialVenues: undefined,
@@ -148,7 +150,7 @@ export class ConfidentialAssetsController {
       'This endpoint enables/disables confidential venue filtering for a given Confidential Asset',
   })
   @ApiParam({
-    name: 'id',
+    name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset',
     type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
@@ -156,12 +158,15 @@ export class ConfidentialAssetsController {
   @ApiTransactionFailedResponse({
     [HttpStatus.NOT_FOUND]: ['The Confidential Asset does not exists'],
   })
-  @Post(':id/venue-filtering')
+  @Post(':confidentialAssetId/venue-filtering')
   public async toggleConfidentialVenueFiltering(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() params: SetConfidentialVenueFilteringParamsDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.confidentialAssetsService.setVenueFilteringDetails(id, params);
+    const result = await this.confidentialAssetsService.setVenueFilteringDetails(
+      confidentialAssetId,
+      params
+    );
 
     return handleServiceResult(result);
   }
@@ -172,7 +177,7 @@ export class ConfidentialAssetsController {
       'This endpoint adds additional Confidential Venues to existing list of Confidential Venues allowed to handle transfer of the given Confidential Asset',
   })
   @ApiParam({
-    name: 'id',
+    name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset',
     type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
@@ -180,16 +185,19 @@ export class ConfidentialAssetsController {
   @ApiTransactionFailedResponse({
     [HttpStatus.NOT_FOUND]: ['The Confidential Asset does not exists'],
   })
-  @Post(':id/venue-filtering/add-allowed-venues')
+  @Post(':confidentialAssetId/venue-filtering/add-allowed-venues')
   public async addAllowedVenues(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() params: AddAllowedConfidentialVenuesDto
   ): Promise<TransactionResponseModel> {
     const { confidentialVenues: allowedVenues, ...rest } = params;
-    const result = await this.confidentialAssetsService.setVenueFilteringDetails(id, {
-      ...rest,
-      allowedVenues,
-    });
+    const result = await this.confidentialAssetsService.setVenueFilteringDetails(
+      confidentialAssetId,
+      {
+        ...rest,
+        allowedVenues,
+      }
+    );
 
     return handleServiceResult(result);
   }
@@ -200,7 +208,7 @@ export class ConfidentialAssetsController {
       'This endpoint removes the given list of Confidential Venues (if present), from the existing list of allowed Confidential Venues for Confidential Asset Transaction',
   })
   @ApiParam({
-    name: 'id',
+    name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset',
     type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
@@ -208,17 +216,20 @@ export class ConfidentialAssetsController {
   @ApiTransactionFailedResponse({
     [HttpStatus.NOT_FOUND]: ['The Confidential Asset does not exists'],
   })
-  @Post(':id/venue-filtering/remove-allowed-venues')
+  @Post(':confidentialAssetId/venue-filtering/remove-allowed-venues')
   public async removeAllowedVenues(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() params: RemoveAllowedConfidentialVenuesDto
   ): Promise<TransactionResponseModel> {
     const { confidentialVenues: disallowedVenues, ...rest } = params;
 
-    const result = await this.confidentialAssetsService.setVenueFilteringDetails(id, {
-      ...rest,
-      disallowedVenues,
-    });
+    const result = await this.confidentialAssetsService.setVenueFilteringDetails(
+      confidentialAssetId,
+      {
+        ...rest,
+        disallowedVenues,
+      }
+    );
 
     return handleServiceResult(result);
   }
@@ -237,13 +248,13 @@ export class ConfidentialAssetsController {
       'The signing identity is not the owner of the Confidential Asset',
     ],
   })
-  @Post(':id/freeze')
+  @Post(':confidentialAssetId/freeze')
   async freezeConfidentialAsset(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() body: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.confidentialAssetsService.toggleFreezeConfidentialAsset(
-      id,
+      confidentialAssetId,
       body,
       true
     );
@@ -265,13 +276,13 @@ export class ConfidentialAssetsController {
       'The signing identity is not the owner of the Confidential Asset',
     ],
   })
-  @Post(':id/unfreeze')
+  @Post(':confidentialAssetId/unfreeze')
   async unfreezeConfidentialAsset(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() body: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.confidentialAssetsService.toggleFreezeConfidentialAsset(
-      id,
+      confidentialAssetId,
       body,
       false
     );
@@ -293,13 +304,13 @@ export class ConfidentialAssetsController {
       'The signing identity is not the owner of the Confidential Asset',
     ],
   })
-  @Post(':id/freeze-account')
+  @Post(':confidentialAssetId/freeze-account')
   async freezeConfidentialAccount(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() body: ToggleFreezeConfidentialAccountAssetDto
   ): Promise<TransactionResponseModel> {
     const result = await this.confidentialAssetsService.toggleFreezeConfidentialAccountAsset(
-      id,
+      confidentialAssetId,
       body,
       true
     );
@@ -322,13 +333,13 @@ export class ConfidentialAssetsController {
       'The signing identity is not the owner of the Confidential Asset',
     ],
   })
-  @Post(':id/unfreeze-account')
+  @Post(':confidentialAssetId/unfreeze-account')
   async unfreezeConfidentialAccount(
-    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
     @Body() body: ToggleFreezeConfidentialAccountAssetDto
   ): Promise<TransactionResponseModel> {
     const result = await this.confidentialAssetsService.toggleFreezeConfidentialAccountAsset(
-      id,
+      confidentialAssetId,
       body,
       false
     );
@@ -341,7 +352,7 @@ export class ConfidentialAssetsController {
       'Check whether trading for a Confidential Asset is frozen for a specific Confidential Account',
   })
   @ApiParam({
-    name: 'id',
+    name: 'confidentialAssetId',
     description: 'The ID of the Confidential Asset',
     type: 'string',
     example: '76702175-d8cb-e3a5-5a19-734433351e25',
@@ -359,11 +370,17 @@ export class ConfidentialAssetsController {
   @ApiNotFoundResponse({
     description: 'The Confidential Asset does not exists',
   })
-  @Get(':id/freeze-account/:confidentialAccount')
+  @Get(':confidentialAssetId/freeze-account/:confidentialAccount')
   async isConfidentialAccountFrozen(
     @Param()
-    { id, confidentialAccount }: ConfidentialAssetIdParamsDto & ConfidentialAccountParamsDto
+    {
+      confidentialAssetId,
+      confidentialAccount,
+    }: ConfidentialAssetIdParamsDto & ConfidentialAccountParamsDto
   ): Promise<boolean> {
-    return this.confidentialAssetsService.isConfidentialAccountFrozen(id, confidentialAccount);
+    return this.confidentialAssetsService.isConfidentialAccountFrozen(
+      confidentialAssetId,
+      confidentialAccount
+    );
   }
 }

--- a/src/confidential-assets/confidential-assets.controller.ts
+++ b/src/confidential-assets/confidential-assets.controller.ts
@@ -9,6 +9,7 @@ import {
 import { ConfidentialAsset } from '@polymeshassociation/polymesh-sdk/types';
 
 import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { handleServiceResult, TransactionResolver, TransactionResponseModel } from '~/common/utils';
 import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { createConfidentialAssetDetailsModel } from '~/confidential-assets/confidential-assets.util';
@@ -18,6 +19,7 @@ import { CreateConfidentialAssetDto } from '~/confidential-assets/dto/create-con
 import { IssueConfidentialAssetDto } from '~/confidential-assets/dto/issue-confidential-asset.dto';
 import { RemoveAllowedConfidentialVenuesDto } from '~/confidential-assets/dto/remove-allowed-confidential-venues.dto';
 import { SetConfidentialVenueFilteringParamsDto } from '~/confidential-assets/dto/set-confidential-venue-filtering-params.dto';
+import { ToggleFreezeConfidentialAccountAssetDto } from '~/confidential-assets/dto/toggle-freeze-confidential-account-asset.dto';
 import { ConfidentialAssetDetailsModel } from '~/confidential-assets/models/confidential-asset-details.model';
 import { ConfidentialVenueFilteringDetailsModel } from '~/confidential-assets/models/confidential-venue-filtering-details.model';
 import { CreatedConfidentialAssetModel } from '~/confidential-assets/models/created-confidential-asset.model';
@@ -215,6 +217,119 @@ export class ConfidentialAssetsController {
       ...rest,
       disallowedVenues,
     });
+
+    return handleServiceResult(result);
+  }
+
+  @ApiOperation({
+    summary: 'Freeze all trading for a Confidential Asset',
+    description:
+      'This endpoint freezes all trading for a Confidential Asset. Note, only the owner of the Confidential asset can perform this operation',
+  })
+  @ApiTransactionResponse({
+    description: 'Details about the transaction',
+  })
+  @ApiTransactionFailedResponse({
+    [HttpStatus.BAD_REQUEST]: [
+      'Asset is already frozen',
+      'The signing identity is not the owner of the Confidential Asset',
+    ],
+  })
+  @Post(':id/freeze')
+  async freezeConfidentialAsset(
+    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Body() body: TransactionBaseDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.confidentialAssetsService.toggleFreezeConfidentialAsset(
+      id,
+      body,
+      true
+    );
+
+    return handleServiceResult(result);
+  }
+
+  @ApiOperation({
+    summary: 'Resume (unfreeze) all trading for a Confidential Asset',
+    description:
+      'This endpoint resumes all trading for a freezed Confidential Asset. Note, only the owner of the Confidential asset can perform this operation',
+  })
+  @ApiTransactionResponse({
+    description: 'Details about the transaction',
+  })
+  @ApiTransactionFailedResponse({
+    [HttpStatus.BAD_REQUEST]: [
+      'Asset is already unfrozen',
+      'The signing identity is not the owner of the Confidential Asset',
+    ],
+  })
+  @Post(':id/unfreeze')
+  async unfreezeConfidentialAsset(
+    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Body() body: TransactionBaseDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.confidentialAssetsService.toggleFreezeConfidentialAsset(
+      id,
+      body,
+      false
+    );
+
+    return handleServiceResult(result);
+  }
+
+  @ApiOperation({
+    summary: 'Freeze trading for a specific Confidential Account for a Confidential Asset',
+    description:
+      'This endpoint freezes trading for a specific Confidential Account for a freezed Confidential Asset. Note, only the owner of the Confidential asset can perform this operation',
+  })
+  @ApiTransactionResponse({
+    description: 'Details about the transaction',
+  })
+  @ApiTransactionFailedResponse({
+    [HttpStatus.BAD_REQUEST]: [
+      'Account is already frozen',
+      'The signing identity is not the owner of the Confidential Asset',
+    ],
+  })
+  @Post(':id/freeze-account')
+  async freezeConfidentialAccount(
+    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Body() body: ToggleFreezeConfidentialAccountAssetDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.confidentialAssetsService.toggleFreezeConfidentialAccountAsset(
+      id,
+      body,
+      true
+    );
+
+    return handleServiceResult(result);
+  }
+
+  @ApiOperation({
+    summary:
+      'Resume (unfreeze) trading for a specific Confidential Account for a Confidential Asset',
+    description:
+      'This endpoint resumes trading for a specific Confidential Account for a freezed Confidential Asset. Note, only the owner of the Confidential asset can perform this operation',
+  })
+  @ApiTransactionResponse({
+    description: 'Details about the transaction',
+  })
+  @ApiTransactionFailedResponse({
+    [HttpStatus.BAD_REQUEST]: [
+      'Confidential Account is already unfrozen',
+      'The signing identity is not the owner of the Confidential Asset',
+    ],
+  })
+  @Post(':id/unfreeze-account')
+  async unfreezeConfidentialAccount(
+    @Param() { id }: ConfidentialAssetIdParamsDto,
+    @Body() body: ToggleFreezeConfidentialAccountAssetDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.confidentialAssetsService.toggleFreezeConfidentialAccountAsset(
+      id,
+      body,
+      false
+    );
 
     return handleServiceResult(result);
   }

--- a/src/confidential-assets/confidential-assets.controller.ts
+++ b/src/confidential-assets/confidential-assets.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, HttpStatus, Param, Post } from '@nestjs/common';
 import {
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
@@ -11,6 +12,7 @@ import { ConfidentialAsset } from '@polymeshassociation/polymesh-sdk/types';
 import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { handleServiceResult, TransactionResolver, TransactionResponseModel } from '~/common/utils';
+import { ConfidentialAccountParamsDto } from '~/confidential-accounts/dto/confidential-account-params.dto';
 import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { createConfidentialAssetDetailsModel } from '~/confidential-assets/confidential-assets.util';
 import { AddAllowedConfidentialVenuesDto } from '~/confidential-assets/dto/add-allowed-confidential-venues.dto';
@@ -332,5 +334,36 @@ export class ConfidentialAssetsController {
     );
 
     return handleServiceResult(result);
+  }
+
+  @ApiOperation({
+    summary:
+      'Check whether trading for a Confidential Asset is frozen for a specific Confidential Account',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the Confidential Asset',
+    type: 'string',
+    example: '76702175-d8cb-e3a5-5a19-734433351e25',
+  })
+  @ApiParam({
+    name: 'confidentialAccount',
+    description: 'The public key of the Confidential Account',
+    type: 'string',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+  })
+  @ApiOkResponse({
+    description: 'Indicator to know if the Confidential Account is frozen or not',
+    type: 'boolean',
+  })
+  @ApiNotFoundResponse({
+    description: 'The Confidential Asset does not exists',
+  })
+  @Get(':id/freeze-account/:confidentialAccount')
+  async isConfidentialAccountFrozen(
+    @Param()
+    { id, confidentialAccount }: ConfidentialAssetIdParamsDto & ConfidentialAccountParamsDto
+  ): Promise<boolean> {
+    return this.confidentialAssetsService.isConfidentialAccountFrozen(id, confidentialAccount);
   }
 }

--- a/src/confidential-assets/confidential-assets.module.ts
+++ b/src/confidential-assets/confidential-assets.module.ts
@@ -1,14 +1,20 @@
 /* istanbul ignore file */
+import { forwardRef, Module } from '@nestjs/common';
 
-import { Module } from '@nestjs/common';
-
+import { ConfidentialAccountsModule } from '~/confidential-accounts/confidential-accounts.module';
 import { ConfidentialAssetsController } from '~/confidential-assets/confidential-assets.controller';
 import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
+import { ConfidentialProofsModule } from '~/confidential-proofs/confidential-proofs.module';
 import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { TransactionsModule } from '~/transactions/transactions.module';
 
 @Module({
-  imports: [PolymeshModule, TransactionsModule],
+  imports: [
+    PolymeshModule,
+    TransactionsModule,
+    ConfidentialAccountsModule,
+    forwardRef(() => ConfidentialProofsModule.register()),
+  ],
   controllers: [ConfidentialAssetsController],
   providers: [ConfidentialAssetsService],
   exports: [ConfidentialAssetsService],

--- a/src/confidential-assets/confidential-assets.service.spec.ts
+++ b/src/confidential-assets/confidential-assets.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { ConfidentialVenueFilteringDetails, TxTags } from '@polymeshassociation/polymesh-sdk/types';
+import { when } from 'jest-when';
 
 import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { POLYMESH_API } from '~/polymesh/polymesh.consts';
@@ -185,6 +186,94 @@ describe('ConfidentialAssetsService', () => {
         signer,
         disallowedVenues: [new BigNumber(2)],
       });
+
+      expect(result).toEqual({
+        transactions: [mockTransaction],
+      });
+    });
+  });
+
+  describe('toggleFreezeConfidentialAsset', () => {
+    it('should freeze/unfreeze a Confidential Asset', async () => {
+      const input = {
+        signer,
+      };
+      const mockTransactions = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.confidentialAsset.SetAssetFrozen,
+      };
+      const mockTransaction = new MockTransaction(mockTransactions);
+      const mockAsset = createMockConfidentialAsset();
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockAsset);
+
+      when(mockTransactionsService.submit)
+        .calledWith(mockAsset.freeze, {}, input)
+        .mockResolvedValue({
+          transactions: [mockTransaction],
+        });
+
+      let result = await service.toggleFreezeConfidentialAsset(id, input, true);
+
+      expect(result).toEqual({
+        transactions: [mockTransaction],
+      });
+
+      when(mockTransactionsService.submit)
+        .calledWith(mockAsset.unfreeze, {}, input)
+        .mockResolvedValue({
+          transactions: [mockTransaction],
+        });
+
+      result = await service.toggleFreezeConfidentialAsset(id, input, false);
+
+      expect(result).toEqual({
+        transactions: [mockTransaction],
+      });
+    });
+  });
+
+  describe('toggleFreezeConfidentialAccountAsset', () => {
+    it('should freeze/unfreeze a Confidential Account from trading a Confidential Asset', async () => {
+      const params = {
+        confidentialAccount: 'SOME_PUBLIC_KEY',
+      };
+      const input = {
+        signer,
+        ...params,
+      };
+      const mockTransactions = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.confidentialAsset.SetAccountAssetFrozen,
+      };
+      const mockTransaction = new MockTransaction(mockTransactions);
+      const mockAsset = createMockConfidentialAsset();
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockAsset);
+
+      when(mockTransactionsService.submit)
+        .calledWith(mockAsset.freezeAccount, params, { signer })
+        .mockResolvedValue({
+          transactions: [mockTransaction],
+        });
+
+      let result = await service.toggleFreezeConfidentialAccountAsset(id, input, true);
+
+      expect(result).toEqual({
+        transactions: [mockTransaction],
+      });
+
+      when(mockTransactionsService.submit)
+        .calledWith(mockAsset.freezeAccount, params, { signer })
+        .mockResolvedValue({
+          transactions: [mockTransaction],
+        });
+
+      result = await service.toggleFreezeConfidentialAccountAsset(id, input, true);
 
       expect(result).toEqual({
         transactions: [mockTransaction],

--- a/src/confidential-assets/confidential-assets.service.spec.ts
+++ b/src/confidential-assets/confidential-assets.service.spec.ts
@@ -268,12 +268,12 @@ describe('ConfidentialAssetsService', () => {
       });
 
       when(mockTransactionsService.submit)
-        .calledWith(mockAsset.freezeAccount, params, { signer })
+        .calledWith(mockAsset.unfreezeAccount, params, { signer })
         .mockResolvedValue({
           transactions: [mockTransaction],
         });
 
-      result = await service.toggleFreezeConfidentialAccountAsset(id, input, true);
+      result = await service.toggleFreezeConfidentialAccountAsset(id, input, false);
 
       expect(result).toEqual({
         transactions: [mockTransaction],

--- a/src/confidential-assets/confidential-assets.service.spec.ts
+++ b/src/confidential-assets/confidential-assets.service.spec.ts
@@ -280,4 +280,17 @@ describe('ConfidentialAssetsService', () => {
       });
     });
   });
+
+  describe('isConfidentialAccountFrozen', () => {
+    it('should return whether a given Confidential Account is frozen', async () => {
+      const asset = createMockConfidentialAsset();
+      asset.isAccountFrozen.mockResolvedValue(false);
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(asset);
+
+      const result = await service.isConfidentialAccountFrozen(id, 'SOME_PUBLIC_KEY');
+
+      expect(result).toEqual(false);
+    });
+  });
 });

--- a/src/confidential-assets/confidential-assets.service.ts
+++ b/src/confidential-assets/confidential-assets.service.ts
@@ -9,6 +9,7 @@ import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { extractTxBase, ServiceReturn } from '~/common/utils';
 import { CreateConfidentialAssetDto } from '~/confidential-assets/dto/create-confidential-asset.dto';
 import { IssueConfidentialAssetDto } from '~/confidential-assets/dto/issue-confidential-asset.dto';
+import { ToggleFreezeConfidentialAccountAssetDto } from '~/confidential-assets/dto/toggle-freeze-confidential-account-asset.dto';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { TransactionsService } from '~/transactions/transactions.service';
 import { handleSdkError } from '~/transactions/transactions.util';
@@ -72,5 +73,31 @@ export class ConfidentialAssetsService {
     const { base, args } = extractTxBase(params);
 
     return this.transactionsService.submit(asset.setVenueFiltering, args, base);
+  }
+
+  public async toggleFreezeConfidentialAsset(
+    assetId: string,
+    base: TransactionBaseDto,
+    freeze: boolean
+  ): ServiceReturn<void> {
+    const asset = await this.findOne(assetId);
+
+    const method = freeze ? asset.freeze : asset.unfreeze;
+
+    return this.transactionsService.submit(method, {}, base);
+  }
+
+  public async toggleFreezeConfidentialAccountAsset(
+    assetId: string,
+    params: ToggleFreezeConfidentialAccountAssetDto,
+    freeze: boolean
+  ): ServiceReturn<void> {
+    const asset = await this.findOne(assetId);
+
+    const { base, args } = extractTxBase(params);
+
+    const method = freeze ? asset.freezeAccount : asset.unfreezeAccount;
+
+    return this.transactionsService.submit(method, args, base);
   }
 }

--- a/src/confidential-assets/confidential-assets.service.ts
+++ b/src/confidential-assets/confidential-assets.service.ts
@@ -100,4 +100,13 @@ export class ConfidentialAssetsService {
 
     return this.transactionsService.submit(method, args, base);
   }
+
+  public async isConfidentialAccountFrozen(
+    assetId: string,
+    confidentialAccount: string
+  ): Promise<boolean> {
+    const asset = await this.findOne(assetId);
+
+    return asset.isAccountFrozen(confidentialAccount);
+  }
 }

--- a/src/confidential-assets/confidential-assets.util.ts
+++ b/src/confidential-assets/confidential-assets.util.ts
@@ -13,13 +13,15 @@ import { IdentityModel } from '~/identities/models/identity.model';
 export async function createConfidentialAssetDetailsModel(
   asset: ConfidentialAsset
 ): Promise<ConfidentialAssetDetailsModel> {
-  const [details, { auditors, mediators }] = await Promise.all([
+  const [details, { auditors, mediators }, isFrozen] = await Promise.all([
     asset.details(),
     asset.getAuditors(),
+    asset.isFrozen(),
   ]);
 
   return new ConfidentialAssetDetailsModel({
     ...details,
+    isFrozen,
     auditors: auditors.map(({ publicKey }) => new ConfidentialAccountModel({ publicKey })),
     mediators: mediators.map(({ did }) => new IdentityModel({ did })),
   });

--- a/src/confidential-assets/dto/burn-confidential-assets.dto.ts
+++ b/src/confidential-assets/dto/burn-confidential-assets.dto.ts
@@ -1,0 +1,28 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+import { IsString } from 'class-validator';
+
+import { ToBigNumber } from '~/common/decorators/transformation';
+import { IsBigNumber } from '~/common/decorators/validation';
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
+
+export class BurnConfidentialAssetsDto extends TransactionBaseDto {
+  @ApiProperty({
+    description: 'The amount of Confidential Assets to be burned',
+    example: '100',
+    type: 'string',
+  })
+  @ToBigNumber()
+  @IsBigNumber()
+  readonly amount: BigNumber;
+
+  @ApiProperty({
+    description: "The asset issuer's Confidential Account to burn the Confidential Assets from",
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+    type: 'string',
+  })
+  @IsString()
+  readonly confidentialAccount: string;
+}

--- a/src/confidential-assets/dto/confidential-asset-id-params.dto.ts
+++ b/src/confidential-assets/dto/confidential-asset-id-params.dto.ts
@@ -4,5 +4,5 @@ import { IsConfidentialAssetId } from '~/common/decorators/validation';
 
 export class ConfidentialAssetIdParamsDto {
   @IsConfidentialAssetId()
-  readonly id: string;
+  readonly confidentialAssetId: string;
 }

--- a/src/confidential-assets/dto/toggle-freeze-confidential-account-asset.dto.ts
+++ b/src/confidential-assets/dto/toggle-freeze-confidential-account-asset.dto.ts
@@ -1,0 +1,17 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
+
+export class ToggleFreezeConfidentialAccountAssetDto extends TransactionBaseDto {
+  @ApiProperty({
+    description:
+      'The Confidential Account for which trading for a specific confidential asset is being modified',
+    example: '0xdeadbeef00000000000000000000000000000000000000000000000000000000',
+    type: 'string',
+  })
+  @IsString()
+  readonly confidentialAccount: string;
+}

--- a/src/confidential-assets/models/confidential-asset-details.model.ts
+++ b/src/confidential-assets/models/confidential-asset-details.model.ts
@@ -34,6 +34,13 @@ export class ConfidentialAssetDetailsModel {
   readonly totalSupply: BigNumber;
 
   @ApiProperty({
+    description: 'Whether trading is frozen for the Confidential Asset',
+    type: 'boolean',
+    example: true,
+  })
+  readonly isFrozen: boolean;
+
+  @ApiProperty({
     description: 'Auditor Confidential Accounts configured for the Confidential Asset',
     type: ConfidentialAccountModel,
   })

--- a/src/confidential-proofs/confidential-proofs.controller.spec.ts
+++ b/src/confidential-proofs/confidential-proofs.controller.spec.ts
@@ -1,17 +1,22 @@
 import { DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import { ConfidentialTransaction } from '@polymeshassociation/polymesh-sdk/types';
+import {
+  ConfidentialAsset,
+  ConfidentialTransaction,
+} from '@polymeshassociation/polymesh-sdk/types';
 import { when } from 'jest-when';
 
 import { ServiceReturn } from '~/common/utils';
 import { ConfidentialAccountModel } from '~/confidential-accounts/models/confidential-account.model';
+import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
 import { ConfidentialProofsController } from '~/confidential-proofs/confidential-proofs.controller';
 import { ConfidentialProofsService } from '~/confidential-proofs/confidential-proofs.service';
 import { ConfidentialAccountEntity } from '~/confidential-proofs/entities/confidential-account.entity';
 import { ConfidentialTransactionsService } from '~/confidential-transactions/confidential-transactions.service';
 import { testValues, txResult } from '~/test-utils/consts';
 import {
+  mockConfidentialAssetsServiceProvider,
   mockConfidentialProofsServiceProvider,
   mockConfidentialTransactionsServiceProvider,
 } from '~/test-utils/service-mocks';
@@ -22,6 +27,7 @@ describe('ConfidentialProofsController', () => {
   let controller: ConfidentialProofsController;
   let mockConfidentialProofsService: DeepMocked<ConfidentialProofsService>;
   let mockConfidentialTransactionsService: DeepMocked<ConfidentialTransactionsService>;
+  let mockConfidentialAssetsService: DeepMocked<ConfidentialAssetsService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -29,6 +35,7 @@ describe('ConfidentialProofsController', () => {
       providers: [
         mockConfidentialProofsServiceProvider,
         mockConfidentialTransactionsServiceProvider,
+        mockConfidentialAssetsServiceProvider,
       ],
     }).compile();
 
@@ -37,6 +44,8 @@ describe('ConfidentialProofsController', () => {
     mockConfidentialTransactionsService = module.get<typeof mockConfidentialTransactionsService>(
       ConfidentialTransactionsService
     );
+    mockConfidentialAssetsService =
+      module.get<typeof mockConfidentialAssetsService>(ConfidentialAssetsService);
     controller = module.get<ConfidentialProofsController>(ConfidentialProofsController);
   });
 
@@ -161,6 +170,25 @@ describe('ConfidentialProofsController', () => {
       );
 
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('burnConfidentialAsset', () => {
+    it('should call the service and return the results', async () => {
+      const input = {
+        signer,
+        amount: new BigNumber(1),
+        confidentialAccount: 'SOME_PUBLIC_KEY',
+      };
+
+      const confidentialAssetId = 'SOME_ASSET_ID';
+
+      when(mockConfidentialAssetsService.burnConfidentialAsset)
+        .calledWith(confidentialAssetId, input)
+        .mockResolvedValue(txResult as unknown as ServiceReturn<ConfidentialAsset>);
+
+      const result = await controller.burnConfidentialAsset({ confidentialAssetId }, input);
+      expect(result).toEqual(txResult);
     });
   });
 });

--- a/src/confidential-proofs/confidential-proofs.controller.ts
+++ b/src/confidential-proofs/confidential-proofs.controller.ts
@@ -12,6 +12,9 @@ import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';
 import { ConfidentialAccountParamsDto } from '~/confidential-accounts/dto/confidential-account-params.dto';
 import { ConfidentialAccountModel } from '~/confidential-accounts/models/confidential-account.model';
+import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
+import { BurnConfidentialAssetsDto } from '~/confidential-assets/dto/burn-confidential-assets.dto';
+import { ConfidentialAssetIdParamsDto } from '~/confidential-assets/dto/confidential-asset-id-params.dto';
 import { ConfidentialProofsService } from '~/confidential-proofs/confidential-proofs.service';
 import { AuditorVerifySenderProofDto } from '~/confidential-proofs/dto/auditor-verify-sender-proof.dto';
 import { DecryptBalanceDto } from '~/confidential-proofs/dto/decrypt-balance.dto';
@@ -25,7 +28,8 @@ import { SenderAffirmConfidentialTransactionDto } from '~/confidential-transacti
 export class ConfidentialProofsController {
   constructor(
     private readonly confidentialProofsService: ConfidentialProofsService,
-    private readonly confidentialTransactionsService: ConfidentialTransactionsService
+    private readonly confidentialTransactionsService: ConfidentialTransactionsService,
+    private readonly confidentialAssetsService: ConfidentialAssetsService
   ) {}
 
   @ApiTags('confidential-accounts')
@@ -173,5 +177,36 @@ export class ConfidentialProofsController {
     @Body() params: DecryptBalanceDto
   ): Promise<DecryptedBalanceModel> {
     return this.confidentialProofsService.decryptBalance(confidentialAccount, params);
+  }
+
+  @ApiTags('confidential-accounts')
+  @ApiOperation({
+    summary: 'Burn Confidential Assets',
+    description:
+      'This endpoints allows to burn a specific amount of Confidential Assets from a given Confidential Account',
+  })
+  @ApiParam({
+    name: 'confidentialAssetId',
+    description: 'The ID of the Confidential Asset to be burned',
+    type: 'string',
+    example: '76702175-d8cb-e3a5-5a19-734433351e25',
+  })
+  @ApiOkResponse({
+    description: 'Decrypted balance value',
+    type: DecryptedBalanceModel,
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Proof server returned a non-OK status',
+  })
+  @Post('confidential-assets/:confidentialAssetId/burn')
+  public async burnConfidentialAsset(
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto,
+    @Body() params: BurnConfidentialAssetsDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.confidentialAssetsService.burnConfidentialAsset(
+      confidentialAssetId,
+      params
+    );
+    return handleServiceResult(result);
   }
 }

--- a/src/confidential-proofs/confidential-proofs.module.ts
+++ b/src/confidential-proofs/confidential-proofs.module.ts
@@ -4,6 +4,7 @@ import { HttpModule } from '@nestjs/axios';
 import { DynamicModule, forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { ConfidentialAssetsModule } from '~/confidential-assets/confidential-assets.module';
 import { ConfidentialProofsController } from '~/confidential-proofs/confidential-proofs.controller';
 import { ConfidentialProofsService } from '~/confidential-proofs/confidential-proofs.service';
 import confidentialProofsConfig from '~/confidential-proofs/config/confidential-proofs.config';
@@ -28,6 +29,7 @@ export class ConfidentialProofsModule {
         HttpModule,
         LoggerModule,
         forwardRef(() => ConfidentialTransactionsModule),
+        forwardRef(() => ConfidentialAssetsModule),
       ],
       controllers,
       providers: [ConfidentialProofsService],

--- a/src/confidential-proofs/confidential-proofs.service.spec.ts
+++ b/src/confidential-proofs/confidential-proofs.service.spec.ts
@@ -119,7 +119,7 @@ describe('ConfidentialProofsService', () => {
       });
 
       const result = await service.generateSenderProof('confidentialAccount', {
-        amount: 100,
+        amount: new BigNumber(100),
         auditors: ['auditor'],
         receiver: 'receiver',
         encryptedBalance: '0xencryptedBalance',
@@ -236,6 +236,34 @@ describe('ConfidentialProofsService', () => {
       expect(result).toEqual({
         value: new BigNumber(10),
       });
+    });
+  });
+
+  describe('generateBurnProof', () => {
+    it('should return generated burn proof', async () => {
+      const mockResult = 'some_proof';
+
+      mockLastValueFrom.mockReturnValue({
+        status: 200,
+        data: mockResult,
+      });
+
+      const result = await service.generateBurnProof('confidentialAccount', {
+        amount: new BigNumber(100),
+        encryptedBalance: '0xencryptedBalance',
+      });
+
+      expect(mockHttpService.request).toHaveBeenCalledWith({
+        url: `${proofServerUrl}/accounts/confidentialAccount/burn`,
+        method: 'POST',
+        data: {
+          amount: 100,
+          encrypted_balance: '0xencryptedBalance',
+        },
+        timeout: 10000,
+      });
+
+      expect(result).toEqual(mockResult);
     });
   });
 });

--- a/src/confidential-proofs/confidential-proofs.service.ts
+++ b/src/confidential-proofs/confidential-proofs.service.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { Method } from 'axios';
 import { lastValueFrom } from 'rxjs';
 
@@ -91,7 +92,7 @@ export class ConfidentialProofsService {
   public async generateSenderProof(
     confidentialAccount: string,
     senderInfo: {
-      amount: number;
+      amount: BigNumber;
       auditors: string[];
       receiver: string;
       encryptedBalance: string;
@@ -156,5 +157,25 @@ export class ConfidentialProofsService {
       'POST',
       params
     );
+  }
+
+  /**
+   * Generates sender proof for a transaction leg. This will be used by the sender to affirm the transaction
+   * @param confidentialAccount
+   * @param burnInfo consisting of the amount and current encrypted balance
+   * @returns sender proof
+   */
+  public async generateBurnProof(
+    confidentialAccount: string,
+    burnInfo: {
+      amount: BigNumber;
+      encryptedBalance: string;
+    }
+  ): Promise<string> {
+    this.logger.debug(
+      `generateBurnProof - Generating burn proof for account ${confidentialAccount}`
+    );
+
+    return this.requestProofServer(`accounts/${confidentialAccount}/burn`, 'POST', burnInfo);
   }
 }

--- a/src/confidential-transactions/confidential-transactions.controller.spec.ts
+++ b/src/confidential-transactions/confidential-transactions.controller.spec.ts
@@ -169,4 +169,17 @@ describe('ConfidentialTransactionsController', () => {
       ]);
     });
   });
+
+  describe('getPendingAffirmsCount', () => {
+    it('should call the service and return the result', async () => {
+      const transactionId = new BigNumber(1);
+      when(mockConfidentialTransactionsService.getPendingAffirmsCount)
+        .calledWith(transactionId)
+        .mockResolvedValue(new BigNumber(3));
+
+      const result = await controller.getPendingAffirmsCount({ id: transactionId });
+
+      expect(result).toEqual(3);
+    });
+  });
 });

--- a/src/confidential-transactions/confidential-transactions.controller.ts
+++ b/src/confidential-transactions/confidential-transactions.controller.ts
@@ -141,4 +141,29 @@ export class ConfidentialTransactionsController {
 
     return result.map(({ did }) => new IdentityModel({ did }));
   }
+
+  @ApiOperation({
+    summary: 'Get pending affirmation count',
+    description:
+      'This endpoint retrieves the number of pending affirmations for a Confidential Transaction',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the Confidential Transaction',
+    type: 'string',
+    example: '1',
+  })
+  @ApiOkResponse({
+    description: 'Number of pending affirmation',
+    type: 'number',
+  })
+  @ApiNotFoundResponse({
+    description: 'Affirm count not available',
+  })
+  @Get(':id/pending-affirmation-count')
+  public async getPendingAffirmsCount(@Param() { id }: IdParamsDto): Promise<number> {
+    const result = await this.confidentialTransactionsService.getPendingAffirmsCount(id);
+
+    return result.toNumber();
+  }
 }

--- a/src/confidential-transactions/confidential-transactions.service.spec.ts
+++ b/src/confidential-transactions/confidential-transactions.service.spec.ts
@@ -319,7 +319,7 @@ describe('ConfidentialTransactionsService', () => {
 
       when(mockConfidentialProofsService.generateSenderProof)
         .calledWith('SENDER_CONFIDENTIAL_ACCOUNT', {
-          amount: 100,
+          amount: new BigNumber(100),
           auditors: ['AUDITOR_CONFIDENTIAL_ACCOUNT'],
           receiver: 'RECEIVER_CONFIDENTIAL_ACCOUNT',
           encryptedBalance: '0x0ceabalance',

--- a/src/confidential-transactions/confidential-transactions.service.spec.ts
+++ b/src/confidential-transactions/confidential-transactions.service.spec.ts
@@ -473,4 +473,19 @@ describe('ConfidentialTransactionsService', () => {
       expect(result).toEqual(mockConfidentialVenues);
     });
   });
+
+  describe('getPendingAffirmsCount', () => {
+    it('should return the pending affirms count for a transaction', async () => {
+      const expectedResult = new BigNumber(3);
+
+      const mockConfidentialTransaction = createMockConfidentialTransaction();
+      mockConfidentialTransaction.getPendingAffirmsCount.mockResolvedValue(expectedResult);
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockConfidentialTransaction);
+
+      const result = await service.getPendingAffirmsCount(new BigNumber(1));
+
+      expect(result).toEqual(expectedResult);
+    });
+  });
 });

--- a/src/confidential-transactions/confidential-transactions.service.ts
+++ b/src/confidential-transactions/confidential-transactions.service.ts
@@ -167,4 +167,10 @@ export class ConfidentialTransactionsService {
 
     return identity.getConfidentialVenues();
   }
+
+  public async getPendingAffirmsCount(transactionId: BigNumber): Promise<BigNumber> {
+    const transaction = await this.findOne(transactionId);
+
+    return transaction.getPendingAffirmsCount();
+  }
 }

--- a/src/confidential-transactions/confidential-transactions.service.ts
+++ b/src/confidential-transactions/confidential-transactions.service.ts
@@ -118,7 +118,7 @@ export class ConfidentialTransactionsService {
       });
 
       const proof = await this.confidentialProofsService.generateSenderProof(sender.publicKey, {
-        amount: amount.toNumber(),
+        amount,
         auditors: assetAuditor.auditors.map(({ publicKey }) => publicKey),
         receiver: receiver.publicKey,
         encryptedBalance,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,10 +1953,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.1.0"
 
-"@polymeshassociation/polymesh-sdk@^24.0.0-confidential-assets.7":
-  version "24.0.0-confidential-assets.7"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.0.0-confidential-assets.7.tgz#005b29dbee8241d47fba99bb0427c3fd3b6c4ea5"
-  integrity sha512-xI13rMdmcL+Y/Wv8YLQCSo6wWdvl3I0s2lCJEVOTKiOSk6mnjBQ8E3b2tu0Nz/4bq4x9fMY7PtH7h9+mCW5XFw==
+"@polymeshassociation/polymesh-sdk@^24.0.0-confidential-assets.11":
+  version "24.0.0-confidential-assets.11"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.0.0-confidential-assets.11.tgz#8739b653d2d985065b739a3e50c169fa5f73615f"
+  integrity sha512-NJdNT3JXhXhbozKIQnlC4ZEbSnL9pp1DMewD8WJ41jNKn9vOobhSVgbrHd/aFC2MElIl5TuuvT0A7Qvh4oTYCw==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "10.9.1"


### PR DESCRIPTION
### JIRA Link 

DA-1091, DA-1092, DA-1093, DA-1113, DA-1114, DA-1094, DA-1115

### Changelog / Description 

Adds API to - 
* freeze/unfreeze a confidential asset
* freeze/unfreeze a confidential account 
* get all balances and incoming balances
* get specific confidential asset balance / incoming balance
* get whether a confidential account has been frozen for a specific confidential asset id
* get details whether a confidential asset is frozen
* burn confidential asset
* get pending affirmations count

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
