### PR TITLE
feat: 🎸 add custom release bot configuration to sign commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
@@ -29,7 +31,9 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
@@ -46,6 +50,8 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
@@ -61,14 +67,41 @@ jobs:
     needs: [lint, build, test]
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile
+      - name: Setup SSH signing key
+        run: |
+          echo "$SSH_KEY_PRIVATE" | tr -d '\r' > /tmp/id_ed25519
+          echo $SSH_KEY_PUBLIC > /tmp/id_ed25519.pub
+          chmod 600 /tmp/id_ed25519
+          eval "$(ssh-agent -s)"
+          ssh-add /tmp/id_ed25519
+          git config --global gpg.format ssh
+          git config --global commit.gpgsign true
+          git config --global user.signingkey /tmp/id_ed25519.pub
+          mkdir -p ~/.config/git
+          echo "${{ vars.RB_EMAIL }} $SSH_KEY_PUBLIC" > ~/.config/git/allowed_signers
+          git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers
+        shell: bash
+        env:
+          SSH_KEY_PRIVATE: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KEY_PUBLIC: ${{ vars.SSH_PUBLIC_KEY }}
       - name: release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_RELEASE_BOT_PAT }}
+          GIT_AUTHOR_NAME: ${{ vars.RB_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.RB_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.RB_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.RB_COMMITTER_EMAIL }}
         run: yarn semantic-release
+      - name: Clear SSH key
+        run: |
+          shred /tmp/id_ed25519
 # TODO @polymath-eric: add SonarCloud step when the account confusion is sorted

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'


### PR DESCRIPTION
### JIRA Link 

### Changelog / Description 

This configures semantic release bot to use custom identity and to sing commits using our key.

### Checklist - 

- [x] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
    - Updated GitHub Actions workflow to include `fetch-depth: 1` parameter for optimized performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->