### PR TITLE
fix: 🐛 test admins endpoint when using signing manager

### DIFF
--- a/src/developer-testing/developer-testing.service.spec.ts
+++ b/src/developer-testing/developer-testing.service.spec.ts
@@ -137,7 +137,7 @@ describe('DeveloperTestingService', () => {
       await service.createTestAccounts(params);
 
       expect(polymeshService.execTransaction).toHaveBeenCalledWith(
-        defaultAdminAddress,
+        expect.objectContaining({ address: defaultAdminAddress }),
         expect.anything(),
         expect.anything()
       );

--- a/src/developer-testing/developer-testing.service.ts
+++ b/src/developer-testing/developer-testing.service.ts
@@ -52,7 +52,7 @@ export class DeveloperTestingService {
 
     const signerAddress = signer
       ? await this.signingService.getAddressByHandle(signer)
-      : this.sudoPair.address;
+      : this.sudoPair;
 
     // Create a DID to attach claim too
     const createDidCalls = accounts.map(({ address }) => identity.cddRegisterDid(address, []));


### PR DESCRIPTION
### JIRA Link 

None

### Changelog / Description 

fix test admin endpoint by passing key pair instead of address to avoid an address lookup

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test reliability for `execTransaction` method in `DeveloperTestingService`.
  - Fixed an issue with `signerAddress` assignment in `DeveloperTestingService` to ensure correct address handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->