### PR TITLE
fix: 🐛 cdd not created with /identities/register

### DIFF
--- a/src/identities/dto/register-identity.dto.ts
+++ b/src/identities/dto/register-identity.dto.ts
@@ -2,7 +2,7 @@
 
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsDate, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsBoolean, IsDate, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { PermissionedAccountDto } from '~/accounts/dto/permissioned-account.dto';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
@@ -31,6 +31,7 @@ export class RegisterIdentityDto extends TransactionBaseDto {
     type: 'boolean',
     example: false,
   })
+  @IsBoolean()
   readonly createCdd: boolean;
 
   @ApiPropertyOptional({


### PR DESCRIPTION
### Changelog / Description 

`createCdd` would always be false, even when specified in the request. Adds a decorator to DTO param so `createCdd` is parsed properly

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
