### PR TITLE
feat: 🎸 allow multiSig signers to submit proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Process modes include:
   - `offline` This creates an unsigned transaction and returns a serialized JSON payload. The information can be signed, and then submitted to the chain.
   - `AMQP` This creates an transaction to be processed by worker processes using an AMQP broker to ensure reliable processing
 
+### MultiSig
+
+If the signer of a transaction is a MultiSig signer the transaction will be implicitly wrapped as a MultiSigProposal. This mostly behaves as a normal transaction with a few exceptions. The transaction may need additional approvals depending on the MultiSig configuration, and will be scheduled to run in a later block. The filed `proposal` will be set and additional details will not be set, e.g. `POST /portfolios/create` will not return portfolio information for a MultiSig signer. For offline payloads the field `multiSig` will be set to the acting MultiSig address when a proposal is being made.
+
 ### Signing Managers
 
 A signing manager is required for `submit` and `submitWithCallback` processing modes.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@polymeshassociation/fireblocks-signing-manager": "^2.5.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "^3.4.0",
     "@polymeshassociation/local-signing-manager": "^3.3.0",
-    "@polymeshassociation/polymesh-sdk": "24.7.0-alpha.2",
+    "@polymeshassociation/polymesh-sdk": "24.7.0-alpha.11",
     "@polymeshassociation/signing-manager-types": "^3.2.0",
     "class-transformer": "0.5.1",
     "class-validator": "^0.14.0",

--- a/src/accounts/accounts.controller.spec.ts
+++ b/src/accounts/accounts.controller.spec.ts
@@ -23,7 +23,7 @@ import { IdentityModel } from '~/identities/models/identity.model';
 import { IdentitySignerModel } from '~/identities/models/identity-signer.model';
 import { NetworkService } from '~/network/network.service';
 import { SubsidyService } from '~/subsidy/subsidy.service';
-import { extrinsic, testValues } from '~/test-utils/consts';
+import { extrinsic, processedTxResult, testValues } from '~/test-utils/consts';
 import {
   createMockResponseObject,
   createMockSubsidy,
@@ -111,7 +111,7 @@ describe('AccountsController', () => {
 
       const result = await controller.transferPolyx(body);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -229,7 +229,7 @@ describe('AccountsController', () => {
 
       const result = await controller.freezeSecondaryAccounts(body);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -242,7 +242,7 @@ describe('AccountsController', () => {
 
       const result = await controller.unfreezeSecondaryAccounts(body);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -257,7 +257,7 @@ describe('AccountsController', () => {
 
       const result = await controller.revokePermissions(body);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -281,7 +281,7 @@ describe('AccountsController', () => {
 
       const result = await controller.modifyPermissions(body);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 

--- a/src/accounts/accounts.controller.ts
+++ b/src/accounts/accounts.controller.ts
@@ -32,7 +32,7 @@ import { AccountDetailsModel } from '~/accounts/models/account-details.model';
 import { MultiSigDetailsModel } from '~/accounts/models/multi-sig-details.model';
 import { PermissionsModel } from '~/accounts/models/permissions.model';
 import { BalanceModel } from '~/assets/models/balance.model';
-import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { ExtrinsicModel } from '~/common/models/extrinsic.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -14,7 +14,7 @@ import { createAuthorizationRequestModel } from '~/authorizations/authorizations
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { MetadataService } from '~/metadata/metadata.service';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { MockAsset, MockAuthorizationRequest } from '~/test-utils/mocks';
 import { MockAssetService, mockMetadataServiceProvider } from '~/test-utils/service-mocks';
 
@@ -223,7 +223,7 @@ describe('AssetsController', () => {
       mockAssetsService.setDocuments.mockResolvedValue(txResult);
 
       const result = await controller.setDocuments({ ticker }, body);
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.setDocuments).toHaveBeenCalledWith(ticker, body);
     });
   });
@@ -240,7 +240,7 @@ describe('AssetsController', () => {
       mockAssetsService.createAsset.mockResolvedValue(txResult);
 
       const result = await controller.createAsset(input);
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.createAsset).toHaveBeenCalledWith(input);
     });
   });
@@ -252,7 +252,7 @@ describe('AssetsController', () => {
       mockAssetsService.issue.mockResolvedValue(txResult);
 
       const result = await controller.issue({ ticker }, { signer, amount });
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.issue).toHaveBeenCalledWith(ticker, { signer, amount });
     });
   });
@@ -272,7 +272,7 @@ describe('AssetsController', () => {
       const result = await controller.transferOwnership({ ticker }, body);
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });
@@ -288,7 +288,7 @@ describe('AssetsController', () => {
       mockAssetsService.redeem.mockResolvedValue(txResult);
 
       const result = await controller.redeem({ ticker }, { signer, amount, from });
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.redeem).toHaveBeenCalledWith(ticker, { signer, amount, from });
     });
   });
@@ -299,7 +299,7 @@ describe('AssetsController', () => {
       mockAssetsService.freeze.mockResolvedValue(txResult);
 
       const result = await controller.freeze({ ticker }, { signer });
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.freeze).toHaveBeenCalledWith(ticker, { signer });
     });
   });
@@ -310,7 +310,7 @@ describe('AssetsController', () => {
       mockAssetsService.unfreeze.mockResolvedValue(txResult);
 
       const result = await controller.unfreeze({ ticker }, { signer });
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.unfreeze).toHaveBeenCalledWith(ticker, { signer });
     });
   });
@@ -325,7 +325,7 @@ describe('AssetsController', () => {
 
       const result = await controller.controllerTransfer({ ticker }, { signer, origin, amount });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.controllerTransfer).toHaveBeenCalledWith(ticker, {
         signer,
         origin,
@@ -391,7 +391,7 @@ describe('AssetsController', () => {
 
       const result = await controller.addRequiredMediators({ ticker }, { signer, mediators });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.addRequiredMediators).toHaveBeenCalledWith(ticker, {
         signer,
         mediators,
@@ -408,7 +408,7 @@ describe('AssetsController', () => {
 
       const result = await controller.removeRequiredMediators({ ticker }, { signer, mediators });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.removeRequiredMediators).toHaveBeenCalledWith(ticker, {
         signer,
         mediators,
@@ -424,7 +424,7 @@ describe('AssetsController', () => {
 
       const result = await controller.preApprove({ ticker }, { signer });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.preApprove).toHaveBeenCalledWith(ticker, {
         signer,
       });
@@ -439,7 +439,7 @@ describe('AssetsController', () => {
 
       const result = await controller.removePreApproval({ ticker }, { signer });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAssetsService.removePreApproval).toHaveBeenCalledWith(ticker, {
         signer,
       });

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -27,7 +27,7 @@ import { IdentityBalanceModel } from '~/assets/models/identity-balance.model';
 import { RequiredMediatorsModel } from '~/assets/models/required-mediators.model';
 import { authorizationRequestResolver } from '~/authorizations/authorizations.util';
 import { CreatedAuthorizationRequestModel } from '~/authorizations/models/created-authorization-request.model';
-import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { TransferOwnershipDto } from '~/common/dto/transfer-ownership.dto';

--- a/src/authorizations/authorizations.controller.spec.ts
+++ b/src/authorizations/authorizations.controller.spec.ts
@@ -3,7 +3,7 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 
 import { AuthorizationsController } from '~/authorizations/authorizations.controller';
 import { AuthorizationsService } from '~/authorizations/authorizations.service';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { MockAuthorizationsService } from '~/test-utils/service-mocks';
 
 describe('AuthorizationsController', () => {
@@ -34,7 +34,7 @@ describe('AuthorizationsController', () => {
       const authId = new BigNumber(1);
       const result = await controller.accept({ id: authId }, { signer });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAuthorizationsService.accept).toHaveBeenCalledWith(authId, { signer });
     });
   });
@@ -46,7 +46,7 @@ describe('AuthorizationsController', () => {
       const authId = new BigNumber(1);
       const result = await controller.remove({ id: authId }, { signer });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockAuthorizationsService.remove).toHaveBeenCalledWith(authId, { signer });
     });
   });

--- a/src/authorizations/models/created-authorization-request.model.ts
+++ b/src/authorizations/models/created-authorization-request.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { AuthorizationRequestModel } from '~/authorizations/models/authorization-request.model';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 
 export class CreatedAuthorizationRequestModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Details of the newly created Authorization Request',
     type: AuthorizationRequestModel,
   })

--- a/src/checkpoints/checkpoints.controller.spec.ts
+++ b/src/checkpoints/checkpoints.controller.spec.ts
@@ -10,7 +10,7 @@ import { PeriodComplexityModel } from '~/checkpoints/models/period-complexity.mo
 import { ScheduleComplexityModel } from '~/checkpoints/models/schedule-complexity.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ResultsModel } from '~/common/models/results.model';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { MockCheckpoint, MockCheckpointSchedule } from '~/test-utils/mocks';
 import { MockCheckpointsService } from '~/test-utils/service-mocks';
 
@@ -115,7 +115,7 @@ describe('CheckpointsController', () => {
       const result = await controller.createCheckpoint({ ticker }, body);
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         checkpoint: mockCheckpoint,
       });
     });
@@ -222,7 +222,7 @@ describe('CheckpointsController', () => {
         pendingPoints: [mockDate],
       });
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         schedule: mockCreatedSchedule,
       });
     });
@@ -299,7 +299,7 @@ describe('CheckpointsController', () => {
 
       const result = await controller.deleteSchedule({ id: new BigNumber(1), ticker }, { signer });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 

--- a/src/checkpoints/checkpoints.controller.ts
+++ b/src/checkpoints/checkpoints.controller.ts
@@ -24,7 +24,7 @@ import { CreatedCheckpointModel } from '~/checkpoints/models/created-checkpoint.
 import { CreatedCheckpointScheduleModel } from '~/checkpoints/models/created-checkpoint-schedule.model';
 import { PeriodComplexityModel } from '~/checkpoints/models/period-complexity.model';
 import { ScheduleComplexityModel } from '~/checkpoints/models/schedule-complexity.model';
-import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { IsTicker } from '~/common/decorators/validation';
 import { IdParamsDto } from '~/common/dto/id-params.dto';
 import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';

--- a/src/checkpoints/models/created-checkpoint-schedule.model.ts
+++ b/src/checkpoints/models/created-checkpoint-schedule.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { CheckpointScheduleModel } from '~/checkpoints/models/checkpoint-schedule.model';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 
 export class CreatedCheckpointScheduleModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Static data (and identifiers) of the newly created Schedule',
     type: CheckpointScheduleModel,
   })

--- a/src/checkpoints/models/created-checkpoint.model.ts
+++ b/src/checkpoints/models/created-checkpoint.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Checkpoint } from '@polymeshassociation/polymesh-sdk/types';
 
 import { FromEntity } from '~/common/decorators/transformation';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 
 export class CreatedCheckpointModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Identifiers of the newly created Checkpoint',
     example: {
       id: '1',

--- a/src/claims/claims.controller.spec.ts
+++ b/src/claims/claims.controller.spec.ts
@@ -12,7 +12,7 @@ import { CustomClaimTypeModel } from '~/claims/models/custom-claim-type.model';
 import { CustomClaimTypeWithDid } from '~/claims/models/custom-claim-type-did.model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { mockPolymeshLoggerProvider } from '~/logger/mock-polymesh-logger';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { mockClaimsServiceProvider } from '~/test-utils/service-mocks';
 
 const { did, txResult, signer } = testValues;
@@ -55,7 +55,7 @@ describe('ClaimsController', () => {
 
       expect(mockClaimsService.addClaimsOnDid).toHaveBeenCalledWith(mockPayload);
 
-      expect(result).toEqual({ ...txResult, results: undefined });
+      expect(result).toEqual({ ...processedTxResult, results: undefined });
     });
   });
 
@@ -67,7 +67,7 @@ describe('ClaimsController', () => {
 
       expect(mockClaimsService.editClaimsOnDid).toHaveBeenCalledWith(mockPayload);
 
-      expect(result).toEqual({ ...txResult, results: undefined });
+      expect(result).toEqual({ ...processedTxResult, results: undefined });
     });
   });
 
@@ -79,7 +79,7 @@ describe('ClaimsController', () => {
 
       expect(mockClaimsService.revokeClaimsFromDid).toHaveBeenCalledWith(mockPayload);
 
-      expect(result).toEqual({ ...txResult, results: undefined });
+      expect(result).toEqual({ ...processedTxResult, results: undefined });
     });
   });
 
@@ -101,7 +101,7 @@ describe('ClaimsController', () => {
       expect(mockClaimsService.registerCustomClaimType).toHaveBeenCalledWith(
         mockRegisterCustomClaimTypeDto
       );
-      expect(result).toEqual({ ...txResult, results: undefined });
+      expect(result).toEqual({ ...processedTxResult, results: undefined });
     });
   });
 

--- a/src/claims/claims.controller.ts
+++ b/src/claims/claims.controller.ts
@@ -20,7 +20,7 @@ import { ModifyClaimsDto } from '~/claims/dto/modify-claims.dto';
 import { RegisterCustomClaimTypeDto } from '~/claims/dto/register-custom-claim-type.dto';
 import { CustomClaimTypeModel } from '~/claims/models/custom-claim-type.model';
 import { CustomClaimTypeWithDid } from '~/claims/models/custom-claim-type-did.model';
-import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';

--- a/src/common/decorators/api-transaction-response.ts
+++ b/src/common/decorators/api-transaction-response.ts
@@ -1,0 +1,45 @@
+/* istanbul ignore file */
+
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiAcceptedResponse,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiResponseOptions,
+} from '@nestjs/swagger';
+
+import { NotificationPayloadModel } from '~/common/models/notification-payload-model';
+import { TransactionPayloadResultModel } from '~/common/models/transaction-payload-result.model';
+import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
+
+/**
+ * A helper that functions like `ApiCreatedResponse`, that also adds an `ApiAccepted` response in case "submitWithCallback" is used and `ApiOKResponse` if "offline" mode is used
+ *
+ * @param options - these will be passed to the `ApiCreatedResponse` decorator
+ */
+export function ApiTransactionResponse(
+  options: ApiResponseOptions
+): ReturnType<typeof applyDecorators> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const optionType = (options as any).type;
+
+  const extendsQueueModel = optionType.prototype instanceof TransactionQueueModel;
+
+  if (extendsQueueModel) {
+    options.description += ` Note: if the signer is a MultiSigSigner, then only properties from "TransactionQueueModel" will be returned. The field "proposal" will be set and properties unique to "${optionType.name}" will be absent.`;
+  }
+
+  return applyDecorators(
+    ApiOkResponse({
+      description:
+        'Returned if `"processMode": "offline"` is passed in `options`. A payload will be returned',
+      type: TransactionPayloadResultModel,
+    }),
+    ApiCreatedResponse(options),
+    ApiAcceptedResponse({
+      description:
+        'Returned if `"processMode": "submitWithCallback"` is passed in `options`. A response will be returned after the transaction has been validated. The result will be posted to the `webhookUrl` given when the transaction is completed',
+      type: NotificationPayloadModel,
+    })
+  );
+}

--- a/src/common/decorators/index.ts
+++ b/src/common/decorators/index.ts
@@ -1,0 +1,4 @@
+export * from '~/common/decorators/swagger';
+export * from '~/common/decorators/transformation';
+export * from '~/common/decorators/validation';
+export * from '~/common/decorators/api-transaction-response';

--- a/src/common/decorators/swagger.ts
+++ b/src/common/decorators/swagger.ts
@@ -2,15 +2,12 @@
 
 import { applyDecorators, HttpStatus, Type } from '@nestjs/common';
 import {
-  ApiAcceptedResponse,
   ApiBadRequestResponse,
-  ApiCreatedResponse,
   ApiExtraModels,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiProperty,
   ApiPropertyOptions,
-  ApiResponseOptions,
   ApiUnprocessableEntityResponse,
   getSchemaPath,
   OmitType,
@@ -20,10 +17,8 @@ import {
   SchemaObject,
 } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 
-import { NotificationPayloadModel } from '~/common/models/notification-payload-model';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { ResultsModel } from '~/common/models/results.model';
-import { TransactionPayloadResultModel } from '~/common/models/transaction-payload-result.model';
 import { Class } from '~/common/types';
 
 export const ApiArrayResponse = <TModel extends Type | string>(
@@ -179,29 +174,6 @@ export const ApiPropertyOneOf = ({
 
   return applyDecorators(ApiProperty({ ...apiPropertyOptions, oneOf: oneOfItems }));
 };
-
-/**
- * A helper that functions like `ApiCreatedResponse`, that also adds an `ApiAccepted` response in case "submitWithCallback" is used and `ApiOKResponse` if "offline" mode is used
- *
- * @param options - these will be passed to the `ApiCreatedResponse` decorator
- */
-export function ApiTransactionResponse(
-  options: ApiResponseOptions
-): ReturnType<typeof applyDecorators> {
-  return applyDecorators(
-    ApiOkResponse({
-      description:
-        'Returned if `"processMode": "offline"` is passed in `options`. A payload will be returned',
-      type: TransactionPayloadResultModel,
-    }),
-    ApiCreatedResponse(options),
-    ApiAcceptedResponse({
-      description:
-        'Returned if `"processMode": "submitWithCallback"` is passed in `options`. A response will be returned after the transaction has been validated. The result will be posted to the `webhookUrl` given when the transaction is completed',
-      type: NotificationPayloadModel,
-    })
-  );
-}
 
 type SupportedHttpStatusCodes =
   | HttpStatus.NOT_FOUND

--- a/src/common/models/transaction-queue.model.ts
+++ b/src/common/models/transaction-queue.model.ts
@@ -1,9 +1,10 @@
 /* istanbul ignore file */
 
-import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
+import { ApiExtraModels, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { MultiSigProposal } from '@polymeshassociation/polymesh-sdk/types';
 import { Type } from 'class-transformer';
 
-import { ApiPropertyOneOf } from '~/common/decorators/swagger';
+import { ApiPropertyOneOf, FromEntity } from '~/common/decorators';
 import { BatchTransactionModel } from '~/common/models/batch-transaction.model';
 import { TransactionModel } from '~/common/models/transaction.model';
 import { TransactionDetailsModel } from '~/common/models/transaction-details.model';
@@ -41,6 +42,17 @@ export class TransactionQueueModel {
   })
   @Type(() => TransactionDetailsModel)
   details: TransactionDetailsModel;
+
+  @ApiPropertyOptional({
+    description:
+      'Proposal information. Set if the signer was a MultiSig signer and the transaction was wrapped as a proposal',
+    example: {
+      multiSigAddress: '5DSv9np6VuG7XeNnudfvvs3VS9P6Q36DMiU4wxGHMkeFGbgZ',
+      id: '7',
+    },
+  })
+  @FromEntity()
+  readonly proposal?: MultiSigProposal;
 
   constructor(model: TransactionQueueModel) {
     Object.assign(this, model);

--- a/src/compliance/compliance-requirements.controller.ts
+++ b/src/compliance/compliance-requirements.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/swagger';
 
 import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
-import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';

--- a/src/compliance/trusted-claim-issuers.controller.ts
+++ b/src/compliance/trusted-claim-issuers.controller.ts
@@ -6,7 +6,7 @@ import {
   ApiArrayResponse,
   ApiTransactionFailedResponse,
   ApiTransactionResponse,
-} from '~/common/decorators/swagger';
+} from '~/common/decorators/';
 import { ResultsModel } from '~/common/models/results.model';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';

--- a/src/corporate-actions/corporate-actions.controller.spec.ts
+++ b/src/corporate-actions/corporate-actions.controller.spec.ts
@@ -12,7 +12,7 @@ import {
 import { MockCorporateActionDefaultConfig } from '~/corporate-actions/mocks/corporate-action-default-config.mock';
 import { MockDistributionWithDetails } from '~/corporate-actions/mocks/distribution-with-details.mock';
 import { MockDistribution } from '~/corporate-actions/mocks/dividend-distribution.mock';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 
 const { did, signer, txResult } = testValues;
 
@@ -73,7 +73,7 @@ describe('CorporateActionsController', () => {
 
       const result = await controller.updateDefaultConfig({ ticker: 'TICKER' }, body);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockCorporateActionsService.updateDefaultConfigByTicker).toHaveBeenCalledWith(
         'TICKER',
         body
@@ -120,8 +120,8 @@ describe('CorporateActionsController', () => {
     it('should call the service and return the results', async () => {
       const mockDistribution = new MockDistribution();
       const response = {
-        result: mockDistribution,
         ...txResult,
+        result: mockDistribution,
       };
       mockCorporateActionsService.createDividendDistribution.mockResolvedValue(response);
       const mockDate = new Date();
@@ -160,7 +160,7 @@ describe('CorporateActionsController', () => {
         { signer }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockCorporateActionsService.remove).toHaveBeenCalledWith('TICKER', new BigNumber(1), {
         signer,
       });
@@ -183,7 +183,7 @@ describe('CorporateActionsController', () => {
         body
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockCorporateActionsService.payDividends).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
@@ -212,7 +212,7 @@ describe('CorporateActionsController', () => {
         body
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -228,7 +228,7 @@ describe('CorporateActionsController', () => {
         { signer }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockCorporateActionsService.claimDividends).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
@@ -249,7 +249,7 @@ describe('CorporateActionsController', () => {
         { signer }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockCorporateActionsService.reclaimRemainingFunds).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),
@@ -272,7 +272,7 @@ describe('CorporateActionsController', () => {
         body
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockCorporateActionsService.modifyCheckpoint).toHaveBeenCalledWith(
         'TICKER',
         new BigNumber(1),

--- a/src/corporate-actions/corporate-actions.controller.ts
+++ b/src/corporate-actions/corporate-actions.controller.ts
@@ -11,7 +11,7 @@ import {
 import { DividendDistribution } from '@polymeshassociation/polymesh-sdk/types';
 
 import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
-import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { IsTicker } from '~/common/decorators/validation';
 import { IdParamsDto } from '~/common/dto/id-params.dto';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';

--- a/src/corporate-actions/models/created-dividend-distribution.model.ts
+++ b/src/corporate-actions/models/created-dividend-distribution.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { DividendDistributionModel } from '~/corporate-actions/models/dividend-distribution.model';
 
 export class CreatedDividendDistributionModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Static data (and identifiers) of the newly created Dividend Distribution',
     type: DividendDistributionModel,
   })

--- a/src/datastore/local-store/repos/__snapshots__/offline-tx.repo.spec.ts.snap
+++ b/src/datastore/local-store/repos/__snapshots__/offline-tx.repo.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`LocalOfflineTxRepo OfflineEvent test suite method: createTx should reco
       "memo": "test utils payload",
     },
     "method": "0x01",
+    "multiSig": null,
     "payload": {
       "address": "address",
       "blockHash": "0x01",

--- a/src/datastore/postgres/repos/__snapshots__/offline-tx.repo.spec.ts.snap
+++ b/src/datastore/postgres/repos/__snapshots__/offline-tx.repo.spec.ts.snap
@@ -10,6 +10,7 @@ OfflineTxModel {
       "memo": "test utils payload",
     },
     "method": "0x01",
+    "multiSig": null,
     "payload": {
       "address": "address",
       "blockHash": "0x01",

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -30,7 +30,7 @@ import { IdentityModel } from '~/identities/models/identity.model';
 import { IdentitySignerModel } from '~/identities/models/identity-signer.model';
 import { mockPolymeshLoggerProvider } from '~/logger/mock-polymesh-logger';
 import { SettlementsService } from '~/settlements/settlements.service';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import {
   MockAsset,
   MockAuthorizationRequest,
@@ -498,7 +498,7 @@ describe('IdentitiesController', () => {
       });
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });
@@ -633,7 +633,7 @@ describe('IdentitiesController', () => {
       const result = await controller.registerIdentity(data);
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         identity: identityData,
       });
     });
@@ -674,7 +674,7 @@ describe('IdentitiesController', () => {
       });
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });
@@ -703,7 +703,7 @@ describe('IdentitiesController', () => {
       );
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });

--- a/src/identities/identities.controller.ts
+++ b/src/identities/identities.controller.ts
@@ -42,7 +42,7 @@ import {
   ApiArrayResponseReplaceModelProperties,
   ApiTransactionFailedResponse,
   ApiTransactionResponse,
-} from '~/common/decorators/swagger';
+} from '~/common/decorators/';
 import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';
 import { DidDto, IncludeExpiredFilterDto } from '~/common/dto/params.dto';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';

--- a/src/identities/models/created-identity.model.ts
+++ b/src/identities/models/created-identity.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { IdentityModel } from '~/identities/models/identity.model';
 
 export class CreatedIdentityModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Static data (and identifiers) of the newly created Identity',
     type: IdentityModel,
   })

--- a/src/metadata/metadata.controller.spec.ts
+++ b/src/metadata/metadata.controller.spec.ts
@@ -14,7 +14,6 @@ import { CreateMetadataDto } from '~/metadata/dto/create-metadata.dto';
 import { SetMetadataDto } from '~/metadata/dto/set-metadata.dto';
 import { MetadataController } from '~/metadata/metadata.controller';
 import { MetadataService } from '~/metadata/metadata.service';
-import { CreatedMetadataEntryModel } from '~/metadata/models/created-metadata-entry.model';
 import { MetadataDetailsModel } from '~/metadata/models/metadata-details.model';
 import { MetadataEntryModel } from '~/metadata/models/metadata-entry.model';
 import { MetadataValueModel } from '~/metadata/models/metadata-value.model';
@@ -128,8 +127,7 @@ describe('MetadataController', () => {
       const result = await controller.createMetadata({ ticker }, mockPayload);
 
       expect(result).toEqual(
-        new CreatedMetadataEntryModel({
-          ...txResult,
+        expect.objectContaining({
           transactions: [transaction],
           metadata: new MetadataEntryModel({ asset: ticker, type, id }),
         })

--- a/src/metadata/metadata.controller.ts
+++ b/src/metadata/metadata.controller.ts
@@ -13,7 +13,7 @@ import {
   ApiArrayResponse,
   ApiTransactionFailedResponse,
   ApiTransactionResponse,
-} from '~/common/decorators/swagger';
+} from '~/common/decorators/';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { ResultsModel } from '~/common/models/results.model';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';

--- a/src/metadata/models/created-metadata-entry.model.ts
+++ b/src/metadata/models/created-metadata-entry.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { MetadataEntryModel } from '~/metadata/models/metadata-entry.model';
 
 export class CreatedMetadataEntryModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Details of the newly created Asset Metadata',
     type: () => MetadataEntryModel,
   })

--- a/src/network/network.service.ts
+++ b/src/network/network.service.ts
@@ -34,7 +34,7 @@ export class NetworkService {
     const { signature, ...txPayload } = transaction;
 
     const result = await this.polymeshService.polymeshApi.network.submitTransaction(
-      txPayload,
+      { ...txPayload, multiSig: null },
       signature
     );
 

--- a/src/nfts/nfts.controller.spec.ts
+++ b/src/nfts/nfts.controller.spec.ts
@@ -8,7 +8,7 @@ import { NftsController } from '~/nfts//nfts.controller';
 import { CollectionKeyModel } from '~/nfts/models/collection-key.model';
 import { NftModel } from '~/nfts/models/nft.model';
 import { NftsService } from '~/nfts/nfts.service';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { mockNftsServiceProvider } from '~/test-utils/service-mocks';
 
 const { signer, ticker, txResult } = testValues;
@@ -70,7 +70,7 @@ describe('NftController', () => {
       );
 
       const result = await controller.createNftCollection(input);
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -80,7 +80,7 @@ describe('NftController', () => {
         signer,
         metadata: [],
       };
-      const fakeResult = txResult as unknown as ServiceReturn<Nft>;
+      const fakeResult = processedTxResult as unknown as ServiceReturn<Nft>;
       mockNftsService.issueNft.mockResolvedValue(fakeResult);
 
       const result = await controller.issueNft({ ticker }, input);
@@ -94,7 +94,7 @@ describe('NftController', () => {
         signer,
         from: new BigNumber(0),
       };
-      const fakeResult = txResult as unknown as ServiceReturn<void>;
+      const fakeResult = processedTxResult as unknown as ServiceReturn<void>;
       mockNftsService.redeemNft.mockResolvedValue(fakeResult);
 
       const result = await controller.redeem({ ticker, id }, input);

--- a/src/nfts/nfts.controller.ts
+++ b/src/nfts/nfts.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiGoneResponse, ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
 import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
-import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';
 import { CreateNftCollectionDto } from '~/nfts/dto/create-nft-collection.dto';

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -26,6 +26,7 @@ export type NotificationPayload<T extends EventType = EventType> = {
   scope: string;
   nonce: number;
   payload: GetPayload<T>;
+  multiSig?: string;
 };
 
 export type NotificationParams = Pick<

--- a/src/offline-starter/models/offline-receipt.model.ts
+++ b/src/offline-starter/models/offline-receipt.model.ts
@@ -34,6 +34,12 @@ export class OfflineReceiptModel {
   })
   readonly metadata: TransactionPayload['metadata'];
 
+  @ApiProperty({
+    description:
+      'The acting MultiSig. Set when the signing account is a MultiSig signer and the transaction was wrapped as a MultiSigProposal',
+  })
+  readonly multiSig: string | null;
+
   constructor(model: OfflineReceiptModel) {
     Object.assign(this, model);
   }

--- a/src/offline-starter/offline-starter.service.ts
+++ b/src/offline-starter/offline-starter.service.ts
@@ -41,6 +41,7 @@ export class OfflineStarterService {
       payload: payload.payload,
       metadata: payload.metadata,
       topicName,
+      multiSig: payload.multiSig,
     });
 
     return model;

--- a/src/portfolios/models/created-portfolio.model.ts
+++ b/src/portfolios/models/created-portfolio.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { PortfolioIdentifierModel } from '~/portfolios/models/portfolio-identifier.model';
 
 export class CreatedPortfolioModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Details of the newly created Portfolio',
     type: PortfolioIdentifierModel,
   })

--- a/src/portfolios/models/historic-settlement.model.ts
+++ b/src/portfolios/models/historic-settlement.model.ts
@@ -2,7 +2,7 @@
 
 import { ApiProperty } from '@nestjs/swagger';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import { SettlementResultEnum } from '@polymeshassociation/polymesh-sdk/middleware/types';
+import { SettlementResultEnum } from '@polymeshassociation/polymesh-sdk/types';
 import { Type } from 'class-transformer';
 
 import { FromBigNumber } from '~/common/decorators/transformation';

--- a/src/portfolios/porfolios.controller.spec.ts
+++ b/src/portfolios/porfolios.controller.spec.ts
@@ -12,7 +12,7 @@ import { HistoricSettlementModel } from '~/portfolios/models/historic-settlement
 import { PortfoliosController } from '~/portfolios/portfolios.controller';
 import { PortfoliosService } from '~/portfolios/portfolios.service';
 import { createPortfolioIdentifierModel, createPortfolioModel } from '~/portfolios/portfolios.util';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { createMockResultSet, MockHistoricSettlement, MockPortfolio } from '~/test-utils/mocks';
 import { MockPortfoliosService } from '~/test-utils/service-mocks';
 
@@ -67,7 +67,7 @@ describe('PortfoliosController', () => {
 
       const result = await controller.moveAssets({ did: '0x6000' }, params);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -87,7 +87,7 @@ describe('PortfoliosController', () => {
       const result = await controller.createPortfolio(params);
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         portfolio: {
           id: '1',
           did,
@@ -105,7 +105,7 @@ describe('PortfoliosController', () => {
         { signer }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -128,7 +128,7 @@ describe('PortfoliosController', () => {
         modifyPortfolioArgs
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -192,9 +192,7 @@ describe('PortfoliosController', () => {
         params
       );
 
-      expect(result).toEqual({
-        ...txResult,
-      });
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -232,9 +230,7 @@ describe('PortfoliosController', () => {
         params
       );
 
-      expect(result).toEqual({
-        ...txResult,
-      });
+      expect(result).toEqual(processedTxResult);
     });
   });
 

--- a/src/portfolios/portfolios.controller.ts
+++ b/src/portfolios/portfolios.controller.ts
@@ -22,7 +22,7 @@ import {
   ApiArrayResponse,
   ApiTransactionFailedResponse,
   ApiTransactionResponse,
-} from '~/common/decorators/swagger';
+} from '~/common/decorators/';
 import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';
 import { DidDto } from '~/common/dto/params.dto';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';

--- a/src/settlements/models/created-instruction.model.ts
+++ b/src/settlements/models/created-instruction.model.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import { ApiExtraModels, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
 import { Instruction } from '@polymeshassociation/polymesh-sdk/types';
 import { Type } from 'class-transformer';
 
@@ -14,7 +14,7 @@ import { OffChainLegModel } from '~/settlements/models/offchain-leg.model';
 
 @ApiExtraModels(LegModel, OffChainLegModel)
 export class CreatedInstructionModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: 'string',
     description: 'ID of the newly created settlement Instruction',
     example: '123',

--- a/src/settlements/models/created-venue.model.ts
+++ b/src/settlements/models/created-venue.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Venue } from '@polymeshassociation/polymesh-sdk/types';
 
 import { FromEntity } from '~/common/decorators/transformation';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 
 export class CreatedVenueModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: 'string',
     description: 'ID of the newly created Venue',
     example: '123',

--- a/src/settlements/settlements.controller.spec.ts
+++ b/src/settlements/settlements.controller.spec.ts
@@ -15,7 +15,7 @@ import { LegType } from '~/common/types';
 import { createPortfolioIdentifierModel } from '~/portfolios/portfolios.util';
 import { SettlementsController } from '~/settlements/settlements.controller';
 import { SettlementsService } from '~/settlements/settlements.service';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { MockInstruction, MockPortfolio } from '~/test-utils/mocks';
 import { MockSettlementsService } from '~/test-utils/service-mocks';
 
@@ -126,7 +126,7 @@ describe('SettlementsController', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await controller.affirmInstruction({ id: new BigNumber(3) }, {} as any);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -139,7 +139,7 @@ describe('SettlementsController', () => {
         { signer: 'signer' }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -152,7 +152,7 @@ describe('SettlementsController', () => {
         { signer: 'signer' }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -166,7 +166,7 @@ describe('SettlementsController', () => {
         {} as any
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -179,7 +179,7 @@ describe('SettlementsController', () => {
         { signer: 'signer' }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -192,7 +192,7 @@ describe('SettlementsController', () => {
         { signer: 'signer' }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -318,7 +318,7 @@ describe('SettlementsController', () => {
         { signer: 'signer' }
       );
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 });

--- a/src/settlements/venues.controller.spec.ts
+++ b/src/settlements/venues.controller.spec.ts
@@ -5,7 +5,7 @@ import { when } from 'jest-when';
 
 import { SettlementsService } from '~/settlements/settlements.service';
 import { VenuesController } from '~/settlements/venues.controller';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { MockInstruction, MockVenue } from '~/test-utils/mocks';
 import { MockSettlementsService } from '~/test-utils/service-mocks';
 
@@ -65,7 +65,7 @@ describe('VenuesController', () => {
       const result = await controller.createVenue(body);
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         venue: mockVenue,
       });
     });
@@ -83,7 +83,7 @@ describe('VenuesController', () => {
 
       const result = await controller.modifyVenue({ id: new BigNumber(3) }, body);
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
     });
   });
 
@@ -103,7 +103,7 @@ describe('VenuesController', () => {
       const result = await controller.createInstruction({ id: new BigNumber(3) }, {} as any);
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         instruction: mockInstruction, // in jest the @FromEntity decorator is not applied
         legs: [],
       });

--- a/src/settlements/venues.controller.ts
+++ b/src/settlements/venues.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import { Instruction, Venue } from '@polymeshassociation/polymesh-sdk/types';
 
-import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { IdParamsDto } from '~/common/dto/id-params.dto';
 import { ResultsModel } from '~/common/models/results.model';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';

--- a/src/subsidy/subsidy.controller.spec.ts
+++ b/src/subsidy/subsidy.controller.spec.ts
@@ -12,7 +12,7 @@ import { ModifyAllowanceDto } from '~/subsidy/dto/modify-allowance.dto';
 import { QuitSubsidyDto } from '~/subsidy/dto/quit-subsidy.dto';
 import { SubsidyController } from '~/subsidy/subsidy.controller';
 import { SubsidyService } from '~/subsidy/subsidy.service';
-import { txResult } from '~/test-utils/consts';
+import { processedTxResult, txResult } from '~/test-utils/consts';
 import { createMockTransactionResult, MockAuthorizationRequest } from '~/test-utils/mocks';
 import { mockSubsidyServiceProvider } from '~/test-utils/service-mocks';
 
@@ -90,7 +90,7 @@ describe('SubsidyController', () => {
 
       expect(result).toEqual(
         new CreatedAuthorizationRequestModel({
-          ...txResult,
+          ...processedTxResult,
           transactions: [transaction],
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),

--- a/src/subsidy/subsidy.controller.ts
+++ b/src/subsidy/subsidy.controller.ts
@@ -10,7 +10,7 @@ import { AllowanceOperation } from '@polymeshassociation/polymesh-sdk/types';
 
 import { authorizationRequestResolver } from '~/authorizations/authorizations.util';
 import { CreatedAuthorizationRequestModel } from '~/authorizations/models/created-authorization-request.model';
-import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';
 import { AccountModel } from '~/identities/models/account.model';

--- a/src/test-utils/consts.ts
+++ b/src/test-utils/consts.ts
@@ -9,6 +9,8 @@ import {
 
 import { TransactionType } from '~/common/types';
 import { OfflineTxModel, OfflineTxStatus } from '~/offline-submitter/models/offline-tx.model';
+import { DirectTransactionResult } from '~/transactions/transactions.util';
+import { ResultType } from '~/transactions/types';
 import { UserModel } from '~/users/model/user.model';
 
 const signer = 'alice';
@@ -46,6 +48,7 @@ const offlineTx = new OfflineTxModel({
     method: '0x01',
     rawPayload: { address: 'address', data: '0x01', type: 'bytes' },
     metadata: { memo: 'test utils payload' },
+    multiSig: null,
   },
   status: OfflineTxStatus.Signed,
   signature: '0x01',
@@ -54,7 +57,8 @@ const offlineTx = new OfflineTxModel({
 });
 
 export const testAccount = createMock<Account>({ address: 'address' });
-export const txResult = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const txResult: DirectTransactionResult<any> = {
   transactions: [
     {
       transactionTag: 'tag',
@@ -78,7 +82,18 @@ export const txResult = {
       type: PayingAccountType.Caller,
     },
   },
+  resultType: ResultType.Direct,
+  result: undefined,
 };
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { result: unusedResult, resultType: unusedType, ...processedResult } = txResult;
+/**
+ * @hidden
+ *
+ * like `txResult`, but without properties not meant for public response API
+ */
+export const processedTxResult = processedResult;
 
 export const testValues = {
   signer,

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -3,15 +3,17 @@
 import { createMock, DeepMocked, PartialFuncReturn } from '@golevelup/ts-jest';
 import { ValueProvider } from '@nestjs/common';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
-import { SettlementResultEnum } from '@polymeshassociation/polymesh-sdk/middleware/types';
 import {
   Account,
   AuthorizationType,
   HistoricSettlement,
   MetadataEntry,
   MetadataType,
+  MultiSig,
+  MultiSigProposal,
   ResultSet,
   SettlementLeg,
+  SettlementResultEnum,
   Subsidy,
   TransactionStatus,
   TrustedClaimIssuer,
@@ -411,6 +413,7 @@ class MockPolymeshTransactionBase {
   blockHash?: string;
   txHash?: string;
   blockNumber?: BigNumber;
+  multiSig?: MultiSig;
   status: TransactionStatus = TransactionStatus.Unapproved;
   error: Error;
   getTotalFees = jest.fn().mockResolvedValue({
@@ -420,6 +423,7 @@ class MockPolymeshTransactionBase {
 
   supportsSubsidy = jest.fn().mockReturnValue(false);
   run = jest.fn().mockReturnValue(Promise.resolve());
+  runAsProposal = jest.fn().mockReturnValue(Promise.resolve(createMock<MultiSigProposal>()));
   toSignablePayload = jest.fn();
   onStatusChange = jest.fn();
 }

--- a/src/ticker-reservations/models/extended-ticker-reservation.model.ts
+++ b/src/ticker-reservations/models/extended-ticker-reservation.model.ts
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { TickerReservationModel } from '~/ticker-reservations/models/ticker-reservation.model';
 
 export class ExtendedTickerReservationModel extends TransactionQueueModel {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Details of the Ticker Reservation',
     type: TickerReservationModel,
   })

--- a/src/ticker-reservations/ticker-reservations.controller.spec.ts
+++ b/src/ticker-reservations/ticker-reservations.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TickerReservationStatus } from '@polymeshassociation/polymesh-sdk/types';
 
 import { createAuthorizationRequestModel } from '~/authorizations/authorizations.util';
-import { testValues } from '~/test-utils/consts';
+import { processedTxResult, testValues } from '~/test-utils/consts';
 import { MockAuthorizationRequest, MockIdentity, MockTickerReservation } from '~/test-utils/mocks';
 import { MockTickerReservationsService } from '~/test-utils/service-mocks';
 import { TickerReservationsController } from '~/ticker-reservations/ticker-reservations.controller';
@@ -36,7 +36,7 @@ describe('TickerReservationsController', () => {
       const ticker = 'SOME_TICKER';
       const result = await controller.reserve({ ticker, signer });
 
-      expect(result).toEqual(txResult);
+      expect(result).toEqual(processedTxResult);
       expect(mockTickerReservationsService.reserve).toHaveBeenCalledWith(ticker, { signer });
     });
   });
@@ -75,7 +75,7 @@ describe('TickerReservationsController', () => {
       const result = await controller.transferOwnership({ ticker }, body);
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });
@@ -107,7 +107,7 @@ describe('TickerReservationsController', () => {
       const result = await controller.extendReservation({ ticker }, { signer, webhookUrl, dryRun });
 
       expect(result).toEqual({
-        ...txResult,
+        ...processedTxResult,
         tickerReservation: mockResult,
       });
       expect(mockTickerReservationsService.extend).toHaveBeenCalledWith(ticker, {

--- a/src/ticker-reservations/ticker-reservations.controller.ts
+++ b/src/ticker-reservations/ticker-reservations.controller.ts
@@ -11,7 +11,7 @@ import { AuthorizationRequest, TickerReservation } from '@polymeshassociation/po
 import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
 import { createAuthorizationRequestModel } from '~/authorizations/authorizations.util';
 import { CreatedAuthorizationRequestModel } from '~/authorizations/models/created-authorization-request.model';
-import { ApiTransactionResponse } from '~/common/decorators/swagger';
+import { ApiTransactionResponse } from '~/common/decorators';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { TransferOwnershipDto } from '~/common/dto/transfer-ownership.dto';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -3,4 +3,9 @@ import {
   PolymeshTransactionBatch,
 } from '@polymeshassociation/polymesh-sdk/types';
 
+export enum ResultType {
+  Direct = 'direct',
+  MultiSigProposal = 'MultiSigProposal',
+}
+
 export type Transaction = PolymeshTransaction | PolymeshTransactionBatch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,10 +1954,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.3.0"
 
-"@polymeshassociation/polymesh-sdk@24.7.0-alpha.2":
-  version "24.7.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.7.0-alpha.2.tgz#38d4be9205cf21321b40b10c8165cd98f0d5f5db"
-  integrity sha512-5XrvgcoMuIneg75/5MuPvWnteqzZieRNziCrlAI/u4D9d/1qum+HxVOcS3/zcX82AV2vJxtnv2B8an/YdfFOKA==
+"@polymeshassociation/polymesh-sdk@24.7.0-alpha.11":
+  version "24.7.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-24.7.0-alpha.11.tgz#a54e28ec13658a8d28a82458e0c1e6462b0f3d0e"
+  integrity sha512-eY3uuY3Q9JWTM1gWze2wUouzRa9A+om8x7JTZkY63Whxvv9BrbsadHjzq7kMCO5SdYZ94MGV2cA1rKd+x789eA==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "11.2.1"
@@ -1986,7 +1986,7 @@
   resolved "https://registry.yarnpkg.com/@polymeshassociation/signing-manager-types/-/signing-manager-types-3.3.0.tgz#ca727b0cde19a0082920a17b231be29b17f60dec"
   integrity sha512-pcnr4XW20htefMDIYnOgOTxPTVspb64DHK0WZFMT7u8ALqtcpN2lgm1XpaMcqCJ+ERWiVgKRvwc6V2AXHhP/ng==
 
-"@prettier/eslint@npm:prettier-eslint@^15.0.1", prettier-eslint@15.0.1:
+"@prettier/eslint@npm:prettier-eslint@^15.0.1":
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-15.0.1.tgz#2543a43e9acec2a9767ad6458165ce81f353db9c"
   integrity sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==
@@ -8821,6 +8821,26 @@ prettier-eslint-cli@7.1.0:
     rxjs "^7.5.6"
     yargs "^13.1.1"
 
+prettier-eslint@15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-15.0.1.tgz#2543a43e9acec2a9767ad6458165ce81f353db9c"
+  integrity sha512-mGOWVHixSvpZWARqSDXbdtTL54mMBxc5oQYQ6RAqy8jecuNJBgN3t9E5a81G66F8x8fsKNiR1HWaBV66MJDOpg==
+  dependencies:
+    "@types/eslint" "^8.4.2"
+    "@types/prettier" "^2.6.0"
+    "@typescript-eslint/parser" "^5.10.0"
+    common-tags "^1.4.0"
+    dlv "^1.1.0"
+    eslint "^8.7.0"
+    indent-string "^4.0.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^2.5.1"
+    pretty-format "^23.0.1"
+    require-relative "^0.8.7"
+    typescript "^4.5.4"
+    vue-eslint-parser "^8.0.1"
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
@@ -9828,7 +9848,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9896,7 +9925,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9916,6 +9945,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -10855,7 +10891,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10877,6 +10913,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### JIRA Link 

[DA-1252](https://polymesh.atlassian.net/browse/DA-1252)

### Changelog / Description 

When a multiSig signer submits a transaction it will be wrapped and a `proposal` field will be present in the response (or `multiSig` field present will be in offline payloads)

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?


[DA-1252]: https://polymesh.atlassian.net/browse/DA-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ