### PR TITLE
feat: 🎸 add asset tranaction history end point

### DIFF
--- a/src/claims/decorators/get-custom-claim-type.pipe.ts
+++ b/src/claims/decorators/get-custom-claim-type.pipe.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import { Injectable, PipeTransform } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 

--- a/src/confidential-assets/confidential-assets.service.spec.ts
+++ b/src/confidential-assets/confidential-assets.service.spec.ts
@@ -1,7 +1,11 @@
 import { DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import { ConfidentialVenueFilteringDetails, TxTags } from '@polymeshassociation/polymesh-sdk/types';
+import {
+  ConfidentialVenueFilteringDetails,
+  EventIdEnum,
+  TxTags,
+} from '@polymeshassociation/polymesh-sdk/types';
 import { when } from 'jest-when';
 
 import { ConfidentialAccountsService } from '~/confidential-accounts/confidential-accounts.service';
@@ -379,6 +383,37 @@ describe('ConfidentialAssetsService', () => {
       jest.spyOn(service, 'findOne').mockResolvedValue(asset);
 
       const result = await service.createdAt('SOME_ASSET_ID');
+
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('transactionHistory', () => {
+    it('should return creation event details for a Confidential Account', async () => {
+      const mockResult = {
+        data: [
+          {
+            id: '',
+            assetId: 'someId',
+            amount: '10',
+            eventId: EventIdEnum.TransactionExecuted,
+            datetime: new Date(),
+            createdBlockId: new BigNumber(3),
+            blockNumber: new BigNumber('2719172'),
+            blockHash: 'someHash',
+            blockDate: new Date('2023-06-26T01:47:45.000Z'),
+            eventIndex: new BigNumber(1),
+          },
+        ],
+        next: '',
+      };
+      const asset = createMockConfidentialAsset();
+
+      asset.getTransactionHistory.mockResolvedValue(mockResult);
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(asset);
+
+      const result = await service.transactionHistory('SOME_ASSET_ID', new BigNumber(10));
 
       expect(result).toEqual(mockResult);
     });

--- a/src/confidential-assets/confidential-assets.service.ts
+++ b/src/confidential-assets/confidential-assets.service.ts
@@ -2,8 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
   ConfidentialAsset,
+  ConfidentialAssetTransactionHistory,
   ConfidentialVenueFilteringDetails,
   EventIdentifier,
+  ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
 
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
@@ -148,5 +150,15 @@ export class ConfidentialAssetsService {
     const asset = await this.findOne(assetId);
 
     return asset.createdAt();
+  }
+
+  public async transactionHistory(
+    assetId: string,
+    size: BigNumber,
+    start?: BigNumber
+  ): Promise<ResultSet<ConfidentialAssetTransactionHistory>> {
+    const asset = await this.findOne(assetId);
+
+    return asset.getTransactionHistory({ size, start });
   }
 }

--- a/src/confidential-assets/models/confidential-asset-transaction.model.ts
+++ b/src/confidential-assets/models/confidential-asset-transaction.model.ts
@@ -1,0 +1,69 @@
+/* istanbul ignore file */
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+
+export class ConfidentialAssetTransactionModel {
+  @ApiProperty({
+    description: 'The confidential asset ID',
+    type: 'string',
+    example: '0x0a732f0ea43bb082ff1cff9a9ff59291',
+  })
+  readonly assetId: string;
+
+  @ApiPropertyOptional({
+    description: 'The DID from which the transaction originated',
+    type: 'string',
+  })
+  readonly fromId?: string;
+
+  @ApiPropertyOptional({
+    description: 'The DID for which the asset was sent to',
+    type: 'string',
+    example: '0x786a5b0ffef119dd43565768a3557e7880be8958c7eda070e4162b27f308b23e',
+    nullable: true,
+  })
+  readonly toId?: string;
+
+  @ApiProperty({
+    description: 'The encrypted amount of the transaction',
+    type: 'string',
+    example:
+      '0x000000000000000000000000000000000000000000000000000000000000000064aff78e09b0fa5dccd82b594cd49d431d0fbf8ddd6830e65a0cdcd428d67428',
+  })
+  readonly amount: string;
+
+  @ApiProperty({
+    description: 'The time the transaction took place',
+    type: 'string',
+    example: '2024-02-20T13:15:54',
+  })
+  readonly datetime: Date;
+
+  @ApiProperty({
+    description: 'The created block id',
+    type: 'string',
+    example: '277',
+  })
+  @FromBigNumber()
+  readonly createdBlockId: BigNumber;
+
+  @ApiProperty({
+    description: 'The event id associated with the transaction record',
+    type: 'string',
+    example: 'AccountDeposit',
+  })
+  readonly eventId: string;
+
+  @ApiPropertyOptional({
+    description: 'The memo',
+    type: 'string',
+  })
+  readonly memo?: string;
+
+  constructor(model: ConfidentialAssetTransactionModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.spec.ts
+++ b/src/middleware/confidential-assets-middleware/confidential-assets-middleware.controller.spec.ts
@@ -2,6 +2,7 @@ import { DeepMocked } from '@golevelup/ts-jest';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+import { EventIdEnum } from '@polymeshassociation/polymesh-sdk/types';
 
 import { EventIdentifierModel } from '~/common/models/event-identifier.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
@@ -89,6 +90,44 @@ describe('ConfidentialAssetsMiddlewareController', () => {
           results: expect.arrayContaining([{ id: 'SOME_ASSET_ID_2' }, { id: 'SOME_ASSET_ID_2' }]),
           total: new BigNumber(mockAssets.count),
           next: mockAssets.next,
+        })
+      );
+    });
+  });
+
+  describe('getTransactionHistory', () => {
+    it('should return the transaction history', async () => {
+      const mockResult = {
+        data: [
+          {
+            id: 'someId',
+            assetId: '0x0a732f0ea43bb082ff1cff9a9ff59291',
+            fromId: 'mockFrom',
+            toId: '0x786a5b0ffef119dd43565768a3557e7880be8958c7eda070e4162b27f308b23e',
+            amount:
+              '0x000000000000000000000000000000000000000000000000000000000000000064aff78e09b0fa5dccd82b594cd49d431d0fbf8ddd6830e65a0cdcd428d67428',
+            datetime: new Date('2024-02-20T13:15:54'),
+            createdBlockId: new BigNumber(277),
+            eventId: EventIdEnum.AccountDeposit,
+            memo: 'someMemo',
+          },
+        ],
+        next: 'abc',
+        count: new BigNumber(1),
+      };
+
+      mockConfidentialAssetsService.transactionHistory.mockResolvedValue(mockResult);
+
+      const result = await controller.getTransactionHistory(
+        { confidentialAssetId: 'SOME_ASSET_ID' },
+        { size: new BigNumber(10) }
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          results: mockResult.data,
+          next: mockResult.next,
+          total: mockResult.count,
         })
       );
     });


### PR DESCRIPTION
### JIRA Link 

[DA-1109](https://polymesh.atlassian.net/browse/DA-1109)

### Changelog / Description 

add GET /confidential-assets/{confidentialAssetId}/transactions to allow fetching of transaction involving the asset

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-1109]: https://polymesh.atlassian.net/browse/DA-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ