### PR TITLE
feat: 🎸 get complexity for period

### DIFF
--- a/src/checkpoints/checkpoints.controller.ts
+++ b/src/checkpoints/checkpoints.controller.ts
@@ -17,10 +17,12 @@ import { CheckpointsService } from '~/checkpoints/checkpoints.service';
 import { CheckpointParamsDto } from '~/checkpoints/dto/checkpoint.dto';
 import { CheckPointBalanceParamsDto } from '~/checkpoints/dto/checkpoint-balance.dto';
 import { CreateCheckpointScheduleDto } from '~/checkpoints/dto/create-checkpoint-schedule.dto';
+import { PeriodQueryDto } from '~/checkpoints/dto/period-query.dto';
 import { CheckpointDetailsModel } from '~/checkpoints/models/checkpoint-details.model';
 import { CheckpointScheduleModel } from '~/checkpoints/models/checkpoint-schedule.model';
 import { CreatedCheckpointModel } from '~/checkpoints/models/created-checkpoint.model';
 import { CreatedCheckpointScheduleModel } from '~/checkpoints/models/created-checkpoint-schedule.model';
+import { PeriodComplexityModel } from '~/checkpoints/models/period-complexity.model';
 import { ScheduleComplexityModel } from '~/checkpoints/models/schedule-complexity.model';
 import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
 import { IsTicker } from '~/common/decorators/validation';
@@ -463,7 +465,7 @@ export class CheckpointsController {
         new CheckpointDetailsModel({ id, createdAt, totalSupply })
     );
   }
-  
+
   @ApiOperation({
     summary: 'Fetch Asset Schedules complexity',
   })
@@ -495,6 +497,54 @@ export class CheckpointsController {
         maxComplexity,
         currentComplexity: new BigNumber(schedule.pendingPoints.length),
       });
+    });
+  }
+
+  @ApiOperation({
+    summary: 'Fetch details of an Asset Checkpoint Schedule',
+  })
+  @ApiParam({
+    name: 'ticker',
+    description: 'The ticker of the Asset whose Checkpoint Schedule is to be fetched',
+    type: 'string',
+    example: 'TICKER',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The ID of the Checkpoint Schedule to be fetched',
+    type: 'string',
+    example: '1',
+  })
+  @ApiQuery({
+    name: 'start',
+    description: 'Start date for the period for which to fetch complexity',
+    type: 'string',
+    required: false,
+    example: '2021-01-01',
+  })
+  @ApiQuery({
+    name: 'end',
+    description: 'End date for the period for which to fetch complexity',
+    type: 'string',
+    required: false,
+    example: '2021-01-31',
+  })
+  @ApiOkResponse({
+    description: 'The complexity of the Schedule for the given period',
+    type: ScheduleComplexityModel,
+  })
+  @ApiNotFoundResponse({
+    description: 'Either the Asset or the Checkpoint Schedule does not exist',
+  })
+  @Get('schedules/:id/complexity')
+  public async getPeriodComplexity(
+    @Param() { ticker, id }: CheckpointScheduleParamsDto,
+    @Query() { start, end }: PeriodQueryDto
+  ): Promise<PeriodComplexityModel> {
+    const complexity = await this.checkpointsService.getComplexityForPeriod(ticker, id, start, end);
+
+    return new PeriodComplexityModel({
+      complexity,
     });
   }
 }

--- a/src/checkpoints/checkpoints.service.ts
+++ b/src/checkpoints/checkpoints.service.ts
@@ -152,4 +152,27 @@ export class CheckpointsService {
 
     return { schedules, maxComplexity };
   }
+
+  public async getComplexityForPeriod(
+    ticker: string,
+    id: BigNumber,
+    start?: Date,
+    end?: Date
+  ): Promise<BigNumber> {
+    const { schedule } = await this.findScheduleById(ticker, id);
+
+    const checkpoints = await schedule.getCheckpoints();
+    const pendingPoints = schedule.pendingPoints;
+    const checkpointDatePromises = checkpoints.map(checkpoint => checkpoint.createdAt());
+
+    const pastCheckpoints = await Promise.all(checkpointDatePromises);
+
+    const allCheckpoints = [...pendingPoints, ...pastCheckpoints];
+
+    const checkpointsInPeriod = allCheckpoints.filter(
+      date => (!start || date >= start) && (!end || date <= end)
+    );
+
+    return new BigNumber(checkpointsInPeriod.length);
+  }
 }

--- a/src/checkpoints/dto/period-query.dto.ts
+++ b/src/checkpoints/dto/period-query.dto.ts
@@ -1,0 +1,13 @@
+/* istanbul ignore file */
+
+import { IsDate, IsOptional } from 'class-validator';
+
+export class PeriodQueryDto {
+  @IsOptional()
+  @IsDate()
+  readonly start?: Date;
+
+  @IsOptional()
+  @IsDate()
+  readonly end?: Date;
+}

--- a/src/checkpoints/models/period-complexity.model.ts
+++ b/src/checkpoints/models/period-complexity.model.ts
@@ -1,0 +1,20 @@
+/* istanbul ignore file */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { BigNumber } from '@polymeshassociation/polymesh-sdk';
+
+import { FromBigNumber } from '~/common/decorators/transformation';
+
+export class PeriodComplexityModel {
+  @ApiProperty({
+    description: 'Total calculated complexity for given period',
+    type: 'string',
+    example: '10000',
+  })
+  @FromBigNumber()
+  readonly complexity: BigNumber;
+
+  constructor(model: PeriodComplexityModel) {
+    Object.assign(this, model);
+  }
+}

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -221,6 +221,7 @@ export class MockCheckpointsService {
   findOne = jest.fn();
   findCheckpointsByScheduleId = jest.fn();
   getComplexityForAsset = jest.fn();
+  getComplexityForPeriod = jest.fn();
 }
 
 export class MockAuthService {


### PR DESCRIPTION
### JIRA Link 

https://polymesh.atlassian.net/browse/DA-86

### Changelog / Description 

- calculates complexity based on number of checkpoints for a schedule in a given period

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [x] Updated the Readme.md (if required) ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to retrieve the complexity of an asset checkpoint schedule for a given period.
  - Added the ability to query checkpoints based on an optional start and end date.

- **Bug Fixes**
  - Enhanced commit authentication workflow to handle spaces or special characters in signers' names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->