### PR TITLE
feat: 🎸 Add API to get creation event data for CA

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { DeveloperTestingModule } from '~/developer-testing/developer-testing.mo
 import { EventsModule } from '~/events/events.module';
 import { IdentitiesModule } from '~/identities/identities.module';
 import { MetadataModule } from '~/metadata/metadata.module';
+import { MiddlewareModule } from '~/middleware/middleware.module';
 import { NetworkModule } from '~/network/network.module';
 import { NftsModule } from '~/nfts/nfts.module';
 import { NotificationsModule } from '~/notifications/notifications.module';
@@ -101,6 +102,7 @@ import { UsersModule } from '~/users/users.module';
     ConfidentialAccountsModule,
     ConfidentialTransactionsModule,
     ConfidentialProofsModule.register(),
+    MiddlewareModule.register(),
   ],
 })
 export class AppModule {}

--- a/src/confidential-assets/confidential-assets.service.spec.ts
+++ b/src/confidential-assets/confidential-assets.service.spec.ts
@@ -363,4 +363,24 @@ describe('ConfidentialAssetsService', () => {
       });
     });
   });
+
+  describe('createdAt', () => {
+    it('should return creation event details for a Confidential Account', async () => {
+      const mockResult = {
+        blockNumber: new BigNumber('2719172'),
+        blockHash: 'someHash',
+        blockDate: new Date('2023-06-26T01:47:45.000Z'),
+        eventIndex: new BigNumber(1),
+      };
+      const asset = createMockConfidentialAsset();
+
+      asset.createdAt.mockResolvedValue(mockResult);
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(asset);
+
+      const result = await service.createdAt('SOME_ASSET_ID');
+
+      expect(result).toEqual(mockResult);
+    });
+  });
 });

--- a/src/confidential-assets/confidential-assets.service.ts
+++ b/src/confidential-assets/confidential-assets.service.ts
@@ -3,6 +3,7 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
   ConfidentialAsset,
   ConfidentialVenueFilteringDetails,
+  EventIdentifier,
 } from '@polymeshassociation/polymesh-sdk/types';
 
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
@@ -141,5 +142,11 @@ export class ConfidentialAssetsService {
       },
       base
     );
+  }
+
+  public async createdAt(assetId: string): Promise<EventIdentifier | null> {
+    const asset = await this.findOne(assetId);
+
+    return asset.createdAt();
   }
 }

--- a/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.spec.ts
+++ b/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.spec.ts
@@ -1,0 +1,57 @@
+import { DeepMocked } from '@golevelup/ts-jest';
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { EventIdentifierModel } from '~/common/models/event-identifier.model';
+import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
+import { ConfidentialAssetsMiddlewareController } from '~/middleware/confidential-assets-middleware/confidential-assets-middleware.controller';
+import { mockConfidentialAssetsServiceProvider } from '~/test-utils/service-mocks';
+
+describe('ConfidentialAssetsMiddlewareController', () => {
+  let controller: ConfidentialAssetsMiddlewareController;
+  let mockConfidentialAssetsService: DeepMocked<ConfidentialAssetsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConfidentialAssetsMiddlewareController],
+      providers: [mockConfidentialAssetsServiceProvider],
+    }).compile();
+
+    mockConfidentialAssetsService =
+      module.get<typeof mockConfidentialAssetsService>(ConfidentialAssetsService);
+    controller = module.get<ConfidentialAssetsMiddlewareController>(
+      ConfidentialAssetsMiddlewareController
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createdAt', () => {
+    it('should throw AppNotFoundError if the event details are not yet ready', () => {
+      mockConfidentialAssetsService.createdAt.mockResolvedValue(null);
+
+      return expect(() =>
+        controller.createdAt({ confidentialAssetId: 'SOME_ASSET_ID' })
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    describe('otherwise', () => {
+      it('should return the Portfolio creation event details', async () => {
+        const eventIdentifier = {
+          blockNumber: new BigNumber('2719172'),
+          blockHash: 'someHash',
+          blockDate: new Date('2021-06-26T01:47:45.000Z'),
+          eventIndex: new BigNumber(1),
+        };
+        mockConfidentialAssetsService.createdAt.mockResolvedValue(eventIdentifier);
+
+        const result = await controller.createdAt({ confidentialAssetId: 'SOME_ASSET_ID' });
+
+        expect(result).toEqual(new EventIdentifierModel(eventIdentifier));
+      });
+    });
+  });
+});

--- a/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.ts
+++ b/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import { EventIdentifierModel } from '~/common/models/event-identifier.model';
+import { ConfidentialAssetsService } from '~/confidential-assets/confidential-assets.service';
+import { ConfidentialAssetIdParamsDto } from '~/confidential-assets/dto/confidential-asset-id-params.dto';
+
+@Controller()
+export class ConfidentialAssetsMiddlewareController {
+  constructor(private readonly confidentialAssetsService: ConfidentialAssetsService) {}
+
+  @ApiOperation({
+    summary: 'Get creation event data for a Confidential Asset',
+    description:
+      'This endpoint will provide the basic details of an Confidential Asset along with the auditors information',
+  })
+  @ApiParam({
+    name: 'confidentialAssetId',
+    description: 'The ID of the Confidential Asset',
+    type: 'string',
+    example: '76702175-d8cb-e3a5-5a19-734433351e25',
+  })
+  @ApiOkResponse({
+    description: 'Details of event where the Confidential Asset was created',
+    type: EventIdentifierModel,
+  })
+  @ApiNotFoundResponse({
+    description: 'Data is not yet processed by the middleware',
+  })
+  @Get('confidential-assets/:confidentialAssetId/created-at')
+  public async createdAt(
+    @Param() { confidentialAssetId }: ConfidentialAssetIdParamsDto
+  ): Promise<EventIdentifierModel> {
+    const result = await this.confidentialAssetsService.createdAt(confidentialAssetId);
+
+    if (!result) {
+      throw new NotFoundException(
+        "Confidential Asset's data hasn't yet been processed by the middleware"
+      );
+    }
+
+    return new EventIdentifierModel(result);
+  }
+}

--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -1,0 +1,27 @@
+/* istanbul ignore file */
+
+import { DynamicModule, forwardRef, Module } from '@nestjs/common';
+
+import { ConfidentialAssetsModule } from '~/confidential-assets/confidential-assets.module';
+import { ConfidentialAssetsMiddlewareController } from '~/middleware/confidential-assets-middleware/confidential-assets-middleware.controller';
+
+@Module({})
+export class MiddlewareModule {
+  static register(): DynamicModule {
+    const controllers = [];
+
+    const middlewareUrl = process.env.POLYMESH_MIDDLEWARE_URL || '';
+
+    if (middlewareUrl.length) {
+      controllers.push(ConfidentialAssetsMiddlewareController);
+    }
+
+    return {
+      module: MiddlewareModule,
+      imports: [forwardRef(() => ConfidentialAssetsModule)],
+      controllers,
+      providers: [],
+      exports: [],
+    };
+  }
+}


### PR DESCRIPTION
### JIRA Link 

DA-1108

### Changelog / Description 

Adds API to get creation event details for a confidential asset

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
