### PR TITLE
feat: get accountDetails

### DIFF
--- a/src/accounts/accounts.controller.spec.ts
+++ b/src/accounts/accounts.controller.spec.ts
@@ -4,6 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
   ExtrinsicsOrderBy,
+  Identity,
   PermissionType,
   TxGroup,
   TxTags,
@@ -11,12 +12,14 @@ import {
 import { Response } from 'express';
 
 import { AccountsController } from '~/accounts/accounts.controller';
-import { AccountsService } from '~/accounts/accounts.service';
+import { AccountDetails, AccountsService } from '~/accounts/accounts.service';
 import { PermissionedAccountDto } from '~/accounts/dto/permissioned-account.dto';
 import { ExtrinsicModel } from '~/common/models/extrinsic.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { PermissionsLikeDto } from '~/identities/dto/permissions-like.dto';
+import * as identityUtil from '~/identities/identities.util';
 import { AccountModel } from '~/identities/models/account.model';
+import { IdentityModel } from '~/identities/models/identity.model';
 import { IdentitySignerModel } from '~/identities/models/identity-signer.model';
 import { NetworkService } from '~/network/network.service';
 import { SubsidyService } from '~/subsidy/subsidy.service';
@@ -289,6 +292,24 @@ describe('AccountsController', () => {
       const result = controller.getTreasuryAccount();
 
       expect(result).toEqual(new AccountModel({ address: testAccount.address }));
+    });
+  });
+
+  describe('getDetails', () => {
+    it('should call the service and return AccountDetailsModel', async () => {
+      const fakeIdentityModel = 'fakeIdentityModel' as unknown as IdentityModel;
+      jest.spyOn(identityUtil, 'createIdentityModel').mockResolvedValue(fakeIdentityModel);
+
+      const mockResponse: AccountDetails = {
+        identity: new MockIdentity() as unknown as Identity,
+        multiSigDetails: null,
+      };
+
+      mockAccountsService.getDetails.mockReturnValue(mockResponse);
+
+      const result = await controller.getAccountDetails({ account: '5xdd' });
+
+      expect(result).toEqual({ identity: fakeIdentityModel });
     });
   });
 });

--- a/src/accounts/accounts.service.spec.ts
+++ b/src/accounts/accounts.service.spec.ts
@@ -3,7 +3,7 @@ const mockIsPolymeshTransaction = jest.fn();
 import { Test, TestingModule } from '@nestjs/testing';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { ExtrinsicsOrderBy } from '@polymeshassociation/polymesh-sdk/middleware/types';
-import { PermissionType, TxGroup, TxTags } from '@polymeshassociation/polymesh-sdk/types';
+import { Account, PermissionType, TxGroup, TxTags } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AccountsService } from '~/accounts/accounts.service';
 import { PermissionedAccountDto } from '~/accounts/dto/permissioned-account.dto';
@@ -17,6 +17,7 @@ import {
   MockAccount,
   MockAsset,
   MockIdentity,
+  MockMultiSig,
   MockPolymesh,
   MockTransaction,
 } from '~/test-utils/mocks';
@@ -355,6 +356,30 @@ describe('AccountsService', () => {
         { secondaryAccounts: [{ account, permissions }] },
         expect.objectContaining({ signer })
       );
+    });
+  });
+
+  describe('getDetails', () => {
+    it('should return the Account details', async () => {
+      const mockAccount = new MockAccount();
+      const mockIdentity = new MockIdentity();
+      const mockMultiSig = new MockMultiSig();
+
+      const findOneSpy = jest.spyOn(service, 'findOne');
+      findOneSpy.mockResolvedValue(mockAccount as unknown as Account);
+
+      mockMultiSig.details.mockResolvedValue({ signers: [], requiredSignatures: new BigNumber(2) });
+      mockAccount.getIdentity.mockResolvedValue(mockIdentity);
+      mockAccount.getMultiSig.mockResolvedValue(mockMultiSig);
+
+      const result = await service.getDetails('address');
+
+      const fakeResult = {
+        identity: mockIdentity,
+        multiSigDetails: { signers: [], requiredSignatures: new BigNumber(2) },
+      };
+
+      expect(result).toStrictEqual(fakeResult);
     });
   });
 });

--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -4,6 +4,8 @@ import {
   AccountBalance,
   ExtrinsicData,
   Identity,
+  MultiSig,
+  MultiSigDetails,
   Permissions,
   ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
@@ -17,6 +19,11 @@ import { extractTxOptions, ServiceReturn } from '~/common/utils';
 import { PolymeshService } from '~/polymesh/polymesh.service';
 import { TransactionsService } from '~/transactions/transactions.service';
 import { handleSdkError } from '~/transactions/transactions.util';
+
+export type AccountDetails = {
+  identity: Identity | null;
+  multiSigDetails: MultiSigDetails | null;
+};
 
 @Injectable()
 export class AccountsService {
@@ -113,5 +120,26 @@ export class AccountsService {
       },
       options
     );
+  }
+
+  private async getMultiSigDetails(multiSig: MultiSig | null): Promise<MultiSigDetails | null> {
+    if (!multiSig) {
+      return null;
+    }
+
+    return await multiSig.details();
+  }
+
+  public async getDetails(address: string): Promise<AccountDetails> {
+    const account = await this.findOne(address);
+
+    const [identity, multiSig] = await Promise.all([account.getIdentity(), account.getMultiSig()]);
+
+    const multiSigDetails = await this.getMultiSigDetails(multiSig);
+
+    return {
+      identity,
+      multiSigDetails,
+    };
   }
 }

--- a/src/accounts/models/account-details.model.ts
+++ b/src/accounts/models/account-details.model.ts
@@ -1,0 +1,27 @@
+/* istanbul ignore file */
+
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+import { MultiSigDetailsModel } from '~/accounts/models/multi-sig-details.model';
+import { IdentityModel } from '~/identities/models/identity.model';
+
+export class AccountDetailsModel {
+  @ApiPropertyOptional({
+    description: 'Static data (and identifiers) of the newly created Identity',
+    type: IdentityModel,
+  })
+  @Type(() => IdentityModel)
+  readonly identity?: IdentityModel;
+
+  @ApiPropertyOptional({
+    description: 'MultiSig Account details',
+    type: MultiSigDetailsModel,
+  })
+  @Type(() => MultiSigDetailsModel)
+  readonly multiSig?: MultiSigDetailsModel;
+
+  constructor(model: AccountDetailsModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/accounts/models/multi-sig-details.model.ts
+++ b/src/accounts/models/multi-sig-details.model.ts
@@ -1,0 +1,30 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+import { Type } from 'class-transformer';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+import { SignerModel } from '~/identities/models/signer.model';
+
+export class MultiSigDetailsModel {
+  @ApiProperty({
+    description: 'Secondary accounts with permissions',
+    isArray: true,
+    type: SignerModel,
+  })
+  @Type(() => SignerModel)
+  readonly signers: SignerModel[];
+
+  @ApiProperty({
+    description: 'Required signers',
+    type: 'string',
+    example: '2',
+  })
+  @FromBigNumber()
+  readonly requiredSignatures: BigNumber;
+
+  constructor(model: MultiSigDetailsModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -455,10 +455,15 @@ export class MockAccount {
   getPermissions = jest.fn();
   getIdentity = jest.fn();
   getSubsidy = jest.fn();
+  getMultiSig = jest.fn();
 
   constructor(address = 'address') {
     this.address = address;
   }
+}
+
+export class MockMultiSig {
+  details = jest.fn();
 }
 
 export function createMockMetadataEntry(

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -105,6 +105,7 @@ export class MockAccountsService {
   revokePermissions = jest.fn();
   getTreasuryAccount = jest.fn();
   getIdentity = jest.fn();
+  getDetails = jest.fn();
 }
 
 export class MockEventsService {


### PR DESCRIPTION
### JIRA Link 

https://polymesh.atlassian.net/browse/DA-930

### Changelog / Description 

- adds an endpoint GET /accounts/:account to fetch account details (primary,secondary key with permissions) and multiSig details if the account is multiSig
- 
### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [x] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced account management with new details retrieval for identity and multi-signature configurations.
	- Introduced new models for account and multi-signature details, enhancing data structure clarity and API documentation.
	- Improved signing capabilities with the addition of identity details in signer models.

- **Bug Fixes**
	- Adjusted account details fetching mechanism to include comprehensive identity and multi-signature information.

- **Refactor**
	- Refined service and controller layers to integrate new account and signing functionalities seamlessly.

- **Tests**
	- Expanded testing suite to cover new functionalities and models related to accounts and signing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->