### PR TITLE
feat: 🎸 get the current/max complexity of all asset schedules

### DIFF
--- a/src/checkpoints/checkpoints.controller.spec.ts
+++ b/src/checkpoints/checkpoints.controller.spec.ts
@@ -6,6 +6,7 @@ import { CheckpointsController } from '~/checkpoints/checkpoints.controller';
 import { CheckpointsService } from '~/checkpoints/checkpoints.service';
 import { CheckpointDetailsModel } from '~/checkpoints/models/checkpoint-details.model';
 import { CheckpointScheduleModel } from '~/checkpoints/models/checkpoint-schedule.model';
+import { ScheduleComplexityModel } from '~/checkpoints/models/schedule-complexity.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ResultsModel } from '~/common/models/results.model';
 import { testValues } from '~/test-utils/consts';
@@ -319,6 +320,38 @@ describe('CheckpointsController', () => {
 
       const result = await controller.getCheckpointsBySchedule({ ticker, id });
       expect(result).toEqual([new CheckpointDetailsModel({ id, totalSupply, createdAt })]);
+    });
+  });
+  
+  describe('getComplexity', () => {
+    it('should return the transaction details', async () => {
+      const maxComplexity = new BigNumber(10);
+      const id = new BigNumber(1);
+      const pendingPoints = [new Date()];
+
+      const mockSchedules = [
+        {
+          schedule: {
+            id: new BigNumber(1),
+            pendingPoints,
+          },
+        },
+      ];
+
+      mockCheckpointsService.getComplexityForAsset.mockResolvedValue({
+        schedules: mockSchedules,
+        maxComplexity,
+      });
+
+      const result = await controller.getComplexity({ ticker: 'TICKER' });
+
+      expect(result).toEqual([
+        new ScheduleComplexityModel({
+          id,
+          maxComplexity,
+          currentComplexity: new BigNumber(pendingPoints.length),
+        }),
+      ]);
     });
   });
 });

--- a/src/checkpoints/checkpoints.service.spec.ts
+++ b/src/checkpoints/checkpoints.service.spec.ts
@@ -29,6 +29,24 @@ jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
 }));
 
 const { signer } = testValues;
+const mockSchedules = [
+  {
+    schedule: {
+      id: new BigNumber(1),
+      period: {
+        unit: CalendarUnit.Month,
+        amount: new BigNumber(3),
+      },
+      start: new Date(),
+      complexity: new BigNumber(4),
+      expiryDate: null,
+    },
+    details: {
+      remainingCheckpoints: new BigNumber(1),
+      nextCheckpointDate: new Date(),
+    },
+  },
+];
 
 describe('CheckpointsService', () => {
   let service: CheckpointsService;
@@ -130,25 +148,6 @@ describe('CheckpointsService', () => {
 
   describe('findSchedulesByTicker', () => {
     it('should return the list of active Checkpoint Schedules for an Asset', async () => {
-      const mockSchedules = [
-        {
-          schedule: {
-            id: new BigNumber(1),
-            period: {
-              unit: CalendarUnit.Month,
-              amount: new BigNumber(3),
-            },
-            start: new Date(),
-            complexity: new BigNumber(4),
-            expiryDate: null,
-          },
-          details: {
-            remainingCheckpoints: new BigNumber(1),
-            nextCheckpointDate: new Date(),
-          },
-        },
-      ];
-
       const mockAsset = new MockAsset();
       mockAsset.checkpoints.schedules.get.mockResolvedValue(mockSchedules);
 
@@ -456,6 +455,26 @@ describe('CheckpointsService', () => {
       expect(mockAsset.checkpoints.schedules.getOne).toHaveBeenCalledWith({
         id,
       });
+    });
+  });
+
+  describe('getComplexityForAsset', () => {
+    it('should return a maxComplexity and schedules for a valid ticker', async () => {
+      const maxComplexity = new BigNumber(1);
+      const mockResult = {
+        schedules: mockSchedules,
+        maxComplexity,
+      };
+
+      const mockAsset = new MockAsset();
+      mockAsset.checkpoints.schedules.get.mockResolvedValue(mockSchedules);
+      mockAsset.checkpoints.schedules.maxComplexity.mockResolvedValue(maxComplexity);
+
+      mockAssetsService.findFungible.mockResolvedValue(mockAsset);
+
+      const result = await service.getComplexityForAsset('TICKER');
+      expect(result).toEqual(mockResult);
+      expect(mockAssetsService.findFungible).toBeCalledWith('TICKER');
     });
   });
 });

--- a/src/checkpoints/models/schedule-complexity.model.ts
+++ b/src/checkpoints/models/schedule-complexity.model.ts
@@ -1,0 +1,36 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+
+export class ScheduleComplexityModel {
+  @ApiProperty({
+    description: 'ID of the Schedule',
+    type: 'string',
+    example: '123',
+  })
+  @FromBigNumber()
+  readonly id: BigNumber;
+
+  @ApiProperty({
+    description: 'Maximum allowed complexity for the Schedule',
+    type: 'string',
+    example: '50',
+  })
+  @FromBigNumber()
+  readonly maxComplexity: BigNumber;
+
+  @ApiProperty({
+    description: 'Current complexity of the Schedule (pending checkpoints)',
+    type: 'string',
+    example: '3',
+  })
+  @FromBigNumber()
+  readonly currentComplexity: BigNumber;
+
+  constructor(model: ScheduleComplexityModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -222,6 +222,7 @@ export class MockAsset {
       getOne: jest.fn(),
       create: jest.fn(),
       remove: jest.fn(),
+      maxComplexity: jest.fn(),
     },
   };
 

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -220,6 +220,7 @@ export class MockCheckpointsService {
   deleteScheduleByTicker = jest.fn();
   findOne = jest.fn();
   findCheckpointsByScheduleId = jest.fn();
+  getComplexityForAsset = jest.fn();
 }
 
 export class MockAuthService {


### PR DESCRIPTION
### JIRA Link 

https://polymesh.atlassian.net/browse/DA-87

### Changelog / Description 

adds endpoint to get the current/max complexity of all schedules associated to an asset 

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [x] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to retrieve asset schedule complexity information.
	- Added functions for interacting with asset checkpoints, including schedule management and balance retrieval.

- **Tests**
	- Enhanced test coverage for new complexity retrieval functionality and schedule management.

- **Chores**
	- Updated authentication script for better handling of variables with special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->