### PR TITLE
feat: 🎸 make venueId optional for createInstruction

### DIFF
--- a/src/settlements/settlements.controller.spec.ts
+++ b/src/settlements/settlements.controller.spec.ts
@@ -9,10 +9,12 @@ import {
   Nft,
   TransferError,
 } from '@polymeshassociation/polymesh-sdk/types';
+import { when } from 'jest-when';
 
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
 import { LegType } from '~/common/types';
 import { createPortfolioIdentifierModel } from '~/portfolios/portfolios.util';
+import { CreateInstructionDto } from '~/settlements/dto/create-instruction.dto';
 import { SettlementsController } from '~/settlements/settlements.controller';
 import { SettlementsService } from '~/settlements/settlements.service';
 import { processedTxResult, testValues } from '~/test-utils/consts';
@@ -320,6 +322,28 @@ describe('SettlementsController', () => {
       );
 
       expect(result).toEqual(processedTxResult);
+    });
+  });
+
+  describe('addInstruction', () => {
+    it('should create an instruction and return the data returned by the service', async () => {
+      const mockInstruction = new MockInstruction();
+
+      when(mockInstruction.getLegs).calledWith().mockResolvedValue({ data: [] });
+
+      const mockData = {
+        ...txResult,
+        result: mockInstruction,
+      };
+      mockSettlementsService.createInstruction.mockResolvedValue(mockData);
+
+      const result = await controller.addInstruction({} as CreateInstructionDto);
+
+      expect(result).toEqual({
+        ...processedTxResult,
+        instruction: mockInstruction, // in jest the @FromEntity decorator is not applied
+        legs: [],
+      });
     });
   });
 });

--- a/src/settlements/settlements.service.ts
+++ b/src/settlements/settlements.service.ts
@@ -57,18 +57,28 @@ export class SettlementsService {
   }
 
   public async createInstruction(
-    venueId: BigNumber,
+    venueId: BigNumber | undefined,
     createInstructionDto: CreateInstructionDto
   ): ServiceReturn<Instruction> {
     const { options, args } = extractTxOptions(createInstructionDto);
-    const venue = await this.findVenue(venueId);
+
+    const {
+      polymeshService: {
+        polymeshApi: { settlements },
+      },
+    } = this;
+
+    if (venueId) {
+      await this.findVenue(venueId); // Check if venue exists
+    }
 
     const params = {
       ...args,
       legs: args.legs.map(leg => leg.toLeg()),
+      venueId,
     };
 
-    return this.transactionsService.submit(venue.addInstruction, params, options);
+    return this.transactionsService.submit(settlements.addInstruction, params, options);
   }
 
   public async findVenuesByOwner(did: string): Promise<Venue[]> {

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -120,6 +120,7 @@ export class MockPolymesh {
     getInstruction: jest.fn(),
     getVenue: jest.fn(),
     createVenue: jest.fn(),
+    addInstruction: jest.fn(),
   };
 
   public claims = {


### PR DESCRIPTION
### JIRA Link 

https://polymesh.atlassian.net/browse/DA-1302

### Changelog / Description 

- makes the venueId optional in settlements service
- adds a new endpoint under settlements controller to create an instruction withouth venueId

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
