### PR TITLE
feat: 🎸 Add API to get account to identity lookup

### DIFF
--- a/src/accounts/accounts.service.spec.ts
+++ b/src/accounts/accounts.service.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/first */
 const mockIsPolymeshTransaction = jest.fn();
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { ExtrinsicsOrderBy } from '@polymeshassociation/polymesh-sdk/middleware/types';
@@ -14,7 +13,13 @@ import { PolymeshModule } from '~/polymesh/polymesh.module';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { SigningModule } from '~/signing/signing.module';
 import { extrinsic, testValues } from '~/test-utils/consts';
-import { MockAccount, MockAsset, MockPolymesh, MockTransaction } from '~/test-utils/mocks';
+import {
+  MockAccount,
+  MockAsset,
+  MockIdentity,
+  MockPolymesh,
+  MockTransaction,
+} from '~/test-utils/mocks';
 import { mockTransactionsProvider, MockTransactionsService } from '~/test-utils/service-mocks';
 import * as transactionsUtilModule from '~/transactions/transactions.util';
 
@@ -84,6 +89,22 @@ describe('AccountsService', () => {
 
         expect(handleSdkErrorSpy).toHaveBeenCalledWith(mockError);
       });
+    });
+  });
+
+  describe('getIdentity', () => {
+    it('should return the Identity associated with a given address', async () => {
+      const mockAccount = new MockAccount();
+
+      const findOneSpy = jest.spyOn(service, 'findOne');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      findOneSpy.mockResolvedValue(mockAccount as any);
+
+      const mockResult = new MockIdentity();
+      mockAccount.getIdentity.mockResolvedValue(mockResult);
+
+      const result = await service.getIdentity('address');
+      expect(result).toEqual(mockResult);
     });
   });
 

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -3,6 +3,7 @@ import {
   Account,
   AccountBalance,
   ExtrinsicData,
+  Identity,
   Permissions,
   ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
@@ -31,6 +32,11 @@ export class AccountsService {
     return await polymeshApi.accountManagement.getAccount({ address }).catch(error => {
       throw handleSdkError(error);
     });
+  }
+
+  public async getIdentity(address: string): Promise<Identity | null> {
+    const account = await this.findOne(address);
+    return account.getIdentity();
   }
 
   public async getAccountBalance(account: string): Promise<AccountBalance> {

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -104,6 +104,7 @@ export class MockAccountsService {
   modifyPermissions = jest.fn();
   revokePermissions = jest.fn();
   getTreasuryAccount = jest.fn();
+  getIdentity = jest.fn();
 }
 
 export class MockEventsService {


### PR DESCRIPTION
### JIRA Link 

DA-1124

### Changelog / Description 

Add API to get account to identity lookup

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `getIdentity` feature to fetch and display the Decentralized Identifier (DID) associated with an account.
- **Tests**
	- Added new tests for the `getIdentity` method to ensure it correctly handles scenarios with no identity associated with an account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->