### PR TITLE
feat: 🎸 identities rotatePrimaryKey/attestPrimaryKeyRotation

### DIFF
--- a/src/common/utils/functions.ts
+++ b/src/common/utils/functions.ts
@@ -170,3 +170,13 @@ export function isNftLeg(leg: Leg): leg is NftLeg {
 export async function clearEventLoop(): Promise<void> {
   await new Promise(resolve => setImmediate(resolve));
 }
+
+/**
+ * helper to get current date plus one year in ISO format
+ */
+export function getNextYearISO(): string {
+  const nextYear = new Date();
+  nextYear.setFullYear(nextYear.getFullYear() + 1);
+
+  return nextYear.toISOString();
+}

--- a/src/identities/dto/rotate-primary-key-params.dto.ts
+++ b/src/identities/dto/rotate-primary-key-params.dto.ts
@@ -1,9 +1,25 @@
 /* istanbul ignore file */
-import { OmitType } from '@nestjs/swagger';
 
-import { RegisterIdentityDto } from '~/identities/dto/register-identity.dto';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDate, IsOptional, IsString } from 'class-validator';
 
-export class RotatePrimaryKeyParamsDto extends OmitType(RegisterIdentityDto, [
-  'secondaryAccounts',
-  'createCdd',
-] as const) {}
+import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
+import { getNextYearISO } from '~/common/utils';
+
+export class RotatePrimaryKeyParamsDto extends TransactionBaseDto {
+  @ApiProperty({
+    description: 'Account address which will become the primary key',
+    example: '5grwXxxXxxXxxXxxXxxXxxXxxXxxXxxXxxXxxXxxXxxXxxXx',
+  })
+  @IsString()
+  readonly targetAccount: string;
+
+  @ApiPropertyOptional({
+    description: 'Date at which the Identity will expire',
+    example: getNextYearISO(),
+    type: 'string',
+  })
+  @IsOptional()
+  @IsDate()
+  readonly expiry?: Date;
+}

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -679,4 +679,33 @@ describe('IdentitiesController', () => {
       });
     });
   });
+
+  describe('attestPrimaryKeyRotation', () => {
+    it('should return the transaction details on attesting primary key rotation for DID', async () => {
+      const mockAuthorization = new MockAuthorizationRequest();
+      const mockData = {
+        ...txResult,
+        result: mockAuthorization,
+      };
+      mockIdentitiesService.attestPrimaryKeyRotation.mockResolvedValue(mockData);
+
+      const mockIdentity = new MockIdentity();
+      mockIdentity.did = did;
+      mockIdentitiesService.findOne.mockResolvedValue(mockIdentity);
+
+      const result = await controller.attestPrimaryKeyRotation(
+        { did },
+        {
+          signer: 'Ox60',
+          targetAccount: '5xdd',
+        }
+      );
+
+      expect(result).toEqual({
+        ...txResult,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
+      });
+    });
+  });
 });

--- a/src/identities/identities.controller.ts
+++ b/src/identities/identities.controller.ts
@@ -627,7 +627,8 @@ export class IdentitiesController {
   @ApiOperation({
     summary: 'Rotate Primary Key',
     description:
-      'Creates an Authorization to rotate primary key of the signing Identity by the `targetAccount`.',
+      'Creates an Authorization to rotate primary key of the signing Identity by the `targetAccount`. <br />' +
+      'The existing key for the signing Identity will be unlinked once the new primary key is attested.',
   })
   @ApiTransactionResponse({
     description: 'Newly created Authorization Request along with transaction details',
@@ -642,6 +643,40 @@ export class IdentitiesController {
     @Body() rotatePrimaryKeyDto: RotatePrimaryKeyParamsDto
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.identitiesService.rotatePrimaryKey(rotatePrimaryKeyDto);
+
+    return handleServiceResult(serviceResult, authorizationRequestResolver);
+  }
+
+  @ApiOperation({
+    summary: 'Attest Primary Key Rotation',
+    description:
+      'The transaction signer must be a CDD provider. <br />' +
+      'This will create Authorization Request to accept the `targetAccount` to become as the primary key of the given Identity.',
+  })
+  @ApiTransactionResponse({
+    description: 'Newly created Authorization Request along with transaction details',
+    type: CreatedAuthorizationRequestModel,
+  })
+  @ApiBadRequestResponse({
+    description:
+      'The target Account already has a pending attestation to become the primary key of the target Identity',
+  })
+  @ApiParam({
+    name: 'did',
+    description: 'The DID of the Identity for which to attest primary key rotation',
+    type: 'string',
+    required: true,
+    example: '0x0600000000000000000000000000000000000000000000000000000000000000',
+  })
+  @Post(':did/rotate-primary-key')
+  async attestPrimaryKeyRotation(
+    @Param() { did }: DidDto,
+    @Body() rotatePrimaryKeyDto: RotatePrimaryKeyParamsDto
+  ): Promise<TransactionResponseModel> {
+    const serviceResult = await this.identitiesService.attestPrimaryKeyRotation(
+      did,
+      rotatePrimaryKeyDto
+    );
 
     return handleServiceResult(serviceResult, authorizationRequestResolver);
   }

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -114,4 +114,28 @@ export class IdentitiesService {
 
     return this.transactionsService.submit(rotatePrimaryKey, args, options);
   }
+
+  public async attestPrimaryKeyRotation(
+    did: string,
+    rotatePrimaryKeyDto: RotatePrimaryKeyParamsDto
+  ): ServiceReturn<AuthorizationRequest> {
+    const {
+      polymeshService: { polymeshApi },
+    } = this;
+
+    const identity = await this.findOne(did);
+
+    const {
+      options,
+      args: { targetAccount, expiry },
+    } = extractTxOptions(rotatePrimaryKeyDto);
+
+    const { attestPrimaryKeyRotation } = polymeshApi.identities;
+
+    return this.transactionsService.submit(
+      attestPrimaryKeyRotation,
+      { identity, targetAccount, expiry },
+      options
+    );
+  }
 }

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -7,7 +7,6 @@ import { SettlementResultEnum } from '@polymeshassociation/polymesh-sdk/middlewa
 import {
   Account,
   AuthorizationType,
-  ComplianceManagerTx,
   HistoricSettlement,
   MetadataEntry,
   MetadataType,
@@ -481,7 +480,7 @@ export function createMockResultSet<T extends any[]>(data: T): ResultSet<T> {
 }
 
 export function createMockTxResult(
-  transactionTag: ComplianceManagerTx
+  transactionTag: TxTag
 ): TransactionResult<void> | ServiceReturn<void> | NotificationPayload<EventType> {
   const transaction = {
     blockHash: '0x1',

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -142,6 +142,7 @@ export class MockIdentitiesService {
   createMockCdd = jest.fn();
   registerDid = jest.fn();
   rotatePrimaryKey = jest.fn();
+  attestPrimaryKeyRotation = jest.fn();
 }
 
 export class MockSettlementsService {


### PR DESCRIPTION
### JIRA Link 

https://polymesh.atlassian.net/browse/DA-50

### Changelog / Description 

- adds `/identities/rotate-primary-key` endpoint for rotating Primary Key for an Identity
- adds `/identities/:did/attest-primary-key-rotation` for attesting Primary Key rotation

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [x] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced primary key rotation functionality for identities, allowing users to rotate and attest primary keys securely.
- **Documentation**
	- Updated API documentation to include new primary key rotation features.
- **Tests**
	- Added comprehensive test cases for primary key rotation and attestation in identities management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->