### PR TITLE
feat: 🎸 return legs information when creating instruction

### DIFF
--- a/src/settlements/models/created-instruction.model.ts
+++ b/src/settlements/models/created-instruction.model.ts
@@ -2,9 +2,11 @@
 
 import { ApiProperty } from '@nestjs/swagger';
 import { Instruction } from '@polymeshassociation/polymesh-sdk/types';
+import { Type } from 'class-transformer';
 
 import { FromEntity } from '~/common/decorators/transformation';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
+import { LegModel } from '~/settlements/models/leg.model';
 
 export class CreatedInstructionModel extends TransactionQueueModel {
   @ApiProperty({
@@ -14,6 +16,14 @@ export class CreatedInstructionModel extends TransactionQueueModel {
   })
   @FromEntity()
   readonly instruction: Instruction;
+
+  @ApiProperty({
+    description: 'List of Legs in the Instruction',
+    type: LegModel,
+    isArray: true,
+  })
+  @Type(() => LegModel)
+  readonly legs: LegModel[];
 
   constructor(model: CreatedInstructionModel) {
     const { transactions, details, ...rest } = model;

--- a/src/settlements/settlements.controller.spec.ts
+++ b/src/settlements/settlements.controller.spec.ts
@@ -10,6 +10,7 @@ import {
   TransferError,
   VenueType,
 } from '@polymeshassociation/polymesh-sdk/types';
+import { when } from 'jest-when';
 
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { createPortfolioIdentifierModel } from '~/portfolios/portfolios.util';
@@ -105,9 +106,13 @@ describe('SettlementsController', () => {
 
   describe('createInstruction', () => {
     it('should create an instruction and return the data returned by the service', async () => {
+      const mockInstruction = new MockInstruction();
+
+      when(mockInstruction.getLegs).calledWith().mockResolvedValue({ data: [] });
+
       const mockData = {
         ...txResult,
-        result: 'fakeInstruction',
+        result: mockInstruction,
       };
       mockSettlementsService.createInstruction.mockResolvedValue(mockData);
 
@@ -116,7 +121,8 @@ describe('SettlementsController', () => {
 
       expect(result).toEqual({
         ...txResult,
-        instruction: 'fakeInstruction',
+        instruction: mockInstruction, // in jest the @FromEntity decorator is not applied
+        legs: [],
       });
     });
   });

--- a/src/settlements/settlements.controller.ts
+++ b/src/settlements/settlements.controller.ts
@@ -29,7 +29,7 @@ import { InstructionAffirmationModel } from '~/settlements/models/instruction-af
 import { TransferBreakdownModel } from '~/settlements/models/transfer-breakdown.model';
 import { VenueDetailsModel } from '~/settlements/models/venue-details.model';
 import { SettlementsService } from '~/settlements/settlements.service';
-import { createInstructionModel } from '~/settlements/settlements.util';
+import { createInstructionModel, legsToLegModel } from '~/settlements/settlements.util';
 
 @ApiTags('settlements')
 @Controller()
@@ -81,16 +81,20 @@ export class SettlementsController {
   ): Promise<TransactionResponseModel> {
     const serviceResult = await this.settlementsService.createInstruction(id, createInstructionDto);
 
-    const resolver: TransactionResolver<Instruction> = ({
+    const resolver: TransactionResolver<Instruction> = async ({
       result: instruction,
       transactions,
       details,
-    }) =>
-      new CreatedInstructionModel({
+    }) => {
+      const { data: legs } = await instruction.getLegs();
+
+      return new CreatedInstructionModel({
         instruction,
         details,
         transactions,
+        legs: legsToLegModel(legs),
       });
+    };
 
     return handleServiceResult(serviceResult, resolver);
   }

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -262,6 +262,12 @@ export class MockInstruction {
   public affirmAsMediator = jest.fn();
   public rejectAsMediator = jest.fn();
   public withdrawAsMediator = jest.fn();
+  public toHuman = jest.fn().mockImplementation(() => {
+    return {
+      id: '1',
+      did,
+    };
+  });
 }
 
 export class MockVenue {


### PR DESCRIPTION

This reverts commit 395cf22aaee0e5bc11ffd2a70207107bd45d17d4.

### JIRA Link 

https://polymesh.atlassian.net/browse/DA-1122


### Changelog / Description 

Returns legs information when creating an instruction

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [x] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property to track multiple legs in a settlement instruction, enhancing detail and accuracy in transaction records.
- **Tests**
	- Improved testing robustness with enhanced mocking capabilities, ensuring more reliable outcomes.
- **Refactor**
	- Optimized settlements processing by isolating leg transformation logic, improving code maintainability and readability.
- **Chores**
	- Enhanced mock utilities with additional methods for more comprehensive testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->