### PR TITLE
feat: 🎸 persist webhook state with repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If using the project's compose file, an Artemis console will be exposed on `:818
 
 ### Webhooks (alpha)
 
-Normally the endpoints that create transactions wait for block finalization before returning a response, which normally takes around 15 seconds. When processMode `submitAndCallback` is used the `webhookUrl` param must also be provided. The server will respond after submitting the transaction to the mempool with 202 (Accepted) status code instead of the usual 201 (Created).
+Normally the endpoints that create transactions wait for block finalization before returning a response, which normally takes around 15 seconds. When processMode `submitWithCallback` is used the `webhookUrl` param must also be provided. The server will respond after submitting the transaction to the mempool with 202 (Accepted) status code instead of the usual 201 (Created).
 
 Before sending any information to the endpoint the service will first make a request with the header `x-hook-secret` set to a value. The endpoint should return a `200` response with this header copied into the response headers.
 
@@ -223,9 +223,6 @@ Currently there are two datastore available:
 To implement a new repo for a service, first define an abstract class describing the desired interface. Also write a test suite to specify the expected behavior from an implementation. Then in the concrete implementations define a new Repo that satisfies the test suite.
 
 To implement a new datastore create a new module in `~/datastores` and create a set of `Repos` that will implement the abstract classes. You will then need to set up the `DatastoreModule` to export the module when it is configured. For testing, each implemented Repo should be able to pass the `test` method defined on the abstract class it is implementing.
-
-
-
 
 ### With docker
 

--- a/compose/init-db.sh
+++ b/compose/init-db.sh
@@ -2,6 +2,7 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE EXTENSION IF NOT EXISTS btree_gist;
     SELECT 'CREATE DATABASE rest'
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'rest')\gexec
 EOSQL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
     command: [ '--alice --chain dev' ]
     healthcheck:
       test: "timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/9933' && exit 0 || exit 1"
-      interval: 10s
+      interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 20
       start_period: 10s
 
   subquery:
@@ -27,7 +27,10 @@ services:
     init: true
     restart: unless-stopped
     depends_on:
-      - 'postgres'
+     postgres:
+        condition: service_started
+     chain:
+        condition: service_healthy
     environment:
       START_BLOCK: 1
       NETWORK_ENDPOINT: ws://chain:9944
@@ -44,13 +47,13 @@ services:
       - --local
     healthcheck:
       test: curl --fail http://localhost:3000/meta || exit 1
-      interval: 20s
-      retries: 10
+      interval: 10s
+      retries: 20
       start_period: 20s
       timeout: 10s
 
   graphql:
-    image: onfinality/subql-query:v1.0.0
+    image: onfinality/subql-query:v2.13.0
     restart: unless-stopped
     ports:
       - ${SQ_PORT:-3001}:3000
@@ -95,9 +98,9 @@ services:
       POSTGRES_PASSWORD: $REST_POSTGRES_PASSWORD
     healthcheck:
       test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      interval: 3s
+      timeout: 3s
+      retries: 10
 
 volumes:
   db-data:

--- a/src/common/decorators/swagger.ts
+++ b/src/common/decorators/swagger.ts
@@ -181,7 +181,7 @@ export const ApiPropertyOneOf = ({
 };
 
 /**
- * A helper that functions like `ApiCreatedResponse`, that also adds an `ApiAccepted` response in case "submitAndCallback" is used and `ApiOKResponse` if "offline" mode is used
+ * A helper that functions like `ApiCreatedResponse`, that also adds an `ApiAccepted` response in case "submitWithCallback" is used and `ApiOKResponse` if "offline" mode is used
  *
  * @param options - these will be passed to the `ApiCreatedResponse` decorator
  */
@@ -197,7 +197,7 @@ export function ApiTransactionResponse(
     ApiCreatedResponse(options),
     ApiAcceptedResponse({
       description:
-        'Returned if `"processMode": "submitAndCallback"` is passed in `options`. A response will be returned after the transaction has been validated. The result will be posted to the `webhookUrl` given when the transaction is completed',
+        'Returned if `"processMode": "submitWithCallback"` is passed in `options`. A response will be returned after the transaction has been validated. The result will be posted to the `webhookUrl` given when the transaction is completed',
       type: NotificationPayloadModel,
     })
   );

--- a/src/datastore/local-store/local-store.module.ts
+++ b/src/datastore/local-store/local-store.module.ts
@@ -5,11 +5,15 @@ import { ConfigModule } from '@nestjs/config';
 
 import { ApiKeyRepo } from '~/auth/repos/api-key.repo';
 import { LocalApiKeysRepo } from '~/datastore/local-store/repos/api-key.repo';
+import { LocalNotificationRepo } from '~/datastore/local-store/repos/notification.repo';
 import { LocalOfflineEventRepo } from '~/datastore/local-store/repos/offline-event.repo';
 import { LocalOfflineTxRepo } from '~/datastore/local-store/repos/offline-tx.repo';
+import { LocalSubscriptionRepo } from '~/datastore/local-store/repos/subscription.repo';
 import { LocalUserRepo } from '~/datastore/local-store/repos/users.repo';
+import { NotificationRepo } from '~/notifications/repo/notifications.repo';
 import { OfflineEventRepo } from '~/offline-recorder/repo/offline-event.repo';
 import { OfflineTxRepo } from '~/offline-submitter/repos/offline-tx.repo';
+import { SubscriptionRepo } from '~/subscriptions/repo/subscription.repo';
 import { UsersRepo } from '~/users/repo/user.repo';
 
 /**
@@ -28,7 +32,16 @@ import { UsersRepo } from '~/users/repo/user.repo';
       useClass: LocalOfflineEventRepo,
     },
     { provide: OfflineTxRepo, useClass: LocalOfflineTxRepo },
+    { provide: SubscriptionRepo, useClass: LocalSubscriptionRepo },
+    { provide: NotificationRepo, useClass: LocalNotificationRepo },
   ],
-  exports: [ApiKeyRepo, UsersRepo, OfflineEventRepo, OfflineTxRepo],
+  exports: [
+    ApiKeyRepo,
+    UsersRepo,
+    OfflineEventRepo,
+    OfflineTxRepo,
+    SubscriptionRepo,
+    NotificationRepo,
+  ],
 })
 export class LocalStoreModule {}

--- a/src/datastore/local-store/repos/__snapshots__/notification.repo.spec.ts.snap
+++ b/src/datastore/local-store/repos/__snapshots__/notification.repo.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LocalNotificationRepo Notification test suite method: create should create a notification 1`] = `
+{
+  "eventId": 0,
+  "id": 1,
+  "nonce": 1,
+  "status": "active",
+  "subscriptionId": 1,
+  "triesLeft": 10,
+}
+`;
+
+exports[`LocalNotificationRepo Notification test suite method: findById should find the created notification 1`] = `
+{
+  "eventId": 0,
+  "id": 1,
+  "nonce": 1,
+  "status": "active",
+  "subscriptionId": 1,
+  "triesLeft": 10,
+}
+`;

--- a/src/datastore/local-store/repos/__snapshots__/subscription.repo.spec.ts.snap
+++ b/src/datastore/local-store/repos/__snapshots__/subscription.repo.spec.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LocalSubscriptionRepo Subscription test suite method: create should create a subscription 1`] = `
+SubscriptionModel {
+  "createdAt": 1987-10-14T00:00:00.000Z,
+  "eventScope": "",
+  "eventType": "transaction.update",
+  "id": 1,
+  "legitimacySecret": "someSecret",
+  "nextNonce": 3,
+  "status": "inactive",
+  "triesLeft": 10,
+  "ttl": 10,
+  "webhookUrl": "http://example.com",
+}
+`;
+
+exports[`LocalSubscriptionRepo Subscription test suite method: findById should find the created notification 1`] = `
+{
+  "eventScope": "",
+  "eventType": "transaction.update",
+  "id": 1,
+  "legitimacySecret": "someSecret",
+  "nextNonce": 3,
+  "status": "inactive",
+  "triesLeft": 10,
+  "ttl": 10,
+  "webhookUrl": "http://example.com",
+}
+`;

--- a/src/datastore/local-store/repos/notification.repo.spec.ts
+++ b/src/datastore/local-store/repos/notification.repo.spec.ts
@@ -1,0 +1,8 @@
+import { LocalNotificationRepo } from '~/datastore/local-store/repos/notification.repo';
+import { NotificationRepo } from '~/notifications/repo/notifications.repo';
+
+describe(`LocalNotificationRepo ${NotificationRepo.type} test suite`, () => {
+  const repo = new LocalNotificationRepo();
+
+  NotificationRepo.test(repo);
+});

--- a/src/datastore/local-store/repos/notification.repo.ts
+++ b/src/datastore/local-store/repos/notification.repo.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+
+import { NotificationModel } from '~/notifications/model/notification.model';
+import { NotificationRepo } from '~/notifications/repo/notifications.repo';
+import { NotificationParams, NotificationStatus } from '~/notifications/types';
+
+const triesLeft = 10;
+
+@Injectable()
+export class LocalNotificationRepo extends NotificationRepo {
+  private currentId = 0;
+  private notifications: Record<string, NotificationModel> = {};
+
+  public async create(params: NotificationParams): Promise<NotificationModel> {
+    this.currentId += 1;
+
+    const model = new NotificationModel({
+      id: this.currentId,
+      ...params,
+      triesLeft,
+      status: NotificationStatus.Active,
+      createdAt: new Date(),
+    });
+
+    this.notifications[model.id] = model;
+
+    return model;
+  }
+
+  public async update(id: number, params: NotificationParams): Promise<NotificationModel> {
+    const model = this.notifications[id];
+
+    const updated = {
+      ...model,
+      ...params,
+    };
+
+    this.notifications[id] = updated;
+
+    return updated;
+  }
+
+  public async findById(id: number): Promise<NotificationModel> {
+    return this.notifications[id];
+  }
+}

--- a/src/datastore/local-store/repos/subscription.repo.spec.ts
+++ b/src/datastore/local-store/repos/subscription.repo.spec.ts
@@ -1,0 +1,8 @@
+import { LocalSubscriptionRepo } from '~/datastore/local-store/repos/subscription.repo';
+import { SubscriptionRepo } from '~/subscriptions/repo/subscription.repo';
+
+describe(`LocalSubscriptionRepo ${SubscriptionRepo.type} test suite`, () => {
+  const repo = new LocalSubscriptionRepo();
+
+  SubscriptionRepo.test(repo);
+});

--- a/src/datastore/local-store/repos/subscription.repo.ts
+++ b/src/datastore/local-store/repos/subscription.repo.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+
+import { AppNotFoundError } from '~/common/errors';
+import { SubscriptionModel } from '~/subscriptions/models/subscription.model';
+import { SubscriptionRepo } from '~/subscriptions/repo/subscription.repo';
+import { SubscriptionParams } from '~/subscriptions/types';
+
+@Injectable()
+export class LocalSubscriptionRepo implements SubscriptionRepo {
+  private currentId = 0;
+  private subscriptions: Record<string, SubscriptionModel> = {};
+
+  public async create(params: SubscriptionParams): Promise<SubscriptionModel> {
+    this.currentId += 1;
+
+    const model = new SubscriptionModel({
+      id: this.currentId,
+      ...params,
+    });
+
+    this.subscriptions[model.id] = model;
+
+    return model;
+  }
+
+  public async update(id: number, params: SubscriptionParams): Promise<SubscriptionModel> {
+    const model = this.subscriptions[id];
+
+    const updated = new SubscriptionModel({
+      ...model,
+      ...params,
+    });
+
+    this.subscriptions[id] = updated;
+
+    return updated;
+  }
+
+  public async findById(id: number): Promise<SubscriptionModel> {
+    const subscription = this.subscriptions[id];
+
+    if (!subscription) {
+      throw new AppNotFoundError(id.toString(), 'notification');
+    }
+
+    return subscription;
+  }
+
+  public async findAll(): Promise<SubscriptionModel[]> {
+    return Object.values(this.subscriptions);
+  }
+
+  public async incrementNonces(ids: number[]): Promise<void> {
+    ids.forEach(id => {
+      this.subscriptions[id].nextNonce += 1;
+    });
+  }
+}

--- a/src/datastore/postgres/entities/notification.entity.ts
+++ b/src/datastore/postgres/entities/notification.entity.ts
@@ -1,0 +1,39 @@
+/* istanbul ignore file */
+
+import { FactoryProvider } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Column, DataSource, Entity, PrimaryGeneratedColumn, Repository } from 'typeorm';
+
+import { NotificationStatus } from '~/notifications/types';
+
+@Entity()
+export class Notification {
+  @PrimaryGeneratedColumn('increment')
+  public id: number;
+
+  @Column({ type: 'int' })
+  public subscriptionId: number;
+
+  @Column({ type: 'int' })
+  public eventId: number;
+
+  @Column({ type: 'int' })
+  public triesLeft: number;
+
+  @Column({ type: 'text' })
+  public status: NotificationStatus;
+
+  @Column({ type: 'int' })
+  public nonce: number;
+
+  @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  public createdAt: Date;
+}
+
+export const notificationRepoProvider: FactoryProvider = {
+  provide: getRepositoryToken(Notification),
+  useFactory: async (dataSource: DataSource): Promise<Repository<Notification>> => {
+    return dataSource.getRepository(Notification);
+  },
+  inject: [DataSource],
+};

--- a/src/datastore/postgres/entities/subscription.entity.ts
+++ b/src/datastore/postgres/entities/subscription.entity.ts
@@ -1,0 +1,49 @@
+/* istanbul ignore file */
+
+import { FactoryProvider } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Column, DataSource, Entity, PrimaryGeneratedColumn, Repository } from 'typeorm';
+
+import { EventType } from '~/events/types';
+import { SubscriptionStatus } from '~/subscriptions/types';
+
+@Entity()
+export class Subscription {
+  @PrimaryGeneratedColumn('increment')
+  public id: number;
+
+  @Column({ type: 'text' })
+  public eventType: EventType;
+
+  @Column({ type: 'text' })
+  public eventScope: string;
+
+  @Column({ type: 'text' })
+  public webhookUrl: string;
+
+  @Column({ type: 'int' })
+  public ttl: number;
+
+  @Column({ type: 'text' })
+  public status: SubscriptionStatus;
+
+  @Column({ type: 'int' })
+  public triesLeft: number;
+
+  @Column({ type: 'int' })
+  public nextNonce: number;
+
+  @Column({ type: 'text' })
+  public legitimacySecret: string;
+
+  @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
+  public createdAt: Date;
+}
+
+export const subscriptionRepoProvider: FactoryProvider = {
+  provide: getRepositoryToken(Subscription),
+  useFactory: async (dataSource: DataSource): Promise<Repository<Subscription>> => {
+    return dataSource.getRepository(Subscription);
+  },
+  inject: [DataSource],
+};

--- a/src/datastore/postgres/migrations/1718398114107-hooks.ts
+++ b/src/datastore/postgres/migrations/1718398114107-hooks.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Hooks1718398114107 implements MigrationInterface {
+  name = 'Hooks1718398114107';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE "subscription" ("id" SERIAL NOT NULL, "eventType" text NOT NULL, "eventScope" text NOT NULL, "webhookUrl" text NOT NULL, "ttl" integer NOT NULL, "status" text NOT NULL, "triesLeft" integer NOT NULL, "nextNonce" integer NOT NULL, "legitimacySecret" text NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_8c3e00ebd02103caa1174cd5d9d" PRIMARY KEY ("id"))'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE "subscription"');
+  }
+}

--- a/src/datastore/postgres/migrations/1719003936380-notifications.ts
+++ b/src/datastore/postgres/migrations/1719003936380-notifications.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Notifications1719003936380 implements MigrationInterface {
+  name = 'Notifications1719003936380';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX "public"."idx_address_nonce"');
+    await queryRunner.query(
+      'CREATE TABLE "notification" ("id" SERIAL NOT NULL, "subscriptionId" integer NOT NULL, "eventId" integer NOT NULL, "triesLeft" integer NOT NULL, "status" text NOT NULL, "nonce" integer NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "PK_705b6c7cdf9b2c2ff7ac7872cb7" PRIMARY KEY ("id"))'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE "notification"');
+    await queryRunner.query(
+      'CREATE INDEX "idx_address_nonce" ON "offline_tx" ("address", "nonce") '
+    );
+  }
+}

--- a/src/datastore/postgres/postgres.module.ts
+++ b/src/datastore/postgres/postgres.module.ts
@@ -4,15 +4,21 @@ import { Module } from '@nestjs/common';
 
 import { ApiKeyRepo } from '~/auth/repos/api-key.repo';
 import { apiKeyRepoProvider } from '~/datastore/postgres/entities/api-key.entity';
+import { notificationRepoProvider } from '~/datastore/postgres/entities/notification.entity';
 import { offlineEventRepoProvider } from '~/datastore/postgres/entities/offline-event.entity';
 import { offlineTxRepoProvider } from '~/datastore/postgres/entities/offline-tx.entity';
+import { subscriptionRepoProvider } from '~/datastore/postgres/entities/subscription.entity';
 import { userRepoProvider } from '~/datastore/postgres/entities/user.entity';
 import { PostgresApiKeyRepo } from '~/datastore/postgres/repos/api-keys.repo';
+import { PostgresNotificationRepo } from '~/datastore/postgres/repos/notification.repo';
 import { PostgresOfflineEventRepo } from '~/datastore/postgres/repos/offline-event.repo';
 import { PostgresOfflineTxRepo } from '~/datastore/postgres/repos/offline-tx.repo';
+import { PostgresSubscriptionRepo } from '~/datastore/postgres/repos/subscription.repo';
 import { PostgresUsersRepo } from '~/datastore/postgres/repos/users.repo';
+import { NotificationRepo } from '~/notifications/repo/notifications.repo';
 import { OfflineEventRepo } from '~/offline-recorder/repo/offline-event.repo';
 import { OfflineTxRepo } from '~/offline-submitter/repos/offline-tx.repo';
+import { SubscriptionRepo } from '~/subscriptions/repo/subscription.repo';
 import { UsersRepo } from '~/users/repo/user.repo';
 
 /**
@@ -24,11 +30,22 @@ import { UsersRepo } from '~/users/repo/user.repo';
     userRepoProvider,
     offlineEventRepoProvider,
     offlineTxRepoProvider,
+    notificationRepoProvider,
+    subscriptionRepoProvider,
     { provide: UsersRepo, useClass: PostgresUsersRepo },
     { provide: ApiKeyRepo, useClass: PostgresApiKeyRepo },
     { provide: OfflineEventRepo, useClass: PostgresOfflineEventRepo },
     { provide: OfflineTxRepo, useClass: PostgresOfflineTxRepo },
+    { provide: NotificationRepo, useClass: PostgresNotificationRepo },
+    { provide: SubscriptionRepo, useClass: PostgresSubscriptionRepo },
   ],
-  exports: [ApiKeyRepo, UsersRepo, OfflineEventRepo, OfflineTxRepo],
+  exports: [
+    ApiKeyRepo,
+    UsersRepo,
+    OfflineEventRepo,
+    OfflineTxRepo,
+    NotificationRepo,
+    SubscriptionRepo,
+  ],
 })
 export class PostgresModule {}

--- a/src/datastore/postgres/repos/__snapshots__/notification.repo.spec.ts.snap
+++ b/src/datastore/postgres/repos/__snapshots__/notification.repo.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostgresNotificationRepo Notification test suite method: create should create a notification 1`] = `
+{
+  "eventId": 0,
+  "id": 1,
+  "nonce": 1,
+  "status": "active",
+  "subscriptionId": 1,
+  "triesLeft": 3,
+}
+`;
+
+exports[`PostgresNotificationRepo Notification test suite method: findById should find the created notification 1`] = `
+{
+  "id": 1,
+}
+`;

--- a/src/datastore/postgres/repos/__snapshots__/subscription.repo.spec.ts.snap
+++ b/src/datastore/postgres/repos/__snapshots__/subscription.repo.spec.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostgresSubscriptionRepo Subscription test suite method: create should create a subscription 1`] = `
+SubscriptionModel {
+  "createdAt": 1987-10-14T00:00:00.000Z,
+  "eventScope": "",
+  "eventType": "transaction.update",
+  "id": 1,
+  "legitimacySecret": "someSecret",
+  "nextNonce": 3,
+  "status": "inactive",
+  "triesLeft": 10,
+  "ttl": 10,
+  "webhookUrl": "http://example.com",
+}
+`;
+
+exports[`PostgresSubscriptionRepo Subscription test suite method: findById should find the created notification 1`] = `
+{
+  "eventScope": "",
+  "eventType": "transaction.update",
+  "id": 1,
+  "legitimacySecret": "someSecret",
+  "nextNonce": 3,
+  "status": "inactive",
+  "triesLeft": 10,
+  "ttl": 10,
+  "webhookUrl": "http://example.com",
+}
+`;

--- a/src/datastore/postgres/repos/notification.repo.spec.ts
+++ b/src/datastore/postgres/repos/notification.repo.spec.ts
@@ -1,0 +1,38 @@
+import { createMock } from '@golevelup/ts-jest';
+import { when } from 'jest-when';
+import { Repository } from 'typeorm';
+
+import { Notification } from '~/datastore/postgres/entities/notification.entity';
+import { PostgresNotificationRepo } from '~/datastore/postgres/repos/notification.repo';
+import { NotificationModel } from '~/notifications/model/notification.model';
+import { NotificationRepo } from '~/notifications/repo/notifications.repo';
+import { MockPostgresRepository } from '~/test-utils/repo-mocks';
+
+describe(`PostgresNotificationRepo ${NotificationRepo.type} test suite`, () => {
+  const mockRepository = new MockPostgresRepository();
+  const repo = new PostgresNotificationRepo(mockRepository as unknown as Repository<Notification>);
+
+  const mockNotification = createMock<NotificationModel>({
+    id: 1,
+  });
+
+  mockRepository.save.mockImplementation(notification => {
+    notification.id = 1;
+    return mockNotification;
+  });
+
+  mockRepository.update.mockImplementation(async (id, params) => {
+    const notification = mockRepository.findOneBy(id);
+
+    when(mockRepository.findOneBy)
+      .calledWith({ id })
+      .mockResolvedValue({ ...notification, ...params });
+  });
+
+  mockRepository.create.mockImplementation(params => params);
+  when(mockRepository.findOneBy)
+    .calledWith({ id: mockNotification.id })
+    .mockResolvedValue(mockNotification);
+
+  NotificationRepo.test(repo);
+});

--- a/src/datastore/postgres/repos/notification.repo.ts
+++ b/src/datastore/postgres/repos/notification.repo.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { AppNotFoundError } from '~/common/errors';
+import { Notification } from '~/datastore/postgres/entities/notification.entity';
+import { convertTypeOrmErrorToAppError } from '~/datastore/postgres/repos/utils';
+import { NotificationModel } from '~/notifications/model/notification.model';
+import { NotificationRepo } from '~/notifications/repo/notifications.repo';
+import { NotificationParams } from '~/notifications/types';
+
+@Injectable()
+export class PostgresNotificationRepo implements NotificationRepo {
+  constructor(@InjectRepository(Notification) private notificationRepo: Repository<Notification>) {}
+
+  public async create(params: NotificationParams): Promise<NotificationModel> {
+    const entity = this.notificationRepo.create({
+      ...params,
+    });
+
+    await this.notificationRepo
+      .save(entity)
+      .catch(
+        convertTypeOrmErrorToAppError(
+          `Subscription ID: ${params.subscriptionId}`,
+          NotificationRepo.type
+        )
+      );
+
+    const notification = new NotificationModel({
+      ...entity,
+    });
+    return notification;
+  }
+
+  public async findById(id: number): Promise<NotificationModel> {
+    const entity = await this.notificationRepo.findOneBy({ id });
+
+    if (!entity) {
+      throw new AppNotFoundError(id.toString(), 'notification');
+    }
+
+    return new NotificationModel({
+      ...entity,
+    });
+  }
+
+  public async update(id: number, params: NotificationParams): Promise<NotificationModel> {
+    await this.notificationRepo.update(id, params);
+
+    const notification = await this.findById(id);
+
+    return notification;
+  }
+}

--- a/src/datastore/postgres/repos/subscription.repo.spec.ts
+++ b/src/datastore/postgres/repos/subscription.repo.spec.ts
@@ -1,0 +1,57 @@
+import { createMock } from '@golevelup/ts-jest';
+import { when } from 'jest-when';
+import { Repository } from 'typeorm';
+
+import { Subscription } from '~/datastore/postgres/entities/subscription.entity';
+import { PostgresSubscriptionRepo } from '~/datastore/postgres/repos/subscription.repo';
+import { SubscriptionModel } from '~/subscriptions/models/subscription.model';
+import { SubscriptionRepo } from '~/subscriptions/repo/subscription.repo';
+import { MockPostgresRepository, MockQueryBuilder } from '~/test-utils/repo-mocks';
+
+describe(`PostgresSubscriptionRepo ${SubscriptionRepo.type} test suite`, () => {
+  const mockRepository = new MockPostgresRepository();
+  const mockQueryBuilder = new MockQueryBuilder();
+  const repo = new PostgresSubscriptionRepo(mockRepository as unknown as Repository<Subscription>);
+  let _id = 1;
+
+  const mockSubscription = createMock<SubscriptionModel>();
+  when(mockRepository.findOneBy).calledWith({ id: 1 }).mockResolvedValue(mockSubscription);
+
+  mockRepository.find.mockResolvedValue([]);
+  mockRepository.update.mockImplementation((id, args) => {
+    const newSub = { ...mockSubscription, id, ...args };
+
+    when(mockRepository.findOneBy).calledWith({ id: newSub.id }).mockResolvedValue(newSub);
+  });
+
+  mockRepository.create.mockImplementation(params => params);
+  mockRepository.findOneBy.mockResolvedValue(null);
+
+  mockRepository.save.mockImplementation(async subscription => {
+    subscription.id = _id++;
+    when(mockRepository.findOneBy)
+      .calledWith({ id: subscription.id })
+      .mockResolvedValue(subscription);
+
+    const existingSubs = await mockRepository.find();
+    mockRepository.find.mockResolvedValue([...existingSubs, subscription]);
+  });
+
+  mockQueryBuilder.execute.mockImplementation(async () => {
+    const existingSubs: SubscriptionModel[] = await mockRepository.find();
+
+    const updatedSubs = existingSubs.map(sub => ({ ...sub, nextNonce: sub.nextNonce + 1 }));
+
+    mockRepository.find.mockResolvedValue(updatedSubs);
+
+    updatedSubs.forEach(sub => {
+      when(mockRepository.findOneBy).calledWith({ id: sub.id }).mockResolvedValue(sub);
+    });
+
+    return { affected: updatedSubs.length };
+  });
+
+  mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+  SubscriptionRepo.test(repo);
+});

--- a/src/datastore/postgres/repos/subscription.repo.ts
+++ b/src/datastore/postgres/repos/subscription.repo.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { AppNotFoundError } from '~/common/errors';
+import { Subscription } from '~/datastore/postgres/entities/subscription.entity';
+import { convertTypeOrmErrorToAppError } from '~/datastore/postgres/repos/utils';
+import { SubscriptionModel } from '~/subscriptions/models/subscription.model';
+import { SubscriptionRepo } from '~/subscriptions/repo/subscription.repo';
+import { SubscriptionParams } from '~/subscriptions/types';
+
+@Injectable()
+export class PostgresSubscriptionRepo implements SubscriptionRepo {
+  constructor(@InjectRepository(Subscription) private subscriptionRepo: Repository<Subscription>) {}
+
+  public async create(params: SubscriptionParams): Promise<SubscriptionModel> {
+    const entity = this.subscriptionRepo.create({
+      ...params,
+    });
+
+    await this.subscriptionRepo
+      .save(entity)
+      .catch(convertTypeOrmErrorToAppError('subscription', SubscriptionRepo.type));
+
+    const subscription = new SubscriptionModel({
+      ...entity,
+    });
+
+    return subscription;
+  }
+
+  public async update(id: number, params: SubscriptionParams): Promise<SubscriptionModel> {
+    await this.subscriptionRepo.update(id, params);
+
+    return this.findById(id);
+  }
+
+  public async findById(id: number): Promise<SubscriptionModel> {
+    const entity = await this.subscriptionRepo.findOneBy({ id });
+
+    if (!entity) {
+      throw new AppNotFoundError(id.toString(), SubscriptionRepo.type);
+    }
+
+    return new SubscriptionModel({
+      ...entity,
+    });
+  }
+
+  public async findAll(): Promise<SubscriptionModel[]> {
+    const results = await this.subscriptionRepo.find();
+
+    return results.map(value => new SubscriptionModel(value));
+  }
+
+  public async incrementNonces(ids: number[]): Promise<void> {
+    /* istanbul ignore next: inline function isn't testable */
+    const nextNonce = (): string => 'nextNonce +1';
+
+    await this.subscriptionRepo
+      .createQueryBuilder()
+      .update(Subscription)
+      .set({ nextNonce })
+      .where('id IN (:...ids)', { ids })
+      .execute();
+  }
+}

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -97,6 +97,26 @@ describe('EventsService', () => {
         },
       ]);
     });
+
+    it('should handle no subscriptions for the event', async () => {
+      const type = EventType.TransactionUpdate;
+      const scope = '0x02';
+      const payload = {
+        type: TransactionType.Single,
+        transactionTag: TxTags.asset.CreateAsset,
+        status: TransactionStatus.Unapproved,
+      } as const;
+
+      mockSubscriptionsService.findAll.mockReturnValue([]);
+
+      await service.createEvent({
+        type,
+        scope,
+        payload,
+      });
+
+      expect(mockNotificationsService.createNotifications).not.toHaveBeenCalled();
+    });
   });
 
   describe('findOne', () => {

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -69,15 +69,19 @@ export class EventsService {
       excludeExpired: true,
     });
 
-    const notifications = affectedSubscriptions.map(({ id: subscriptionId, nextNonce: nonce }) => ({
-      subscriptionId,
-      eventId,
-      nonce,
-    }));
+    if (affectedSubscriptions.length) {
+      const notifications = affectedSubscriptions.map(
+        ({ id: subscriptionId, nextNonce: nonce }) => ({
+          subscriptionId,
+          eventId,
+          nonce,
+        })
+      );
 
-    await subscriptionsService.batchBumpNonce(affectedSubscriptions.map(({ id }) => id));
+      await subscriptionsService.batchBumpNonce(affectedSubscriptions.map(({ id }) => id));
 
-    await notificationsService.createNotifications(notifications);
+      await notificationsService.createNotifications(notifications);
+    }
   }
 
   private async markEventAsProcessed(id: number): Promise<void> {

--- a/src/notifications/model/notification.model.ts
+++ b/src/notifications/model/notification.model.ts
@@ -2,7 +2,7 @@
 
 import { NotificationStatus } from '~/notifications/types';
 
-export class NotificationEntity {
+export class NotificationModel {
   public id: number;
 
   public subscriptionId: number;
@@ -17,7 +17,7 @@ export class NotificationEntity {
 
   public nonce: number;
 
-  constructor(entity: NotificationEntity) {
+  constructor(entity: NotificationModel) {
     Object.assign(this, entity);
   }
 }

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -2,6 +2,7 @@ import { HttpModule } from '@nestjs/axios';
 import { forwardRef, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { DatastoreModule } from '~/datastore/datastore.module';
 import { EventsModule } from '~/events/events.module';
 import { LoggerModule } from '~/logger/logger.module';
 import notificationsConfig from '~/notifications/config/notifications.config';
@@ -11,6 +12,7 @@ import { SubscriptionsModule } from '~/subscriptions/subscriptions.module';
 
 @Module({
   imports: [
+    DatastoreModule.registerAsync(),
     ConfigModule.forFeature(notificationsConfig),
     forwardRef(() => EventsModule),
     SubscriptionsModule,

--- a/src/notifications/repo/notification.repo.suite.ts
+++ b/src/notifications/repo/notification.repo.suite.ts
@@ -1,0 +1,46 @@
+/* istanbul ignore file */
+
+import { NotificationRepo } from '~/notifications/repo/notifications.repo';
+import { NotificationStatus } from '~/notifications/types';
+
+export const testNotificationRepo = async (notificationRepo: NotificationRepo): Promise<void> => {
+  let id: number;
+
+  describe('method: create', () => {
+    it('should create a notification', async () => {
+      const notification = await notificationRepo.create({
+        status: NotificationStatus.Active,
+        eventId: 0,
+        subscriptionId: 1,
+        nonce: 1,
+        triesLeft: 3,
+      });
+      id = notification.id;
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { createdAt: _, ...params } = notification;
+      expect(params).toMatchSnapshot();
+    });
+  });
+
+  describe('method: findById', () => {
+    it('should find the created notification', async () => {
+      const notification = await notificationRepo.findById(id);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { createdAt: _, ...params } = notification!;
+
+      expect(params).toMatchSnapshot();
+    });
+  });
+
+  describe('method: update', () => {
+    it('should update the notification', async () => {
+      await notificationRepo.update(id, { status: NotificationStatus.Acknowledged });
+
+      const notification = await notificationRepo.findById(id);
+
+      expect(notification?.status).toEqual(NotificationStatus.Acknowledged);
+    });
+  });
+};

--- a/src/notifications/repo/notifications.repo.ts
+++ b/src/notifications/repo/notifications.repo.ts
@@ -1,0 +1,21 @@
+import { NotificationModel } from '~/notifications/model/notification.model';
+import { testNotificationRepo } from '~/notifications/repo/notification.repo.suite';
+import { NotificationParams } from '~/notifications/types';
+
+export abstract class NotificationRepo {
+  public static readonly type = 'Notification';
+
+  public abstract create(params: NotificationParams): Promise<NotificationModel>;
+  public abstract findById(id: number): Promise<NotificationModel | undefined>;
+  public abstract update(
+    id: number,
+    params: Partial<NotificationParams>
+  ): Promise<NotificationModel>;
+
+  /**
+   * a set of tests implementers should pass
+   */
+  public static async test(repo: NotificationRepo): Promise<void> {
+    return testNotificationRepo(repo);
+  }
+}

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -1,4 +1,5 @@
 import { EventType, GetPayload } from '~/events/types';
+import { NotificationModel } from '~/notifications/model/notification.model';
 
 export enum NotificationStatus {
   /**
@@ -26,3 +27,8 @@ export type NotificationPayload<T extends EventType = EventType> = {
   nonce: number;
   payload: GetPayload<T>;
 };
+
+export type NotificationParams = Pick<
+  NotificationModel,
+  'eventId' | 'subscriptionId' | 'nonce' | 'status' | 'triesLeft'
+>;

--- a/src/subscriptions/models/subscription.model.ts
+++ b/src/subscriptions/models/subscription.model.ts
@@ -3,7 +3,7 @@
 import { EventType } from '~/events/types';
 import { SubscriptionStatus } from '~/subscriptions/types';
 
-export class SubscriptionEntity {
+export class SubscriptionModel {
   public id: number;
 
   public eventType: EventType;
@@ -36,7 +36,7 @@ export class SubscriptionEntity {
     return new Date(createdAt.getTime() + ttl) <= new Date();
   }
 
-  constructor(entity: Omit<SubscriptionEntity, 'isExpired'>) {
+  constructor(entity: Omit<SubscriptionModel, 'isExpired'>) {
     Object.assign(this, entity);
   }
 }

--- a/src/subscriptions/repo/subscription.repo.suite.ts
+++ b/src/subscriptions/repo/subscription.repo.suite.ts
@@ -1,0 +1,73 @@
+/* istanbul ignore file */
+
+import { AppNotFoundError } from '~/common/errors';
+import { EventType } from '~/events/types';
+import { SubscriptionRepo } from '~/subscriptions/repo/subscription.repo';
+import { SubscriptionStatus } from '~/subscriptions/types';
+
+export const testSubscriptionRepo = async (subscriptionRepo: SubscriptionRepo): Promise<void> => {
+  let id: number;
+
+  describe('method: create', () => {
+    it('should create a subscription', async () => {
+      const subscription = await subscriptionRepo.create({
+        status: SubscriptionStatus.Inactive,
+        eventType: EventType.TransactionUpdate,
+        eventScope: '',
+        webhookUrl: 'http://example.com',
+        legitimacySecret: 'someSecret',
+        ttl: 10,
+        triesLeft: 10,
+        nextNonce: 3,
+        createdAt: new Date('1987-10-14'),
+      });
+
+      id = subscription.id;
+      expect(subscription).toMatchSnapshot();
+    });
+  });
+
+  describe('method: findById', () => {
+    it('should find the created notification', async () => {
+      const subscription = await subscriptionRepo.findById(id);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { createdAt: _, ...params } = subscription!;
+
+      expect(params).toMatchSnapshot();
+    });
+
+    it('should throw an error for an ID that does not exist', async () => {
+      return expect(subscriptionRepo.findById(-1)).rejects.toThrow(AppNotFoundError);
+    });
+  });
+
+  describe('method: update', () => {
+    it('should update the notification', async () => {
+      await subscriptionRepo.update(id, { status: SubscriptionStatus.Active });
+
+      const subscription = await subscriptionRepo.findById(id);
+
+      expect(subscription?.status).toEqual(SubscriptionStatus.Active);
+    });
+  });
+
+  describe('method: findAll', () => {
+    it('should return all of the subscriptions', async () => {
+      const subscriptions = await subscriptionRepo.findAll();
+
+      expect(subscriptions.length).toEqual(1);
+      expect(subscriptions[0].id).toEqual(id);
+    });
+  });
+
+  describe('method: incrementNonces', () => {
+    it('should increment nonces', async () => {
+      await subscriptionRepo.incrementNonces([id]);
+
+      const subscription = await subscriptionRepo.findById(id);
+
+      expect(subscription?.nextNonce).toEqual(4);
+    });
+  });
+};

--- a/src/subscriptions/repo/subscription.repo.ts
+++ b/src/subscriptions/repo/subscription.repo.ts
@@ -1,0 +1,29 @@
+import { SubscriptionModel } from '~/subscriptions/models/subscription.model';
+import { testSubscriptionRepo } from '~/subscriptions/repo/subscription.repo.suite';
+import { SubscriptionParams } from '~/subscriptions/types';
+
+export abstract class SubscriptionRepo {
+  public static readonly type = 'Subscription';
+
+  public abstract create(
+    params: Omit<SubscriptionModel, 'id' | 'isExpired'>
+  ): Promise<SubscriptionModel>;
+
+  public abstract findAll(): Promise<SubscriptionModel[]>;
+
+  public abstract findById(id: number): Promise<SubscriptionModel | undefined>;
+
+  public abstract update(
+    id: number,
+    params: Partial<SubscriptionParams>
+  ): Promise<SubscriptionModel>;
+
+  public abstract incrementNonces(id: number[]): Promise<void>;
+
+  /**
+   * a set of tests implementers should pass
+   */
+  public static async test(repo: SubscriptionRepo): Promise<void> {
+    return testSubscriptionRepo(repo);
+  }
+}

--- a/src/subscriptions/subscriptions.module.ts
+++ b/src/subscriptions/subscriptions.module.ts
@@ -2,13 +2,20 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 
+import { DatastoreModule } from '~/datastore/datastore.module';
 import { LoggerModule } from '~/logger/logger.module';
 import { ScheduleModule } from '~/schedule/schedule.module';
 import subscriptionsConfig from '~/subscriptions/config/subscriptions.config';
 import { SubscriptionsService } from '~/subscriptions/subscriptions.service';
 
 @Module({
-  imports: [ConfigModule.forFeature(subscriptionsConfig), ScheduleModule, HttpModule, LoggerModule],
+  imports: [
+    DatastoreModule.registerAsync(),
+    ConfigModule.forFeature(subscriptionsConfig),
+    ScheduleModule,
+    HttpModule,
+    LoggerModule,
+  ],
   providers: [SubscriptionsService],
   exports: [SubscriptionsService],
 })

--- a/src/subscriptions/types.ts
+++ b/src/subscriptions/types.ts
@@ -1,3 +1,5 @@
+import { SubscriptionModel } from '~/subscriptions/models/subscription.model';
+
 export enum SubscriptionStatus {
   /**
    * Not yet confirmed by receiver
@@ -16,3 +18,5 @@ export enum SubscriptionStatus {
    */
   Done = 'done',
 }
+
+export type SubscriptionParams = Omit<SubscriptionModel, 'id' | 'isExpired'>;

--- a/src/test-utils/repo-mocks.ts
+++ b/src/test-utils/repo-mocks.ts
@@ -16,6 +16,13 @@ export const mockUserRepoProvider: ValueProvider<UsersRepo> = {
   useValue: createMock<UsersRepo>(),
 };
 
+export class MockQueryBuilder {
+  update = jest.fn().mockReturnThis();
+  set = jest.fn().mockReturnThis();
+  where = jest.fn().mockReturnThis();
+  execute = jest.fn().mockResolvedValue({ affected: 1 });
+}
+
 /**
  * mocks TypeORM repository
  */
@@ -24,4 +31,7 @@ export class MockPostgresRepository {
   save = jest.fn();
   delete = jest.fn();
   create = jest.fn();
+  update = jest.fn();
+  find = jest.fn();
+  createQueryBuilder = jest.fn().mockReturnValue(new MockQueryBuilder());
 }


### PR DESCRIPTION


### JIRA Link 

[DA-999](https://polymesh.atlassian.net/browse/DA-999) (MQ integration remains though)

### Changelog / Description 

add Local and Postgres repositories for subscriptions and notifications

### Checklist - 

- [x] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-999]: https://polymesh.atlassian.net/browse/DA-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `LocalNotificationRepo` and `LocalSubscriptionRepo` for local data storage.
	- Added `Notification` and `Subscription` entity classes for PostgreSQL database.

- **Bug Fixes**
	- Corrected descriptions in API documentation to reflect the change from `submitAndCallback` to `submitWithCallback`.

- **Documentation**
	- Updated README to reflect new webhook process and removed redundant lines.

- **Chores**
	- Added the `btree_gist` extension creation in the database initialization script.

- **Tests**
	- Introduced new test suites for `LocalNotificationRepo` and `LocalSubscriptionRepo`.
	- Enhanced mocking capabilities in `MockPostgresRepository`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->