### PR TITLE
feat: 🎸 add pre-approval endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@polymeshassociation/fireblocks-signing-manager": "^2.3.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "^3.1.0",
     "@polymeshassociation/local-signing-manager": "^3.1.0",
-    "@polymeshassociation/polymesh-sdk": "24.0.0-alpha.12",
+    "@polymeshassociation/polymesh-sdk": "24.0.0-alpha.16",
     "@polymeshassociation/signing-manager-types": "^3.1.0",
     "class-transformer": "0.5.1",
     "class-validator": "^0.14.0",

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -415,4 +415,34 @@ describe('AssetsController', () => {
       });
     });
   });
+
+  describe('preApprove', () => {
+    it('should call the service and return the results', async () => {
+      const ticker = 'TICKER';
+
+      mockAssetsService.preApprove.mockResolvedValue(txResult);
+
+      const result = await controller.preApprove({ ticker }, { signer });
+
+      expect(result).toEqual(txResult);
+      expect(mockAssetsService.preApprove).toHaveBeenCalledWith(ticker, {
+        signer,
+      });
+    });
+  });
+
+  describe('removePreApproval', () => {
+    it('should call the service and return the results', async () => {
+      const ticker = 'TICKER';
+
+      mockAssetsService.removePreApproval.mockResolvedValue(txResult);
+
+      const result = await controller.removePreApproval({ ticker }, { signer });
+
+      expect(result).toEqual(txResult);
+      expect(mockAssetsService.removePreApproval).toHaveBeenCalledWith(ticker, {
+        signer,
+      });
+    });
+  });
 });

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -513,4 +513,64 @@ export class AssetsController {
     const result = await this.assetsService.removeRequiredMediators(ticker, params);
     return handleServiceResult(result);
   }
+
+  @ApiOperation({
+    summary: 'Pre-approve receiving an asset',
+    description: 'This endpoint enables automatic affirmation when receiving the asset',
+  })
+  @ApiParam({
+    name: 'ticker',
+    description: 'The ticker of the Asset to pre-approve',
+    type: 'string',
+    example: 'TICKER',
+  })
+  @ApiTransactionResponse({
+    description: 'Details about the transaction',
+    type: TransactionQueueModel,
+  })
+  @ApiNotFoundResponse({
+    description: 'The Asset does not exist',
+  })
+  @ApiBadRequestResponse({
+    description: 'The signing identity has already pre-approved the asset',
+  })
+  @Post(':ticker/pre-approve')
+  public async preApprove(
+    @Param() { ticker }: TickerParamsDto,
+    @Body() params: TransactionBaseDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.assetsService.preApprove(ticker, params);
+
+    return handleServiceResult(result);
+  }
+
+  @ApiOperation({
+    summary: 'Remove pre-approve receiving an asset',
+    description: 'This endpoint disables automatic affirmation when receiving the asset',
+  })
+  @ApiParam({
+    name: 'ticker',
+    description: 'The ticker of the Asset to remove pre-approval for',
+    type: 'string',
+    example: 'TICKER',
+  })
+  @ApiTransactionResponse({
+    description: 'Details about the transaction',
+    type: TransactionQueueModel,
+  })
+  @ApiNotFoundResponse({
+    description: 'The Asset does not exist',
+  })
+  @ApiBadRequestResponse({
+    description: 'The asset is not pre-approved for the signing identity',
+  })
+  @Post(':ticker/remove-pre-approval')
+  public async removePreApproval(
+    @Param() { ticker }: TickerParamsDto,
+    @Body() params: TransactionBaseDto
+  ): Promise<TransactionResponseModel> {
+    const result = await this.assetsService.removePreApproval(ticker, params);
+
+    return handleServiceResult(result);
+  }
 }

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -636,4 +636,72 @@ describe('AssetsService', () => {
       );
     });
   });
+
+  describe('preApprove', () => {
+    it('should run a preApproveTicker procedure and return the transaction results', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.asset.PreApproveTicker,
+      };
+      const mockTransaction = new MockTransaction(transaction);
+
+      const mockAsset = new MockAsset();
+      mockAsset.settlements.preApprove.mockResolvedValue(mockTransaction);
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockAsset as any);
+
+      const result = await service.preApprove('TICKER', {
+        signer,
+      });
+
+      expect(result).toEqual({
+        result: undefined,
+        transactions: [mockTransaction],
+      });
+
+      expect(mockTransactionsService.submit).toHaveBeenCalledWith(
+        mockAsset.settlements.preApprove,
+        {},
+        expect.objectContaining({ signer })
+      );
+    });
+  });
+
+  describe('removePreApproval', () => {
+    it('should run a removePreApproval procedure and return the transaction results', async () => {
+      const transaction = {
+        blockHash: '0x1',
+        txHash: '0x2',
+        blockNumber: new BigNumber(1),
+        tag: TxTags.asset.RemoveTickerPreApproval,
+      };
+      const mockTransaction = new MockTransaction(transaction);
+
+      const mockAsset = new MockAsset();
+      mockAsset.settlements.removePreApproval.mockResolvedValue(mockTransaction);
+      mockTransactionsService.submit.mockResolvedValue({ transactions: [mockTransaction] });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockAsset as any);
+
+      const result = await service.removePreApproval('TICKER', {
+        signer,
+      });
+
+      expect(result).toEqual({
+        result: undefined,
+        transactions: [mockTransaction],
+      });
+
+      expect(mockTransactionsService.submit).toHaveBeenCalledWith(
+        mockAsset.settlements.removePreApproval,
+        {},
+        expect.objectContaining({ signer })
+      );
+    });
+  });
 });

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -195,4 +195,24 @@ export class AssetsService {
 
     return this.transactionsService.submit(removeRequiredMediators, { mediators }, options);
   }
+
+  public async preApprove(ticker: string, params: TransactionBaseDto): ServiceReturn<void> {
+    const { options } = extractTxOptions(params);
+
+    const {
+      settlements: { preApprove },
+    } = await this.findOne(ticker);
+
+    return this.transactionsService.submit(preApprove, {}, options);
+  }
+
+  public async removePreApproval(ticker: string, params: TransactionBaseDto): ServiceReturn<void> {
+    const { options } = extractTxOptions(params);
+
+    const {
+      settlements: { removePreApproval },
+    } = await this.findOne(ticker);
+
+    return this.transactionsService.submit(removePreApproval, {}, options);
+  }
 }

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -32,6 +32,7 @@ import { mockPolymeshLoggerProvider } from '~/logger/mock-polymesh-logger';
 import { SettlementsService } from '~/settlements/settlements.service';
 import { testValues } from '~/test-utils/consts';
 import {
+  MockAsset,
   MockAuthorizationRequest,
   MockIdentity,
   MockTickerReservation,
@@ -705,6 +706,51 @@ describe('IdentitiesController', () => {
         ...txResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
+      });
+    });
+  });
+
+  describe('getIsPreApprove', () => {
+    it('should return the asset pre-approval status', async () => {
+      mockIdentitiesService.isTickerPreApproved.mockResolvedValue(true);
+
+      const result = await controller.getIsTickerPreApproved({ did }, { ticker });
+
+      expect(result).toEqual({ ticker, did, isPreApproved: true });
+    });
+  });
+
+  describe('getPreApprovedAssets', () => {
+    const paginatedResult = {
+      data: [new MockAsset()],
+      next: null,
+      count: new BigNumber(1),
+    };
+    it('should return pre-approved assets without start value', async () => {
+      mockIdentitiesService.getPreApprovedAssets.mockResolvedValue(
+        paginatedResult as ResultSet<MockAsset>
+      );
+
+      const result = await controller.getPreApprovedAssets({ did }, { size: new BigNumber(10) });
+      expect(result).toEqual({
+        total: paginatedResult.count,
+        next: paginatedResult.next,
+        results: [expect.objectContaining({ ticker, did, isPreApproved: true })],
+      });
+    });
+
+    it('should give pre-approved assets with start value', async () => {
+      mockIdentitiesService.getPreApprovedAssets.mockResolvedValue(
+        paginatedResult as ResultSet<MockAsset>
+      );
+      const result = await controller.getPreApprovedAssets(
+        { did },
+        { size: new BigNumber(10), start: new BigNumber(1) }
+      );
+      expect(result).toEqual({
+        total: paginatedResult.count,
+        next: paginatedResult.next,
+        results: [expect.objectContaining({ ticker, did, isPreApproved: true })],
       });
     });
   });

--- a/src/identities/identities.service.spec.ts
+++ b/src/identities/identities.service.spec.ts
@@ -252,4 +252,42 @@ describe('IdentitiesService', () => {
       expect(mockTransactionsService.submit).toHaveBeenCalled();
     });
   });
+
+  describe('isTickerPreApproved', () => {
+    it('should return if the asset is pre-approved', async () => {
+      const mockIdentity = new MockIdentity();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockIdentity as any);
+      mockIdentity.isAssetPreApproved.mockResolvedValue(true);
+
+      const result = await service.isTickerPreApproved('0x01', 'TICKER');
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe('getPreApprovedAssets', () => {
+    it('should return the pre-approved assets', async () => {
+      const mockAssets = {
+        data: [
+          {
+            ticker: 'TICKER',
+          },
+          {
+            ticker: 'TICKER2',
+          },
+        ],
+        next: new BigNumber(2),
+        count: new BigNumber(2),
+      };
+      const mockIdentity = new MockIdentity();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockIdentity as any);
+      mockIdentity.preApprovedAssets.mockResolvedValue(mockAssets);
+
+      const result = await service.getPreApprovedAssets('0x01', new BigNumber(2));
+      expect(result).toEqual(mockAssets);
+    });
+  });
 });

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -5,6 +5,7 @@ import {
   AuthorizationRequest,
   FungibleAsset,
   Identity,
+  NftCollection,
   RegisterIdentityParams,
   ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
@@ -137,5 +138,21 @@ export class IdentitiesService {
       { identity, targetAccount, expiry },
       options
     );
+  }
+
+  public async getPreApprovedAssets(
+    did: string,
+    size: BigNumber,
+    start?: string
+  ): Promise<ResultSet<FungibleAsset | NftCollection>> {
+    const identity = await this.findOne(did);
+
+    return identity.preApprovedAssets({ size, start });
+  }
+
+  public async isTickerPreApproved(did: string, ticker: string): Promise<boolean> {
+    const identity = await this.findOne(did);
+
+    return identity.isAssetPreApproved(ticker);
   }
 }

--- a/src/identities/models/pre-approved.model.ts
+++ b/src/identities/models/pre-approved.model.ts
@@ -1,0 +1,27 @@
+/** istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PreApprovedModel {
+  @ApiProperty({
+    description: 'The ticker that is subject to pre-approval',
+    example: 'TICKER',
+  })
+  readonly ticker: string;
+
+  @ApiProperty({
+    description: 'The DID for whom the asset is pre-approved for',
+    example: '0x0600000000000000000000000000000000000000000000000000000000000000',
+  })
+  readonly did: string;
+
+  @ApiProperty({
+    description: 'Whether or not the asset is pre-approved',
+    example: true,
+  })
+  isPreApproved: boolean;
+
+  constructor(model: PreApprovedModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -190,6 +190,8 @@ export class MockAsset {
 
   public settlements = {
     canTransfer: jest.fn(),
+    preApprove: jest.fn(),
+    removePreApproval: jest.fn(),
   };
 
   public compliance = {
@@ -295,6 +297,8 @@ export class MockIdentity {
   public getSecondaryAccounts = jest.fn();
   public getTrustingAssets = jest.fn();
   public getHeldAssets = jest.fn();
+  public preApprovedAssets = jest.fn();
+  public isAssetPreApproved = jest.fn();
 }
 
 export class MockPortfolio {

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -41,6 +41,8 @@ export class MockAssetService {
   getRequiredMediators = jest.fn();
   addRequiredMediators = jest.fn();
   removeRequiredMediators = jest.fn();
+  preApprove = jest.fn();
+  removePreApproval = jest.fn();
 }
 
 export class MockTransactionsService {
@@ -143,6 +145,8 @@ export class MockIdentitiesService {
   registerDid = jest.fn();
   rotatePrimaryKey = jest.fn();
   attestPrimaryKeyRotation = jest.fn();
+  isTickerPreApproved = jest.fn();
+  getPreApprovedAssets = jest.fn();
 }
 
 export class MockSettlementsService {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,10 +1990,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.2.0"
 
-"@polymeshassociation/polymesh-sdk@24.0.0-alpha.12":
-  version "24.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.0.0-alpha.12.tgz#7021b2591e48050d8e4074c4ba2ee9c6b58e2dba"
-  integrity sha512-sm6MZOnIFQiQUGc07Te7QKR9xBIripKFEOG6CNONyIVV2xzQCBbSR+zozF/kmsUkgEAYeIYxN5ywfFxLnlOfyA==
+"@polymeshassociation/polymesh-sdk@24.0.0-alpha.16":
+  version "24.0.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.0.0-alpha.16.tgz#6c71936c6dfb8a04c9a402ff04022b5924a5f2b8"
+  integrity sha512-wfkjk3sIt96d6ktPeV+hqPzCtM5n09sRuK5SCAi3b9meRGZ0yk96OOMWNuxmxOU+qJfi0/JPOHvj/vnXX0gi2Q==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "10.9.1"


### PR DESCRIPTION
### JIRA Link 

✅ Closes: [DA-1080](https://polymesh.atlassian.net/browse/DA-1080)

### Changelog / Description 

 adds `POST /assets/:ticker/{pre-approve, remove-pre-approval}` to allow
setting asset pre-approval. adds `GET
/identities/:did/{getIsTickerPreApproved, pre-approved-assets}` for fetching pre-approval status


### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-1080]: https://polymesh.atlassian.net/browse/DA-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Added functionality for pre-approving assets and removing pre-approval.
    - Introduced methods for fetching pre-approved assets and checking if a ticker symbol is pre-approved based on DID.

- **Tests**
    - Implemented new test cases for assets and identities related to pre-approval functionalities.

- **Documentation**
    - Added a new `PreApprovedModel` class with detailed properties.

- **Chores**
    - Updated dependencies to ensure compatibility and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->