### PR TITLE
feat: 🎸 Add support for Asset IDs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A REST API wrapper for the Polymesh blockchain.
 
-This version is compatible with chain versions 6.0.x - 6.2.x
+This version is compatible with chain versions 6.3.x - 7.0.x
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@polymeshassociation/fireblocks-signing-manager": "^2.5.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "^3.4.0",
     "@polymeshassociation/local-signing-manager": "^3.3.0",
-    "@polymeshassociation/polymesh-sdk": "26.0.0-alpha.2",
+    "@polymeshassociation/polymesh-sdk": "26.0.0-beta.1",
     "@polymeshassociation/signing-manager-types": "^3.2.0",
     "class-transformer": "0.5.1",
     "class-validator": "^0.14.0",

--- a/src/accounts/dto/transaction-history-filters.dto.ts
+++ b/src/accounts/dto/transaction-history-filters.dto.ts
@@ -36,7 +36,7 @@ export class TransactionHistoryFiltersDto {
     description: 'Transaction tags to be filtered',
     type: 'string',
     enum: getTxTags(),
-    example: TxTags.asset.RegisterTicker,
+    example: TxTags.asset.RegisterUniqueTicker,
   })
   @IsOptional()
   @IsTxTag()

--- a/src/accounts/models/transaction-permissions.model.ts
+++ b/src/accounts/models/transaction-permissions.model.ts
@@ -18,10 +18,10 @@ export class TransactionPermissionsModel extends PermissionTypeModel {
 
   @ApiPropertyOptional({
     description:
-      'Transactions exempted from inclusion or exclusion. For example, if "type" is "Include", "values" contains "asset" and "exceptions" includes "asset.registerTicker", it means that all transactions in the "asset" module are included, EXCEPT for "registerTicker"',
+      'Transactions exempted from inclusion or exclusion. For example, if "type" is "Include", "values" contains "asset" and "exceptions" includes "asset.RegisterUniqueTicker", it means that all transactions in the "asset" module are included, EXCEPT for "RegisterUniqueTicker"',
     isArray: true,
     enum: getTxTags(),
-    example: [TxTags.asset.RegisterTicker],
+    example: [TxTags.asset.RegisterUniqueTicker],
   })
   readonly exceptions?: TxTag[];
 

--- a/src/assets/assets.consts.ts
+++ b/src/assets/assets.consts.ts
@@ -1,3 +1,5 @@
 export const MAX_TICKER_LENGTH = 12;
 
+export const ASSET_ID_LENGTH = 34; // 32 Hex bytes + 0x prefix
+
 export const MAX_CONTENT_HASH_LENGTH = 130;

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -18,7 +18,7 @@ import { processedTxResult, testValues } from '~/test-utils/consts';
 import { MockAsset, MockAuthorizationRequest } from '~/test-utils/mocks';
 import { MockAssetService, mockMetadataServiceProvider } from '~/test-utils/service-mocks';
 
-const { signer, did, txResult } = testValues;
+const { signer, did, txResult, assetId } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
@@ -95,7 +95,7 @@ describe('AssetsController', () => {
       mockAssetsService.findOne.mockResolvedValue(mockAsset);
       mockIsFungibleAsset.mockReturnValue(true);
 
-      const result = await controller.getDetails({ ticker: 'TICKER' });
+      const result = await controller.getDetails({ asset: assetId });
 
       const mockResult = {
         ...mockAssetDetails,
@@ -123,7 +123,7 @@ describe('AssetsController', () => {
     it('should return the list of Asset holders', async () => {
       mockAssetsService.findHolders.mockResolvedValue(mockHolders);
 
-      const result = await controller.getHolders({ ticker: 'TICKER' }, { size: new BigNumber(1) });
+      const result = await controller.getHolders({ asset: assetId }, { size: new BigNumber(1) });
       const expectedResults = mockHolders.data.map(holder => {
         return { identity: holder.identity.did, balance: holder.balance };
       });
@@ -141,7 +141,7 @@ describe('AssetsController', () => {
       mockAssetsService.findHolders.mockResolvedValue(mockHolders);
 
       const result = await controller.getHolders(
-        { ticker: 'TICKER' },
+        { asset: assetId },
         { size: new BigNumber(1), start: 'SOME_START_KEY' }
       );
 
@@ -175,10 +175,7 @@ describe('AssetsController', () => {
     it('should return the list of Asset documents', async () => {
       mockAssetsService.findDocuments.mockResolvedValue(mockDocuments);
 
-      const result = await controller.getDocuments(
-        { ticker: 'TICKER' },
-        { size: new BigNumber(1) }
-      );
+      const result = await controller.getDocuments({ asset: assetId }, { size: new BigNumber(1) });
 
       expect(result).toEqual(
         new PaginatedResultsModel({
@@ -193,7 +190,7 @@ describe('AssetsController', () => {
       mockAssetsService.findDocuments.mockResolvedValue(mockDocuments);
 
       const result = await controller.getDocuments(
-        { ticker: 'TICKER' },
+        { asset: assetId },
         { size: new BigNumber(1), start: 'SOME_START_KEY' }
       );
 
@@ -219,12 +216,11 @@ describe('AssetsController', () => {
           }),
         ],
       };
-      const ticker = 'TICKER';
       mockAssetsService.setDocuments.mockResolvedValue(txResult);
 
-      const result = await controller.setDocuments({ ticker }, body);
+      const result = await controller.setDocuments({ asset: assetId }, body);
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.setDocuments).toHaveBeenCalledWith(ticker, body);
+      expect(mockAssetsService.setDocuments).toHaveBeenCalledWith(assetId, body);
     });
   });
 
@@ -247,13 +243,12 @@ describe('AssetsController', () => {
 
   describe('issue', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
       const amount = new BigNumber(1000);
       mockAssetsService.issue.mockResolvedValue(txResult);
 
-      const result = await controller.issue({ ticker }, { signer, amount });
+      const result = await controller.issue({ asset: assetId }, { signer, amount });
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.issue).toHaveBeenCalledWith(ticker, { signer, amount });
+      expect(mockAssetsService.issue).toHaveBeenCalledWith(assetId, { signer, amount });
     });
   });
 
@@ -267,66 +262,64 @@ describe('AssetsController', () => {
       mockAssetsService.transferOwnership.mockResolvedValue(mockData);
 
       const body = { signer: '0x6000', target: '0x1000' };
-      const ticker = 'SOME_TICKER';
 
-      const result = await controller.transferOwnership({ ticker }, body);
+      const result = await controller.transferOwnership({ asset: assetId }, body);
 
       expect(result).toEqual({
         ...processedTxResult,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         authorizationRequest: createAuthorizationRequestModel(mockAuthorization as any),
       });
-      expect(mockAssetsService.transferOwnership).toHaveBeenCalledWith(ticker, body);
+      expect(mockAssetsService.transferOwnership).toHaveBeenCalledWith(assetId, body);
     });
   });
 
   describe('redeem', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
       const amount = new BigNumber(1000);
       const from = new BigNumber(1);
       mockAssetsService.redeem.mockResolvedValue(txResult);
 
-      const result = await controller.redeem({ ticker }, { signer, amount, from });
+      const result = await controller.redeem({ asset: assetId }, { signer, amount, from });
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.redeem).toHaveBeenCalledWith(ticker, { signer, amount, from });
+      expect(mockAssetsService.redeem).toHaveBeenCalledWith(assetId, { signer, amount, from });
     });
   });
 
   describe('freeze', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
       mockAssetsService.freeze.mockResolvedValue(txResult);
 
-      const result = await controller.freeze({ ticker }, { signer });
+      const result = await controller.freeze({ asset: assetId }, { signer });
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.freeze).toHaveBeenCalledWith(ticker, { signer });
+      expect(mockAssetsService.freeze).toHaveBeenCalledWith(assetId, { signer });
     });
   });
 
   describe('unfreeze', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
       mockAssetsService.unfreeze.mockResolvedValue(txResult);
 
-      const result = await controller.unfreeze({ ticker }, { signer });
+      const result = await controller.unfreeze({ asset: assetId }, { signer });
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.unfreeze).toHaveBeenCalledWith(ticker, { signer });
+      expect(mockAssetsService.unfreeze).toHaveBeenCalledWith(assetId, { signer });
     });
   });
 
   describe('controllerTransfer', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
       const amount = new BigNumber(1000);
       const origin = new PortfolioDto({ id: new BigNumber(1), did: '0x1000' });
 
       mockAssetsService.controllerTransfer.mockResolvedValue(txResult);
 
-      const result = await controller.controllerTransfer({ ticker }, { signer, origin, amount });
+      const result = await controller.controllerTransfer(
+        { asset: assetId },
+        { signer, origin, amount }
+      );
 
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.controllerTransfer).toHaveBeenCalledWith(ticker, {
+      expect(mockAssetsService.controllerTransfer).toHaveBeenCalledWith(assetId, {
         signer,
         origin,
         amount,
@@ -355,7 +348,7 @@ describe('AssetsController', () => {
       ];
       mockAssetsService.getOperationHistory.mockResolvedValue(mockAgentOperations);
 
-      const result = await controller.getOperationHistory({ ticker: 'TICKER' });
+      const result = await controller.getOperationHistory({ asset: assetId });
 
       expect(result).toEqual([
         {
@@ -374,7 +367,7 @@ describe('AssetsController', () => {
 
       mockAssetsService.getRequiredMediators.mockResolvedValue([mockMediator]);
 
-      const result = await controller.getRequiredMediators({ ticker: 'TICKER' });
+      const result = await controller.getRequiredMediators({ asset: assetId });
 
       expect(result).toEqual({
         mediators: [mockMediator.did],
@@ -384,15 +377,17 @@ describe('AssetsController', () => {
 
   describe('addRequiredMediators', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
       const mediators = ['someDid'];
 
       mockAssetsService.addRequiredMediators.mockResolvedValue(txResult);
 
-      const result = await controller.addRequiredMediators({ ticker }, { signer, mediators });
+      const result = await controller.addRequiredMediators(
+        { asset: assetId },
+        { signer, mediators }
+      );
 
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.addRequiredMediators).toHaveBeenCalledWith(ticker, {
+      expect(mockAssetsService.addRequiredMediators).toHaveBeenCalledWith(assetId, {
         signer,
         mediators,
       });
@@ -401,15 +396,17 @@ describe('AssetsController', () => {
 
   describe('removeRequiredMediators', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
       const mediators = ['someDid'];
 
       mockAssetsService.removeRequiredMediators.mockResolvedValue(txResult);
 
-      const result = await controller.removeRequiredMediators({ ticker }, { signer, mediators });
+      const result = await controller.removeRequiredMediators(
+        { asset: assetId },
+        { signer, mediators }
+      );
 
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.removeRequiredMediators).toHaveBeenCalledWith(ticker, {
+      expect(mockAssetsService.removeRequiredMediators).toHaveBeenCalledWith(assetId, {
         signer,
         mediators,
       });
@@ -418,14 +415,12 @@ describe('AssetsController', () => {
 
   describe('preApprove', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
-
       mockAssetsService.preApprove.mockResolvedValue(txResult);
 
-      const result = await controller.preApprove({ ticker }, { signer });
+      const result = await controller.preApprove({ asset: assetId }, { signer });
 
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.preApprove).toHaveBeenCalledWith(ticker, {
+      expect(mockAssetsService.preApprove).toHaveBeenCalledWith(assetId, {
         signer,
       });
     });
@@ -433,14 +428,12 @@ describe('AssetsController', () => {
 
   describe('removePreApproval', () => {
     it('should call the service and return the results', async () => {
-      const ticker = 'TICKER';
-
       mockAssetsService.removePreApproval.mockResolvedValue(txResult);
 
-      const result = await controller.removePreApproval({ ticker }, { signer });
+      const result = await controller.removePreApproval({ asset: assetId }, { signer });
 
       expect(result).toEqual(processedTxResult);
-      expect(mockAssetsService.removePreApproval).toHaveBeenCalledWith(ticker, {
+      expect(mockAssetsService.removePreApproval).toHaveBeenCalledWith(assetId, {
         signer,
       });
     });

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -13,13 +13,13 @@ import {
 
 import { AssetsService } from '~/assets/assets.service';
 import { createAssetDetailsModel } from '~/assets/assets.util';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import { ControllerTransferDto } from '~/assets/dto/controller-transfer.dto';
 import { CreateAssetDto } from '~/assets/dto/create-asset.dto';
 import { IssueDto } from '~/assets/dto/issue.dto';
 import { RedeemTokensDto } from '~/assets/dto/redeem-tokens.dto';
 import { RequiredMediatorsDto } from '~/assets/dto/required-mediators.dto';
 import { SetAssetDocumentsDto } from '~/assets/dto/set-asset-documents.dto';
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
 import { AgentOperationModel } from '~/assets/models/agent-operation.model';
 import { AssetDetailsModel } from '~/assets/models/asset-details.model';
 import { AssetDocumentModel } from '~/assets/models/asset-document.model';
@@ -69,20 +69,20 @@ export class AssetsController {
     description: 'This endpoint will provide the basic details of an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose details are to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose details are to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiOkResponse({
     description: 'Basic details of the Asset',
     type: AssetDetailsModel,
   })
-  @Get(':ticker')
-  public async getDetails(@Param() { ticker }: TickerParamsDto): Promise<AssetDetailsModel> {
-    const asset = await this.assetsService.findOne(ticker);
+  @Get(':asset')
+  public async getDetails(@Param() { asset }: AssetParamsDto): Promise<AssetDetailsModel> {
+    const result = await this.assetsService.findOne(asset);
 
-    return createAssetDetailsModel(asset);
+    return createAssetDetailsModel(result);
   }
 
   @ApiOperation({
@@ -91,10 +91,10 @@ export class AssetsController {
       'This endpoint will provide the list of Asset holders along with their current balance',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose holders are to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose holders are to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiQuery({
     name: 'size',
@@ -113,16 +113,16 @@ export class AssetsController {
     description: 'List of Asset holders, each consisting of a DID and their current Asset balance',
     paginated: true,
   })
-  @Get(':ticker/holders')
+  @Get(':asset/holders')
   public async getHolders(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Query() { size, start }: PaginatedParamsDto
   ): Promise<PaginatedResultsModel<IdentityBalanceModel>> {
     const {
       data,
       count: total,
       next,
-    } = await this.assetsService.findHolders(ticker, size, start?.toString());
+    } = await this.assetsService.findHolders(asset, size, start?.toString());
 
     return new PaginatedResultsModel({
       results: data.map(
@@ -143,10 +143,10 @@ export class AssetsController {
     description: 'This endpoint will provide the list of documents attached to an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose attached documents are to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose attached documents are to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiQuery({
     name: 'size',
@@ -166,16 +166,16 @@ export class AssetsController {
     description: 'List of documents attached to the Asset',
     paginated: true,
   })
-  @Get(':ticker/documents')
+  @Get(':asset/documents')
   public async getDocuments(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Query() { size, start }: PaginatedParamsDto
   ): Promise<PaginatedResultsModel<AssetDocumentModel>> {
     const {
       data,
       count: total,
       next,
-    } = await this.assetsService.findDocuments(ticker, size, start?.toString());
+    } = await this.assetsService.findDocuments(asset, size, start?.toString());
 
     return new PaginatedResultsModel({
       results: data.map(
@@ -200,10 +200,10 @@ export class AssetsController {
       'This endpoint assigns a new list of Documents to the Asset by replacing the existing list of Documents with the ones passed in the body',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose documents are to be updated',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose documents are to be updated',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiOkResponse({
     description: 'Details of the transaction',
@@ -214,12 +214,12 @@ export class AssetsController {
   @ApiBadRequestResponse({
     description: 'The supplied Document list is equal to the current one',
   })
-  @Post(':ticker/documents/set')
+  @Post(':asset/documents/set')
   public async setDocuments(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() setAssetDocumentsDto: SetAssetDocumentsDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.setDocuments(ticker, setAssetDocumentsDto);
+    const result = await this.assetsService.setDocuments(asset, setAssetDocumentsDto);
     return handleServiceResult(result);
   }
 
@@ -228,10 +228,10 @@ export class AssetsController {
     description: 'This endpoint issues more of a given Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to issue',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to issue',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -240,12 +240,12 @@ export class AssetsController {
   @ApiNotFoundResponse({
     description: 'The Asset does not exist',
   })
-  @Post(':ticker/issue')
+  @Post(':asset/issue')
   public async issue(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: IssueDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.issue(ticker, params);
+    const result = await this.assetsService.issue(asset, params);
     return handleServiceResult(result);
   }
 
@@ -275,21 +275,21 @@ export class AssetsController {
       'This endpoint transfers ownership of the Asset to a `target` Identity. This generates an authorization request that must be accepted by the `target` Identity',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'Ticker of the Asset whose ownership is to be transferred',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose ownership is to be transferred',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Newly created Authorization Request along with transaction details',
     type: CreatedAuthorizationRequestModel,
   })
-  @Post('/:ticker/transfer-ownership')
+  @Post('/:asset/transfer-ownership')
   public async transferOwnership(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: TransferOwnershipDto
   ): Promise<TransactionResponseModel> {
-    const serviceResult = await this.assetsService.transferOwnership(ticker, params);
+    const serviceResult = await this.assetsService.transferOwnership(asset, params);
 
     return handleServiceResult(serviceResult, authorizationRequestResolver);
   }
@@ -310,12 +310,12 @@ export class AssetsController {
     description:
       "The amount to be redeemed is larger than the free balance in the Signer's Default Portfolio",
   })
-  @Post(':ticker/redeem')
+  @Post(':asset/redeem')
   public async redeem(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: RedeemTokensDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.redeem(ticker, params);
+    const result = await this.assetsService.redeem(asset, params);
     return handleServiceResult(result);
   }
 
@@ -326,10 +326,10 @@ export class AssetsController {
       'This endpoint submits a transaction that causes the Asset to become frozen. This means that it cannot be transferred or minted until it is unfrozen',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to freeze',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to freeze',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -341,12 +341,12 @@ export class AssetsController {
   @ApiUnprocessableEntityResponse({
     description: 'The Asset is already frozen',
   })
-  @Post(':ticker/freeze')
+  @Post(':asset/freeze')
   public async freeze(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.freeze(ticker, transactionBaseDto);
+    const result = await this.assetsService.freeze(asset, transactionBaseDto);
     return handleServiceResult(result);
   }
 
@@ -357,10 +357,10 @@ export class AssetsController {
       'This endpoint submits a transaction that unfreezes the Asset. This means that transfers and minting can be performed until it is frozen again',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to unfreeze',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to unfreeze',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -372,12 +372,12 @@ export class AssetsController {
   @ApiUnprocessableEntityResponse({
     description: 'The Asset is already unfrozen',
   })
-  @Post(':ticker/unfreeze')
+  @Post(':asset/unfreeze')
   public async unfreeze(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.unfreeze(ticker, transactionBaseDto);
+    const result = await this.assetsService.unfreeze(asset, transactionBaseDto);
     return handleServiceResult(result);
   }
 
@@ -387,10 +387,10 @@ export class AssetsController {
       'This endpoint forces a transfer from the `origin` Portfolio to the signer’s Default Portfolio',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to be transferred',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to be transferred',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -402,12 +402,12 @@ export class AssetsController {
   @ApiUnprocessableEntityResponse({
     description: 'The `origin` Portfolio does not have enough free balance for the transfer',
   })
-  @Post(':ticker/controller-transfer')
+  @Post(':asset/controller-transfer')
   public async controllerTransfer(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: ControllerTransferDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.controllerTransfer(ticker, params);
+    const result = await this.assetsService.controllerTransfer(asset, params);
     return handleServiceResult(result);
   }
 
@@ -417,21 +417,21 @@ export class AssetsController {
       "This endpoint provides a list of events triggered by transactions performed by various agent Identities, related to the Asset's configuration",
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose operation history is to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose operation history is to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiOkResponse({
     description: 'List of operations grouped by the agent Identity who performed them',
     isArray: true,
     type: AgentOperationModel,
   })
-  @Get(':ticker/operations')
+  @Get(':asset/operations')
   public async getOperationHistory(
-    @Param() { ticker }: TickerParamsDto
+    @Param() { asset }: AssetParamsDto
   ): Promise<AgentOperationModel[]> {
-    const agentOperations = await this.assetsService.getOperationHistory(ticker);
+    const agentOperations = await this.assetsService.getOperationHistory(asset);
 
     return agentOperations.map(agentOperation => new AgentOperationModel(agentOperation));
   }
@@ -442,20 +442,20 @@ export class AssetsController {
       'This endpoint provides a list of required mediators for the asset. These identities must affirm any instruction involving the asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose required mediators is to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose required mediators is to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiOkResponse({
     description: 'The required mediators for the asset',
     type: RequiredMediatorsModel,
   })
-  @Get(':ticker/required-mediators')
+  @Get(':asset/required-mediators')
   public async getRequiredMediators(
-    @Param() { ticker }: TickerParamsDto
+    @Param() { asset }: AssetParamsDto
   ): Promise<RequiredMediatorsModel> {
-    const mediatorIdentities = await this.assetsService.getRequiredMediators(ticker);
+    const mediatorIdentities = await this.assetsService.getRequiredMediators(asset);
     const mediators = mediatorIdentities.map(({ did }) => did);
 
     return new RequiredMediatorsModel({ mediators });
@@ -467,10 +467,10 @@ export class AssetsController {
       'This endpoint adds required mediators for an asset. These identities will need to affirm instructions involving this asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to set required mediators for',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to set required mediators for',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -479,12 +479,12 @@ export class AssetsController {
   @ApiNotFoundResponse({
     description: 'The Asset does not exist',
   })
-  @Post(':ticker/add-required-mediators')
+  @Post(':asset/add-required-mediators')
   public async addRequiredMediators(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: RequiredMediatorsDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.addRequiredMediators(ticker, params);
+    const result = await this.assetsService.addRequiredMediators(asset, params);
     return handleServiceResult(result);
   }
 
@@ -493,10 +493,10 @@ export class AssetsController {
     description: 'This endpoint removes required mediators for an asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to set required mediators for',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to set required mediators for',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -505,12 +505,12 @@ export class AssetsController {
   @ApiNotFoundResponse({
     description: 'The Asset does not exist',
   })
-  @Post(':ticker/remove-required-mediators')
+  @Post(':asset/remove-required-mediators')
   public async removeRequiredMediators(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: RequiredMediatorsDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.removeRequiredMediators(ticker, params);
+    const result = await this.assetsService.removeRequiredMediators(asset, params);
     return handleServiceResult(result);
   }
 
@@ -519,10 +519,10 @@ export class AssetsController {
     description: 'This endpoint enables automatic affirmation when receiving the asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to pre-approve',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to pre-approve',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -534,12 +534,12 @@ export class AssetsController {
   @ApiBadRequestResponse({
     description: 'The signing identity has already pre-approved the asset',
   })
-  @Post(':ticker/pre-approve')
+  @Post(':asset/pre-approve')
   public async preApprove(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.preApprove(ticker, params);
+    const result = await this.assetsService.preApprove(asset, params);
 
     return handleServiceResult(result);
   }
@@ -549,10 +549,10 @@ export class AssetsController {
     description: 'This endpoint disables automatic affirmation when receiving the asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to remove pre-approval for',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to remove pre-approval for',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
@@ -564,12 +564,12 @@ export class AssetsController {
   @ApiBadRequestResponse({
     description: 'The asset is not pre-approved for the signing identity',
   })
-  @Post(':ticker/remove-pre-approval')
+  @Post(':asset/remove-pre-approval')
   public async removePreApproval(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.assetsService.removePreApproval(ticker, params);
+    const result = await this.assetsService.removePreApproval(asset, params);
 
     return handleServiceResult(result);
   }

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -12,6 +12,7 @@ import {
   ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
 
+import { ASSET_ID_LENGTH } from '~/assets/assets.consts';
 import { ControllerTransferDto } from '~/assets/dto/controller-transfer.dto';
 import { CreateAssetDto } from '~/assets/dto/create-asset.dto';
 import { IssueDto } from '~/assets/dto/issue.dto';
@@ -34,18 +35,30 @@ export class AssetsService {
     private readonly transactionsService: TransactionsService
   ) {}
 
-  public async findOne(ticker: string): Promise<Asset> {
-    return await this.polymeshService.polymeshApi.assets.getAsset({ ticker }).catch(error => {
+  public async findOne(asset: string): Promise<Asset> {
+    let getAssetPromise;
+    if (asset.length === ASSET_ID_LENGTH) {
+      getAssetPromise = this.polymeshService.polymeshApi.assets.getAsset({ assetId: asset });
+    } else {
+      getAssetPromise = this.polymeshService.polymeshApi.assets.getAsset({ ticker: asset });
+    }
+    return await getAssetPromise.catch(error => {
       throw handleSdkError(error);
     });
   }
 
-  public async findFungible(ticker: string): Promise<FungibleAsset> {
-    return await this.polymeshService.polymeshApi.assets
-      .getFungibleAsset({ ticker })
-      .catch(error => {
-        throw handleSdkError(error);
+  public async findFungible(asset: string): Promise<FungibleAsset> {
+    let getAssetPromise;
+    if (asset.length === ASSET_ID_LENGTH) {
+      getAssetPromise = this.polymeshService.polymeshApi.assets.getFungibleAsset({
+        assetId: asset,
       });
+    } else {
+      getAssetPromise = this.polymeshService.polymeshApi.assets.getFungibleAsset({ ticker: asset });
+    }
+    return await getAssetPromise.catch(error => {
+      throw handleSdkError(error);
+    });
   }
 
   public async findAllByOwner(owner: string): Promise<(FungibleAsset | NftCollection)[]> {

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -12,13 +12,13 @@ import {
   ResultSet,
 } from '@polymeshassociation/polymesh-sdk/types';
 
-import { ASSET_ID_LENGTH } from '~/assets/assets.consts';
 import { ControllerTransferDto } from '~/assets/dto/controller-transfer.dto';
 import { CreateAssetDto } from '~/assets/dto/create-asset.dto';
 import { IssueDto } from '~/assets/dto/issue.dto';
 import { RedeemTokensDto } from '~/assets/dto/redeem-tokens.dto';
 import { RequiredMediatorsDto } from '~/assets/dto/required-mediators.dto';
 import { SetAssetDocumentsDto } from '~/assets/dto/set-asset-documents.dto';
+import { isAssetId } from '~/common/decorators';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { TransferOwnershipDto } from '~/common/dto/transfer-ownership.dto';
 import { AppNotFoundError } from '~/common/errors';
@@ -37,7 +37,7 @@ export class AssetsService {
 
   public async findOne(asset: string): Promise<Asset> {
     let getAssetPromise;
-    if (asset.length === ASSET_ID_LENGTH) {
+    if (isAssetId(asset)) {
       getAssetPromise = this.polymeshService.polymeshApi.assets.getAsset({ assetId: asset });
     } else {
       getAssetPromise = this.polymeshService.polymeshApi.assets.getAsset({ ticker: asset });
@@ -49,7 +49,7 @@ export class AssetsService {
 
   public async findFungible(asset: string): Promise<FungibleAsset> {
     let getAssetPromise;
-    if (asset.length === ASSET_ID_LENGTH) {
+    if (isAssetId(asset)) {
       getAssetPromise = this.polymeshService.polymeshApi.assets.getFungibleAsset({
         assetId: asset,
       });

--- a/src/assets/dto/asset-params.dto.ts
+++ b/src/assets/dto/asset-params.dto.ts
@@ -1,9 +1,8 @@
 /* istanbul ignore file */
 
 import { IsAsset } from '~/common/decorators/validation';
-import { IdParamsDto } from '~/common/dto/id-params.dto';
 
-export class CheckpointParamsDto extends IdParamsDto {
+export class AssetParamsDto {
   @IsAsset()
   readonly asset: string;
 }

--- a/src/assets/dto/create-asset.dto.ts
+++ b/src/assets/dto/create-asset.dto.ts
@@ -15,17 +15,19 @@ import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 export class CreateAssetDto extends TransactionBaseDto {
   @ApiProperty({
     description: 'The name of the Asset',
-    example: 'Ticker Corp',
+    example: 'Asset Corp',
   })
   @IsString()
   readonly name: string;
 
-  @ApiProperty({
-    description: 'The ticker of the Asset. This must either be free or reserved by the Signer',
+  @ApiPropertyOptional({
+    description:
+      'The ticker of the Asset. This must either be free or reserved by the Signer. Note, this value is optional from 7.x chain',
     example: 'TICKER',
   })
+  @IsOptional()
   @IsTicker()
-  readonly ticker: string;
+  readonly ticker?: string;
 
   @ApiPropertyOptional({
     description: 'The initial supply count of the Asset',

--- a/src/checkpoints/checkpoints.service.ts
+++ b/src/checkpoints/checkpoints.service.ts
@@ -28,100 +28,104 @@ export class CheckpointsService {
     logger.setContext(CheckpointsService.name);
   }
 
-  public async findAllByTicker(
-    ticker: string,
+  public async findAllByAsset(
+    asset: string,
     size: BigNumber,
     start?: string
   ): Promise<ResultSet<CheckpointWithData>> {
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
-    return asset.checkpoints.get({ start, size });
+    return fungibleAsset.checkpoints.get({ start, size });
   }
 
-  public async findOne(ticker: string, id: BigNumber): Promise<Checkpoint> {
-    const asset = await this.assetsService.findFungible(ticker);
+  public async findOne(asset: string, id: BigNumber): Promise<Checkpoint> {
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
-    return await asset.checkpoints.getOne({ id }).catch(error => {
+    return await fungibleAsset.checkpoints.getOne({ id }).catch(error => {
       throw handleSdkError(error);
     });
   }
 
-  public async findSchedulesByTicker(ticker: string): Promise<ScheduleWithDetails[]> {
-    const asset = await this.assetsService.findFungible(ticker);
+  public async findSchedulesByAsset(asset: string): Promise<ScheduleWithDetails[]> {
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
-    return asset.checkpoints.schedules.get();
+    return fungibleAsset.checkpoints.schedules.get();
   }
 
-  public async findScheduleById(ticker: string, id: BigNumber): Promise<ScheduleWithDetails> {
-    const asset = await this.assetsService.findFungible(ticker);
+  public async findScheduleById(asset: string, id: BigNumber): Promise<ScheduleWithDetails> {
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
-    return await asset.checkpoints.schedules.getOne({ id }).catch(error => {
+    return await fungibleAsset.checkpoints.schedules.getOne({ id }).catch(error => {
       throw handleSdkError(error);
     });
   }
 
-  public async createByTicker(
-    ticker: string,
+  public async createByAsset(
+    asset: string,
     signerDto: TransactionBaseDto
   ): ServiceReturn<Checkpoint> {
     const { options } = extractTxOptions(signerDto);
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
-    return this.transactionsService.submit(asset.checkpoints.create, {}, options);
+    return this.transactionsService.submit(fungibleAsset.checkpoints.create, {}, options);
   }
 
-  public async createScheduleByTicker(
-    ticker: string,
+  public async createScheduleByAsset(
+    asset: string,
     createCheckpointScheduleDto: CreateCheckpointScheduleDto
   ): ServiceReturn<CheckpointSchedule> {
     const { options, args } = extractTxOptions(createCheckpointScheduleDto);
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
-    return this.transactionsService.submit(asset.checkpoints.schedules.create, args, options);
+    return this.transactionsService.submit(
+      fungibleAsset.checkpoints.schedules.create,
+      args,
+      options
+    );
   }
 
   public async getAssetBalance(
-    ticker: string,
+    asset: string,
     did: string,
     checkpointId: BigNumber
   ): Promise<IdentityBalanceModel> {
-    const checkpoint = await this.findOne(ticker, checkpointId);
+    const checkpoint = await this.findOne(asset, checkpointId);
     const balance = await checkpoint.balance({ identity: did });
 
     return new IdentityBalanceModel({ identity: did, balance });
   }
 
   public async getHolders(
-    ticker: string,
+    asset: string,
     checkpointId: BigNumber,
     size: BigNumber,
     start?: string
   ): Promise<ResultSet<IdentityBalance>> {
-    const checkpoint = await this.findOne(ticker, checkpointId);
+    const checkpoint = await this.findOne(asset, checkpointId);
 
     return checkpoint.allBalances({ start, size });
   }
 
-  public async deleteScheduleByTicker(
-    ticker: string,
+  public async deleteScheduleByAsset(
+    asset: string,
     id: BigNumber,
     transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const { options } = extractTxOptions(transactionBaseDto);
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
     return this.transactionsService.submit(
-      asset.checkpoints.schedules.remove,
+      fungibleAsset.checkpoints.schedules.remove,
       { schedule: id },
       options
     );
   }
 
   public async findCheckpointsByScheduleId(
-    ticker: string,
+    asset: string,
     id: BigNumber
   ): Promise<CheckpointWithData[]> {
-    const schedule = await this.findScheduleById(ticker, id);
+    const schedule = await this.findScheduleById(asset, id);
 
     const checkpoints = await schedule.schedule.getCheckpoints();
 
@@ -142,24 +146,24 @@ export class CheckpointsService {
   }
 
   public async getComplexityForAsset(
-    ticker: string
+    asset: string
   ): Promise<{ schedules: ScheduleWithDetails[]; maxComplexity: BigNumber }> {
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
     const [schedules, maxComplexity] = await Promise.all([
-      asset.checkpoints.schedules.get(),
-      asset.checkpoints.schedules.maxComplexity(),
+      fungibleAsset.checkpoints.schedules.get(),
+      fungibleAsset.checkpoints.schedules.maxComplexity(),
     ]);
 
     return { schedules, maxComplexity };
   }
 
   public async getComplexityForPeriod(
-    ticker: string,
+    asset: string,
     id: BigNumber,
     start?: Date,
     end?: Date
   ): Promise<BigNumber> {
-    const { schedule } = await this.findScheduleById(ticker, id);
+    const { schedule } = await this.findScheduleById(asset, id);
 
     const checkpoints = await schedule.getCheckpoints();
     const pendingPoints = schedule.pendingPoints;

--- a/src/checkpoints/dto/checkpoint-balance.dto.ts
+++ b/src/checkpoints/dto/checkpoint-balance.dto.ts
@@ -1,11 +1,11 @@
 /* istanbul ignore file */
 
-import { IsDid, IsTicker } from '~/common/decorators/validation';
+import { IsAsset, IsDid } from '~/common/decorators/validation';
 import { IdParamsDto } from '~/common/dto/id-params.dto';
 
 export class CheckPointBalanceParamsDto extends IdParamsDto {
-  @IsTicker()
-  readonly ticker: string;
+  @IsAsset()
+  readonly asset: string;
 
   @IsDid()
   readonly did: string;

--- a/src/checkpoints/models/checkpoint-schedule.model.ts
+++ b/src/checkpoints/models/checkpoint-schedule.model.ts
@@ -15,11 +15,11 @@ export class CheckpointScheduleModel {
   readonly id: BigNumber;
 
   @ApiProperty({
-    description: 'Ticker of the Asset whose Checkpoints will be created with this Schedule',
+    description: 'The Asset (Asset ID/Ticker) whose Checkpoints will be created with this Schedule',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
-  readonly ticker: string;
+  readonly asset: string;
 
   @ApiProperty({
     description:

--- a/src/common/decorators/validation.ts
+++ b/src/common/decorators/validation.ts
@@ -42,7 +42,7 @@ export function IsTicker(validationOptions?: ValidationOptions) {
   );
 }
 
-const assetIdRegex = /0x[0-9A-F]{32}/;
+const assetIdRegex = /0x[0-9a-fA-F]{32}/;
 export const isAssetId = (id: string): boolean => {
   return assetIdRegex.test(id);
 };

--- a/src/common/decorators/validation.ts
+++ b/src/common/decorators/validation.ts
@@ -14,7 +14,7 @@ import {
   ValidationOptions,
 } from 'class-validator';
 
-import { MAX_TICKER_LENGTH } from '~/assets/assets.consts';
+import { ASSET_ID_LENGTH, MAX_TICKER_LENGTH } from '~/assets/assets.consts';
 import { getTxTags, getTxTagsWithModuleNames } from '~/common/utils';
 import { DID_LENGTH } from '~/identities/identities.consts';
 
@@ -40,6 +40,31 @@ export function IsTicker(validationOptions?: ValidationOptions) {
     MaxLength(MAX_TICKER_LENGTH, validationOptions),
     IsUppercase(validationOptions)
   );
+}
+
+export function IsAsset(validationOptions?: ValidationOptions) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isAsset',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: string) {
+          if (value.startsWith('0x')) {
+            // check for Asset ID
+            return value.length === ASSET_ID_LENGTH;
+          }
+
+          return value.length <= MAX_TICKER_LENGTH && value === value.toUpperCase();
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be either a Ticker (${MAX_TICKER_LENGTH} characters uppercase string) or an Asset ID (${ASSET_ID_LENGTH} characters long hex string)`;
+        },
+      },
+    });
+  };
 }
 
 export function IsBigNumber(

--- a/src/common/decorators/validation.ts
+++ b/src/common/decorators/validation.ts
@@ -42,6 +42,11 @@ export function IsTicker(validationOptions?: ValidationOptions) {
   );
 }
 
+const assetIdRegex = /0x[0-9A-F]{32}/;
+export const isAssetId = (id: string): boolean => {
+  return assetIdRegex.test(id);
+};
+
 export function IsAsset(validationOptions?: ValidationOptions) {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return function (object: Object, propertyName: string) {
@@ -52,12 +57,9 @@ export function IsAsset(validationOptions?: ValidationOptions) {
       options: validationOptions,
       validator: {
         validate(value: string) {
-          if (value.startsWith('0x')) {
-            // check for Asset ID
-            return value.length === ASSET_ID_LENGTH;
-          }
-
-          return value.length <= MAX_TICKER_LENGTH && value === value.toUpperCase();
+          return (
+            isAssetId(value) || (value.length <= MAX_TICKER_LENGTH && value === value.toUpperCase())
+          );
         },
         defaultMessage(args: ValidationArguments) {
           return `${args.property} must be either a Ticker (${MAX_TICKER_LENGTH} characters uppercase string) or an Asset ID (${ASSET_ID_LENGTH} characters long hex string)`;

--- a/src/common/models/batch-transaction.model.ts
+++ b/src/common/models/batch-transaction.model.ts
@@ -11,7 +11,7 @@ export class BatchTransactionModel extends TransactionIdentifierModel {
       'List of Transaction type identifier (for UI purposes). The format for each identifier is <palletName>.<transactionName>',
     type: 'string',
     isArray: true,
-    example: 'asset.registerTicker',
+    example: 'asset.RegisterUniqueTicker',
   })
   readonly transactionTags?: string[];
 

--- a/src/common/models/extrinsic.model.ts
+++ b/src/common/models/extrinsic.model.ts
@@ -54,7 +54,7 @@ export class ExtrinsicModel {
       'Transaction type identifier (for UI purposes). The format is <palletName>.<transactionName>',
     type: 'string',
     enum: getTxTags(),
-    example: TxTags.asset.RegisterTicker,
+    example: TxTags.asset.RegisterUniqueTicker,
   })
   readonly transactionTag: TxTag;
 
@@ -63,8 +63,8 @@ export class ExtrinsicModel {
     isArray: true,
     example: [
       {
-        name: 'ticker',
-        value: 'TICKER',
+        name: 'asset',
+        value: '0xa3616b82e8e1080aedc952ea28b9db8b',
       },
     ],
   })

--- a/src/common/models/transaction.model.ts
+++ b/src/common/models/transaction.model.ts
@@ -10,7 +10,7 @@ export class TransactionModel extends TransactionIdentifierModel {
     description:
       'Transaction type identifier (for UI purposes). The format is <palletName>.<transactionName>',
     type: 'string',
-    example: 'asset.registerTicker',
+    example: 'asset.RegisterUniqueTicker',
   })
   readonly transactionTag: string;
 

--- a/src/compliance/compliance-requirements.controller.spec.ts
+++ b/src/compliance/compliance-requirements.controller.spec.ts
@@ -17,9 +17,8 @@ import { mockComplianceRequirementsServiceProvider } from '~/test-utils/service-
 describe('ComplianceRequirementsController', () => {
   let controller: ComplianceRequirementsController;
   let mockService: ComplianceRequirementsService;
-  const { did, signer, txResult } = testValues;
+  const { did, signer, txResult, assetId } = testValues;
 
-  const ticker = 'TICKER';
   const validBody = {
     signer,
     requirements: [
@@ -59,10 +58,10 @@ describe('ComplianceRequirementsController', () => {
   describe('getComplianceRequirements', () => {
     it('should return the list of all compliance requirements of an Asset', async () => {
       when(mockService.findComplianceRequirements)
-        .calledWith(ticker)
+        .calledWith(assetId)
         .mockResolvedValue(mockComplianceRequirements);
 
-      const result = await controller.getComplianceRequirements({ ticker });
+      const result = await controller.getComplianceRequirements({ asset: assetId });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(result).toEqual(new ComplianceRequirementsModel(mockComplianceRequirements as any));
@@ -74,10 +73,13 @@ describe('ComplianceRequirementsController', () => {
       const response = createMockTransactionResult<void>({ ...txResult, transactions: [] });
 
       when(mockService.setRequirements)
-        .calledWith(ticker, validBody as SetRequirementsDto)
+        .calledWith(assetId, validBody as SetRequirementsDto)
         .mockResolvedValue(response);
 
-      const result = await controller.setRequirements({ ticker }, validBody as SetRequirementsDto);
+      const result = await controller.setRequirements(
+        { asset: assetId },
+        validBody as SetRequirementsDto
+      );
       expect(result).toEqual(response);
     });
   });
@@ -85,10 +87,10 @@ describe('ComplianceRequirementsController', () => {
   describe('pauseRequirements', () => {
     it('should accept TransactionBaseDto and pause Asset Compliance Rules', async () => {
       when(mockService.pauseRequirements)
-        .calledWith(ticker, validBody)
+        .calledWith(assetId, validBody)
         .mockResolvedValue(txResponse);
 
-      const result = await controller.pauseRequirements({ ticker }, validBody);
+      const result = await controller.pauseRequirements({ asset: assetId }, validBody);
       expect(result).toEqual(txResponse);
     });
   });
@@ -96,29 +98,29 @@ describe('ComplianceRequirementsController', () => {
   describe('unpauseRequirements', () => {
     it('should accept TransactionBaseDto and unpause Asset Compliance Rules', async () => {
       when(mockService.unpauseRequirements)
-        .calledWith(ticker, validBody)
+        .calledWith(assetId, validBody)
         .mockResolvedValue(txResponse);
 
-      const result = await controller.unpauseRequirements({ ticker }, validBody);
+      const result = await controller.unpauseRequirements({ asset: assetId }, validBody);
       expect(result).toEqual(txResponse);
     });
   });
 
   describe('deleteRequirement', () => {
-    it('should accept TransactionBaseDto and compliance requirement ID and delete the corresponding Asset Compliance rule for the given ticker', async () => {
-      when(mockService.deleteOne).calledWith(ticker, id, validBody).mockResolvedValue(txResponse);
+    it('should accept TransactionBaseDto and compliance requirement ID and delete the corresponding Asset Compliance rule for the given Asset', async () => {
+      when(mockService.deleteOne).calledWith(assetId, id, validBody).mockResolvedValue(txResponse);
 
-      const result = await controller.deleteRequirement({ ticker, id }, validBody);
+      const result = await controller.deleteRequirement({ asset: assetId, id }, validBody);
 
       expect(result).toEqual(txResponse);
     });
   });
 
   describe('deleteRequirements', () => {
-    it('should accept TransactionBaseDto and delete all the Asset Compliance rules for the given ticker', async () => {
-      when(mockService.deleteAll).calledWith(ticker, validBody).mockResolvedValue(txResponse);
+    it('should accept TransactionBaseDto and delete all the Asset Compliance rules for the given Asset', async () => {
+      when(mockService.deleteAll).calledWith(assetId, validBody).mockResolvedValue(txResponse);
 
-      const result = await controller.deleteRequirements({ ticker }, validBody);
+      const result = await controller.deleteRequirements({ asset: assetId }, validBody);
 
       expect(result).toEqual(txResponse);
     });
@@ -129,13 +131,13 @@ describe('ComplianceRequirementsController', () => {
       const { requirements } = validBody;
 
       when(mockService.add)
-        .calledWith(ticker, {
+        .calledWith(assetId, {
           signer,
           conditions: requirements[0],
         } as RequirementDto)
         .mockResolvedValue(txResponse);
 
-      const result = await controller.addRequirement({ ticker }, {
+      const result = await controller.addRequirement({ asset: assetId }, {
         signer,
         conditions: requirements[0],
       } as RequirementDto);
@@ -149,13 +151,13 @@ describe('ComplianceRequirementsController', () => {
       const { requirements } = validBody;
 
       when(mockService.modify)
-        .calledWith(ticker, id, {
+        .calledWith(assetId, id, {
           signer,
           conditions: requirements[0],
         } as RequirementDto)
         .mockResolvedValue(response);
 
-      const result = await controller.modifyComplianceRequirement({ ticker, id }, {
+      const result = await controller.modifyComplianceRequirement({ asset: assetId, id }, {
         signer,
         conditions: requirements[0],
       } as RequirementDto);
@@ -168,9 +170,9 @@ describe('ComplianceRequirementsController', () => {
     it('should return the result of arePaused method', async () => {
       const response = false;
 
-      when(mockService.arePaused).calledWith(ticker).mockResolvedValue(response);
+      when(mockService.arePaused).calledWith(assetId).mockResolvedValue(response);
 
-      const result = await controller.areRequirementsPaused({ ticker });
+      const result = await controller.areRequirementsPaused({ asset: assetId });
 
       expect(result).toEqual(new ComplianceStatusModel({ arePaused: response }));
     });

--- a/src/compliance/compliance-requirements.controller.ts
+++ b/src/compliance/compliance-requirements.controller.ts
@@ -7,7 +7,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import { ApiTransactionFailedResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
@@ -22,7 +22,7 @@ import { RequirementModel } from '~/compliance/models/requirement.model';
 import { TrustedClaimIssuerModel } from '~/compliance/models/trusted-claim-issuer.model';
 
 @ApiTags('assets', 'compliance')
-@Controller('assets/:ticker/compliance-requirements')
+@Controller('assets/:asset/compliance-requirements')
 export class ComplianceRequirementsController {
   constructor(private readonly complianceRequirementsService: ComplianceRequirementsService) {}
 
@@ -32,10 +32,10 @@ export class ComplianceRequirementsController {
       'This endpoint will provide the list of all compliance requirements of an Asset along with Default Trusted Claim Issuers',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose Compliance Requirements are to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose Compliance Requirements are to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiOkResponse({
     description:
@@ -47,10 +47,10 @@ export class ComplianceRequirementsController {
   })
   @Get()
   public async getComplianceRequirements(
-    @Param() { ticker }: TickerParamsDto
+    @Param() { asset }: AssetParamsDto
   ): Promise<ComplianceRequirementsModel> {
     const { requirements, defaultTrustedClaimIssuers } =
-      await this.complianceRequirementsService.findComplianceRequirements(ticker);
+      await this.complianceRequirementsService.findComplianceRequirements(asset);
 
     return new ComplianceRequirementsModel({
       requirements: requirements.map(
@@ -68,10 +68,10 @@ export class ComplianceRequirementsController {
       'This endpoint sets Compliance rules for an Asset. This method will replace the current rules',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose compliance requirements are to be set',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose compliance requirements are to be set',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -82,10 +82,10 @@ export class ComplianceRequirementsController {
   })
   @Post('set')
   public async setRequirements(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: SetRequirementsDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.setRequirements(ticker, params);
+    const result = await this.complianceRequirementsService.setRequirements(asset, params);
     return handleServiceResult(result);
   }
 
@@ -94,10 +94,10 @@ export class ComplianceRequirementsController {
     description: 'This endpoint pauses compliance rules for an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose compliance requirements are to be paused',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose compliance requirements are to be paused',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -109,11 +109,11 @@ export class ComplianceRequirementsController {
   })
   @Post('pause')
   public async pauseRequirements(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.complianceRequirementsService.pauseRequirements(
-      ticker,
+      asset,
       transactionBaseDto
     );
     return handleServiceResult(result);
@@ -124,10 +124,10 @@ export class ComplianceRequirementsController {
     description: 'This endpoint unpauses compliance rules for an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose compliance requirements are to be unpaused',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose compliance requirements are to be unpaused',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -138,11 +138,11 @@ export class ComplianceRequirementsController {
   })
   @Post('unpause')
   public async unpauseRequirements(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.complianceRequirementsService.unpauseRequirements(
-      ticker,
+      asset,
       transactionBaseDto
     );
     return handleServiceResult(result);
@@ -153,10 +153,10 @@ export class ComplianceRequirementsController {
     description: 'This endpoint deletes referenced compliance requirement for an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset from whose compliance requirement is to be deleted',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) from whose compliance requirement is to be deleted',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiParam({
     name: 'id',
@@ -174,11 +174,11 @@ export class ComplianceRequirementsController {
   })
   @Post(':id/delete')
   public async deleteRequirement(
-    @Param() { id, ticker }: RequirementParamsDto,
+    @Param() { id, asset }: RequirementParamsDto,
     @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
     const result = await this.complianceRequirementsService.deleteOne(
-      ticker,
+      asset,
       id,
       transactionBaseDto
     );
@@ -191,10 +191,10 @@ export class ComplianceRequirementsController {
     description: 'This endpoint deletes all compliance requirements for an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose compliance requirements are to be deleted',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose compliance requirements are to be deleted',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -208,10 +208,10 @@ export class ComplianceRequirementsController {
   })
   @Post('delete')
   public async deleteRequirements(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() transactionBaseDto: TransactionBaseDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.deleteAll(ticker, transactionBaseDto);
+    const result = await this.complianceRequirementsService.deleteAll(asset, transactionBaseDto);
 
     return handleServiceResult(result);
   }
@@ -222,10 +222,10 @@ export class ComplianceRequirementsController {
       "This endpoint adds a new compliance requirement to the specified Asset. This doesn't modify the existing requirements",
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset to which the compliance requirement is to be added',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) to which the compliance requirement is to be added',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -238,10 +238,10 @@ export class ComplianceRequirementsController {
   })
   @Post('add')
   public async addRequirement(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: RequirementDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.add(ticker, params);
+    const result = await this.complianceRequirementsService.add(asset, params);
     return handleServiceResult(result);
   }
 
@@ -250,10 +250,11 @@ export class ComplianceRequirementsController {
     description: 'This endpoint modifies referenced compliance requirement for an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset for which the compliance requirement is to be modified',
+    name: 'asset',
+    description:
+      'The Asset (Ticker/Asset ID) for which the compliance requirement is to be modified',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiParam({
     name: 'id',
@@ -271,23 +272,23 @@ export class ComplianceRequirementsController {
   })
   @Post(':id/modify')
   public async modifyComplianceRequirement(
-    @Param() { id, ticker }: RequirementParamsDto,
+    @Param() { id, asset }: RequirementParamsDto,
     @Body() params: RequirementDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.complianceRequirementsService.modify(ticker, id, params);
+    const result = await this.complianceRequirementsService.modify(asset, id, params);
     return handleServiceResult(result);
   }
 
   @ApiOperation({
     summary: 'Check if the requirements are paused',
-    description:
-      'This endpoint checks if the compliance requirements are paused for a given ticker',
+    description: 'This endpoint checks if the compliance requirements are paused for a given asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose compliance requirements status are to be fetched',
+    name: 'asset',
+    description:
+      'The Asset (Ticker/Asset ID) whose compliance requirements status are to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiOkResponse({
     description: 'Compliance Requirement status',
@@ -298,9 +299,9 @@ export class ComplianceRequirementsController {
   })
   @Get('status')
   public async areRequirementsPaused(
-    @Param() { ticker }: TickerParamsDto
+    @Param() { asset }: AssetParamsDto
   ): Promise<ComplianceStatusModel> {
-    const arePaused = await this.complianceRequirementsService.arePaused(ticker);
+    const arePaused = await this.complianceRequirementsService.arePaused(asset);
 
     return new ComplianceStatusModel({ arePaused });
   }

--- a/src/compliance/dto/requirement-params.dto.ts
+++ b/src/compliance/dto/requirement-params.dto.ts
@@ -2,11 +2,11 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import { ToBigNumber } from '~/common/decorators/transformation';
 import { IsBigNumber } from '~/common/decorators/validation';
 
-export class RequirementParamsDto extends TickerParamsDto {
+export class RequirementParamsDto extends AssetParamsDto {
   @ApiProperty({
     description: 'Requirement ID',
     type: 'string',

--- a/src/compliance/trusted-claim-issuers.controller.spec.ts
+++ b/src/compliance/trusted-claim-issuers.controller.spec.ts
@@ -7,11 +7,14 @@ import { RemoveTrustedClaimIssuersDto } from '~/compliance/dto/remove-trusted-cl
 import { SetTrustedClaimIssuersDto } from '~/compliance/dto/set-trusted-claim-issuers.dto';
 import { TrustedClaimIssuersController } from '~/compliance/trusted-claim-issuers.controller';
 import { TrustedClaimIssuersService } from '~/compliance/trusted-claim-issuers.service';
+import { testValues } from '~/test-utils/consts';
 import { createMockTxResult, mockTrustedClaimIssuer } from '~/test-utils/mocks';
 import { mockTrustedClaimIssuersServiceProvider } from '~/test-utils/service-mocks';
 
+const { assetId } = testValues;
+
 describe('TrustedClaimIssuersController', () => {
-  const mockParams = { ticker: 'TICKER' };
+  const mockParams = { asset: assetId };
   let controller: TrustedClaimIssuersController;
   let mockService: DeepMocked<TrustedClaimIssuersService>;
 
@@ -32,9 +35,7 @@ describe('TrustedClaimIssuersController', () => {
 
   describe('getTrustedClaimIssuers', () => {
     it('should return the list of all trusted Claim Issuers of an Asset', async () => {
-      when(mockService.find)
-        .calledWith(mockParams.ticker)
-        .mockResolvedValue([mockTrustedClaimIssuer]);
+      when(mockService.find).calledWith(assetId).mockResolvedValue([mockTrustedClaimIssuer]);
 
       const result = await controller.getTrustedClaimIssuers(mockParams);
 
@@ -59,11 +60,9 @@ describe('TrustedClaimIssuersController', () => {
         signer: 'Alice',
       };
 
-      when(mockService.set)
-        .calledWith(mockParams.ticker, mockPayload)
-        .mockResolvedValue(testTxResult);
+      when(mockService.set).calledWith(assetId, mockPayload).mockResolvedValue(testTxResult);
 
-      const result = await controller.setTrustedClaimIssuers({ ticker: 'TICKER' }, mockPayload);
+      const result = await controller.setTrustedClaimIssuers(mockParams, mockPayload);
 
       expect(result).toEqual(testTxResult);
     });
@@ -79,11 +78,9 @@ describe('TrustedClaimIssuersController', () => {
         signer: 'Alice',
       };
 
-      when(mockService.add)
-        .calledWith(mockParams.ticker, mockPayload)
-        .mockResolvedValue(testTxResult);
+      when(mockService.add).calledWith(assetId, mockPayload).mockResolvedValue(testTxResult);
 
-      const result = await controller.addTrustedClaimIssuers({ ticker: 'TICKER' }, mockPayload);
+      const result = await controller.addTrustedClaimIssuers(mockParams, mockPayload);
 
       expect(result).toEqual(testTxResult);
     });
@@ -100,11 +97,9 @@ describe('TrustedClaimIssuersController', () => {
         signer: 'Alice',
       };
 
-      when(mockService.remove)
-        .calledWith(mockParams.ticker, mockPayload)
-        .mockResolvedValue(testTxResult);
+      when(mockService.remove).calledWith(assetId, mockPayload).mockResolvedValue(testTxResult);
 
-      const result = await controller.removeTrustedClaimIssuers({ ticker: 'TICKER' }, mockPayload);
+      const result = await controller.removeTrustedClaimIssuers(mockParams, mockPayload);
 
       expect(result).toEqual(testTxResult);
     });

--- a/src/compliance/trusted-claim-issuers.controller.ts
+++ b/src/compliance/trusted-claim-issuers.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, HttpStatus, Param, Post } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import {
   ApiArrayResponse,
   ApiTransactionFailedResponse,
@@ -16,7 +16,7 @@ import { TrustedClaimIssuerModel } from '~/compliance/models/trusted-claim-issue
 import { TrustedClaimIssuersService } from '~/compliance/trusted-claim-issuers.service';
 
 @ApiTags('assets', 'compliance')
-@Controller('assets/:ticker/trusted-claim-issuers')
+@Controller('assets/:asset/trusted-claim-issuers')
 export class TrustedClaimIssuersController {
   constructor(private readonly trustedClaimIssuersService: TrustedClaimIssuersService) {}
 
@@ -26,10 +26,10 @@ export class TrustedClaimIssuersController {
       'This endpoint will provide the list of all default trusted Claim Issuers of an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose trusted Claim Issuers are to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose trusted Claim Issuers are to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiArrayResponse(TrustedClaimIssuerModel, {
     description: 'List of trusted Claim Issuers of the Asset',
@@ -37,9 +37,9 @@ export class TrustedClaimIssuersController {
   })
   @Get('')
   public async getTrustedClaimIssuers(
-    @Param() { ticker }: TickerParamsDto
+    @Param() { asset }: AssetParamsDto
   ): Promise<ResultsModel<TrustedClaimIssuerModel>> {
-    const results = await this.trustedClaimIssuersService.find(ticker);
+    const results = await this.trustedClaimIssuersService.find(asset);
     return new ResultsModel({
       results: results.map(
         ({ identity: { did }, trustedFor }) => new TrustedClaimIssuerModel({ did, trustedFor })
@@ -53,10 +53,10 @@ export class TrustedClaimIssuersController {
       'This endpoint will assign a new default list of trusted Claim Issuers to the Asset by replacing the existing ones',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose trusted Claim Issuers are to be set',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose trusted Claim Issuers are to be set',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -68,10 +68,10 @@ export class TrustedClaimIssuersController {
   })
   @Post('set')
   public async setTrustedClaimIssuers(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: SetTrustedClaimIssuersDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.trustedClaimIssuersService.set(ticker, params);
+    const result = await this.trustedClaimIssuersService.set(asset, params);
 
     return handleServiceResult(result);
   }
@@ -82,10 +82,10 @@ export class TrustedClaimIssuersController {
       "This endpoint will add the supplied Identities to the Asset's list of trusted claim issuers",
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose trusted Claim Issuers are to be added',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose trusted Claim Issuers are to be added',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -99,10 +99,10 @@ export class TrustedClaimIssuersController {
   })
   @Post('add')
   public async addTrustedClaimIssuers(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: SetTrustedClaimIssuersDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.trustedClaimIssuersService.add(ticker, params);
+    const result = await this.trustedClaimIssuersService.add(asset, params);
 
     return handleServiceResult(result);
   }
@@ -113,10 +113,10 @@ export class TrustedClaimIssuersController {
       "This endpoint will remove the supplied Identities from the Asset's list of trusted claim issuers",
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose trusted Claim Issuers are to be removed',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose trusted Claim Issuers are to be removed',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details of the transaction',
@@ -130,10 +130,10 @@ export class TrustedClaimIssuersController {
   })
   @Post('remove')
   public async removeTrustedClaimIssuers(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: RemoveTrustedClaimIssuersDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.trustedClaimIssuersService.remove(ticker, params);
+    const result = await this.trustedClaimIssuersService.remove(asset, params);
 
     return handleServiceResult(result);
   }

--- a/src/corporate-actions/corporate-actions.service.ts
+++ b/src/corporate-actions/corporate-actions.service.ts
@@ -25,40 +25,40 @@ export class CorporateActionsService {
     private readonly transactionService: TransactionsService
   ) {}
 
-  public async findDefaultConfigByTicker(ticker: string): Promise<CorporateActionDefaultConfig> {
-    const asset = await this.assetsService.findFungible(ticker);
-    return asset.corporateActions.getDefaultConfig();
+  public async findDefaultConfigByAsset(asset: string): Promise<CorporateActionDefaultConfig> {
+    const fungibleAsset = await this.assetsService.findFungible(asset);
+    return fungibleAsset.corporateActions.getDefaultConfig();
   }
 
-  public async updateDefaultConfigByTicker(
-    ticker: string,
+  public async updateDefaultConfigByAsset(
+    asset: string,
     corporateActionDefaultConfigDto: CorporateActionDefaultConfigDto
   ): ServiceReturn<void> {
     const { options, args } = extractTxOptions(corporateActionDefaultConfigDto);
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
     return this.transactionService.submit(
-      asset.corporateActions.setDefaultConfig,
+      fungibleAsset.corporateActions.setDefaultConfig,
       args as Required<typeof args>,
       options
     );
   }
 
-  public async findDistributionsByTicker(ticker: string): Promise<DistributionWithDetails[]> {
-    const asset = await this.assetsService.findFungible(ticker);
-    return asset.corporateActions.distributions.get();
+  public async findDistributionsByAsset(asset: string): Promise<DistributionWithDetails[]> {
+    const fungibleAsset = await this.assetsService.findFungible(asset);
+    return fungibleAsset.corporateActions.distributions.get();
   }
 
-  public async findDistribution(ticker: string, id: BigNumber): Promise<DistributionWithDetails> {
-    const asset = await this.assetsService.findFungible(ticker);
+  public async findDistribution(asset: string, id: BigNumber): Promise<DistributionWithDetails> {
+    const fungibleAsset = await this.assetsService.findFungible(asset);
 
-    return await asset.corporateActions.distributions.getOne({ id }).catch(error => {
+    return await fungibleAsset.corporateActions.distributions.getOne({ id }).catch(error => {
       throw handleSdkError(error);
     });
   }
 
   public async createDividendDistribution(
-    ticker: string,
+    asset: string,
     dividendDistributionDto: DividendDistributionDto
   ): ServiceReturn<DividendDistribution> {
     const {
@@ -66,9 +66,9 @@ export class CorporateActionsService {
       args: { originPortfolio, ...rest },
     } = extractTxOptions(dividendDistributionDto);
 
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
     return this.transactionService.submit(
-      asset.corporateActions.distributions.configureDividendDistribution,
+      fungibleAsset.corporateActions.distributions.configureDividendDistribution,
       {
         ...rest,
         originPortfolio: toPortfolioId(originPortfolio),
@@ -78,32 +78,32 @@ export class CorporateActionsService {
   }
 
   public async remove(
-    ticker: string,
+    asset: string,
     corporateAction: BigNumber,
     transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const { options } = extractTxOptions(transactionBaseDto);
-    const asset = await this.assetsService.findFungible(ticker);
+    const fungibleAsset = await this.assetsService.findFungible(asset);
     return this.transactionService.submit(
-      asset.corporateActions.remove,
+      fungibleAsset.corporateActions.remove,
       { corporateAction },
       options
     );
   }
 
   public async payDividends(
-    ticker: string,
+    asset: string,
     id: BigNumber,
     payDividendsDto: PayDividendsDto
   ): ServiceReturn<void> {
     const { options, args } = extractTxOptions(payDividendsDto);
-    const { distribution } = await this.findDistribution(ticker, id);
+    const { distribution } = await this.findDistribution(asset, id);
 
     return this.transactionService.submit(distribution.pay, args, options);
   }
 
   public async linkDocuments(
-    ticker: string,
+    asset: string,
     id: BigNumber,
     linkDocumentsDto: LinkDocumentsDto
   ): ServiceReturn<void> {
@@ -112,7 +112,7 @@ export class CorporateActionsService {
       args: { documents },
     } = extractTxOptions(linkDocumentsDto);
 
-    const { distribution } = await this.findDistribution(ticker, id);
+    const { distribution } = await this.findDistribution(asset, id);
 
     const params = {
       documents: documents.map(document => document.toAssetDocument()),
@@ -121,34 +121,34 @@ export class CorporateActionsService {
   }
 
   public async claimDividends(
-    ticker: string,
+    asset: string,
     id: BigNumber,
     transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const { options } = extractTxOptions(transactionBaseDto);
-    const { distribution } = await this.findDistribution(ticker, id);
+    const { distribution } = await this.findDistribution(asset, id);
     return this.transactionService.submit(distribution.claim, undefined, options);
   }
 
   public async reclaimRemainingFunds(
-    ticker: string,
+    asset: string,
     id: BigNumber,
     transactionBaseDto: TransactionBaseDto
   ): ServiceReturn<void> {
     const { options } = extractTxOptions(transactionBaseDto);
-    const { distribution } = await this.findDistribution(ticker, id);
+    const { distribution } = await this.findDistribution(asset, id);
 
     return this.transactionService.submit(distribution.reclaimFunds, undefined, options);
   }
 
   public async modifyCheckpoint(
-    ticker: string,
+    asset: string,
     id: BigNumber,
     modifyDistributionCheckpointDto: ModifyDistributionCheckpointDto
   ): ServiceReturn<void> {
     const { options, args } = extractTxOptions(modifyDistributionCheckpointDto);
 
-    const { distribution } = await this.findDistribution(ticker, id);
+    const { distribution } = await this.findDistribution(asset, id);
 
     return this.transactionService.submit(distribution.modifyCheckpoint, args, options);
   }

--- a/src/corporate-actions/models/corporate-action.model.ts
+++ b/src/corporate-actions/models/corporate-action.model.ts
@@ -21,7 +21,7 @@ export class CorporateActionModel {
     description:
       'The Asset associated with the corporate action. NOTE: For 6.x chains, asset is represented by its ticker, but from 7.x, asset is represented by its unique Asset ID',
     type: 'string',
-    examples: ['TICKER', '0xa3616b82e8e1080aedc952ea28b9db8b'],
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   readonly asset: string;
 

--- a/src/developer-testing/developer-testing.service.ts
+++ b/src/developer-testing/developer-testing.service.ts
@@ -56,7 +56,7 @@ export class DeveloperTestingService {
 
     // Create a DID to attach claim too
     const createDidCalls = accounts.map(({ address }) => identity.cddRegisterDid(address, []));
-    await this.polymeshService.execTransaction(signerAddress, utility.batchAtomic, createDidCalls);
+    await this.polymeshService.execTransaction(signerAddress, utility.batch, createDidCalls);
 
     // Fetch the Account and Identity that was made
     const madeAccounts = await this.fetchAccountForAccountParams(accounts);

--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -24,7 +24,7 @@ describe('EventsService', () => {
     createdAt: new Date('10/14/1987'),
     payload: {
       type: TransactionType.Single,
-      transactionTag: TxTags.asset.RegisterTicker,
+      transactionTag: TxTags.asset.RegisterUniqueTicker,
       status: TransactionStatus.Unapproved,
     },
   });

--- a/src/identities/dto/add-secondary-account-params.dto.spec.ts
+++ b/src/identities/dto/add-secondary-account-params.dto.spec.ts
@@ -140,7 +140,7 @@ describe('addSecondaryAccountParamsDto', () => {
           permissions: {
             transactions: {
               type: PermissionType.Include,
-              values: [TxTags.identity.FreezeSecondaryKeys, TxTags.asset.RegisterTicker],
+              values: [TxTags.identity.FreezeSecondaryKeys, TxTags.asset.RegisterUniqueTicker],
             },
           },
           signer,
@@ -153,7 +153,7 @@ describe('addSecondaryAccountParamsDto', () => {
           permissions: {
             transactions: {
               type: PermissionType.Include,
-              values: [ModuleName.Identity, TxTags.asset.RegisterTicker],
+              values: [ModuleName.Identity, TxTags.asset.RegisterUniqueTicker],
             },
           },
           signer,
@@ -166,7 +166,7 @@ describe('addSecondaryAccountParamsDto', () => {
           permissions: {
             transactions: {
               type: PermissionType.Include,
-              values: [ModuleName.Identity, TxTags.asset.RegisterTicker],
+              values: [ModuleName.Identity, TxTags.asset.RegisterUniqueTicker],
               exceptions: [TxTags.identity.LeaveIdentityAsKey],
             },
           },
@@ -217,7 +217,9 @@ describe('addSecondaryAccountParamsDto', () => {
           },
           signer,
         },
-        ['permissions.assets.each value in values must be uppercase'],
+        [
+          'permissions.assets.values must be either a Ticker (12 characters uppercase string) or an Asset ID (34 characters long hex string)',
+        ],
       ],
       [
         'Invite with portfolios permissions with no portfolio details',
@@ -313,7 +315,7 @@ describe('addSecondaryAccountParamsDto', () => {
             transactions: {
               type: PermissionType.Include,
               values: [ModuleName.Asset],
-              exceptions: [TxTags.asset.RegisterTicker],
+              exceptions: [TxTags.asset.RegisterUniqueTicker],
             },
             transactionGroups: [],
           },

--- a/src/identities/dto/asset-permissions.dto.ts
+++ b/src/identities/dto/asset-permissions.dto.ts
@@ -4,7 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { SectionPermissions } from '@polymeshassociation/polymesh-sdk/types';
 import { IsArray } from 'class-validator';
 
-import { IsTicker } from '~/common/decorators/validation';
+import { IsAsset } from '~/common/decorators/validation';
 import { PermissionTypeDto } from '~/identities/dto/permission-type.dto';
 
 export class AssetPermissionsDto extends PermissionTypeDto {
@@ -15,7 +15,7 @@ export class AssetPermissionsDto extends PermissionTypeDto {
     example: ['TICKER123456'],
   })
   @IsArray()
-  @IsTicker({ each: true })
+  @IsAsset({ each: true })
   readonly values: string[];
 
   public toAssetPermissions(): SectionPermissions<string> | null {

--- a/src/identities/dto/transaction-permissions.dto.ts
+++ b/src/identities/dto/transaction-permissions.dto.ts
@@ -30,7 +30,7 @@ export class TransactionPermissionsDto extends PermissionTypeDto {
       'Transactions to be exempted from inclusion/exclusion. For example, if you wish to exclude the entire `asset` module except for `asset.createAsset`, you would pass `ModuleName.Asset` as part of the `values` array, and `TxTags.asset.CreateAsset` as part of the `exceptions` array',
     isArray: true,
     enum: getTxTags(),
-    example: [TxTags.asset.RegisterTicker],
+    example: [TxTags.asset.RegisterUniqueTicker],
   })
   @IsArray()
   @ArrayNotEmpty()

--- a/src/identities/identities.controller.spec.ts
+++ b/src/identities/identities.controller.spec.ts
@@ -469,10 +469,10 @@ describe('IdentitiesController', () => {
     it('should return the list of Assets for which the Identity is a default trusted Claim Issuer', async () => {
       const mockAssets = [
         {
-          ticker: 'BAR_TICKER',
+          assetId: '0x1234',
         },
         {
-          ticker: 'FOO_TICKER',
+          assetId: '0x5678',
         },
       ];
       mockIdentitiesService.findTrustingAssets.mockResolvedValue(mockAssets);
@@ -712,11 +712,11 @@ describe('IdentitiesController', () => {
 
   describe('getIsPreApprove', () => {
     it('should return the asset pre-approval status', async () => {
-      mockIdentitiesService.isTickerPreApproved.mockResolvedValue(true);
+      mockIdentitiesService.isAssetPreApproved.mockResolvedValue(true);
 
-      const result = await controller.getIsTickerPreApproved({ did }, { ticker });
+      const result = await controller.getIsAssetPreApproved({ did }, { asset: assetId });
 
-      expect(result).toEqual({ asset: ticker, did, isPreApproved: true });
+      expect(result).toEqual({ asset: assetId, did, isPreApproved: true });
     });
   });
 

--- a/src/identities/identities.controller.ts
+++ b/src/identities/identities.controller.ts
@@ -21,7 +21,7 @@ import {
 } from '@polymeshassociation/polymesh-sdk/types';
 
 import { AssetsService } from '~/assets/assets.service';
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import { AuthorizationsService } from '~/authorizations/authorizations.service';
 import {
   authorizationRequestResolver,
@@ -246,8 +246,8 @@ export class IdentitiesController {
       'List of all the held Assets. NOTE: For 6.x chains, asset is represented by its ticker, but from 7.x, asset is represented by its unique Asset ID',
     paginated: true,
     examples: [
-      ['FOO_TICKER', 'BAR_TICKER', 'BAZ_TICKER'],
       ['0xa3616b82e8e1080aedc952ea28b9db8b', '0x2593d3d0aca79e43ac0deaa16081eba2'],
+      ['FOO_TICKER', 'BAR_TICKER', 'BAZ_TICKER'],
     ],
   })
   @Get(':did/held-assets')
@@ -685,7 +685,7 @@ export class IdentitiesController {
   }
 
   @ApiOperation({
-    summary: 'Check if a ticker is pre-approved for an identity',
+    summary: 'Check if a Asset is pre-approved for an identity',
     description: 'This endpoint returns wether or not an asset is pre-approved for an identity',
   })
   @ApiParam({
@@ -700,13 +700,13 @@ export class IdentitiesController {
     type: PreApprovedModel,
   })
   @Get(':did/is-pre-approved')
-  public async getIsTickerPreApproved(
+  public async getIsAssetPreApproved(
     @Param() { did }: DidDto,
-    @Query() { ticker }: TickerParamsDto
+    @Query() { asset }: AssetParamsDto
   ): Promise<PreApprovedModel> {
-    const isPreApproved = await this.identitiesService.isTickerPreApproved(did, ticker);
+    const isPreApproved = await this.identitiesService.isAssetPreApproved(did, asset);
 
-    return new PreApprovedModel({ asset: ticker, did, isPreApproved });
+    return new PreApprovedModel({ asset, did, isPreApproved });
   }
 
   @ApiOperation({

--- a/src/identities/identities.service.spec.ts
+++ b/src/identities/identities.service.spec.ts
@@ -253,7 +253,7 @@ describe('IdentitiesService', () => {
     });
   });
 
-  describe('isTickerPreApproved', () => {
+  describe('isAssetPreApproved', () => {
     it('should return if the asset is pre-approved', async () => {
       const mockIdentity = new MockIdentity();
 
@@ -261,7 +261,7 @@ describe('IdentitiesService', () => {
       jest.spyOn(service, 'findOne').mockResolvedValue(mockIdentity as any);
       mockIdentity.isAssetPreApproved.mockResolvedValue(true);
 
-      const result = await service.isTickerPreApproved('0x01', 'TICKER');
+      const result = await service.isAssetPreApproved('0x01', 'TICKER');
       expect(result).toEqual(true);
     });
   });

--- a/src/identities/identities.service.ts
+++ b/src/identities/identities.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { KeyringPair } from '@polkadot/keyring/types';
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import {
   AuthorizationRequest,
@@ -21,8 +20,6 @@ import { handleSdkError } from '~/transactions/transactions.util';
 
 @Injectable()
 export class IdentitiesService {
-  private alicePair: KeyringPair;
-
   constructor(
     private readonly polymeshService: PolymeshService,
     private readonly logger: PolymeshLogger,
@@ -150,9 +147,9 @@ export class IdentitiesService {
     return identity.preApprovedAssets({ size, start });
   }
 
-  public async isTickerPreApproved(did: string, ticker: string): Promise<boolean> {
+  public async isAssetPreApproved(did: string, asset: string): Promise<boolean> {
     const identity = await this.findOne(did);
 
-    return identity.isAssetPreApproved(ticker);
+    return identity.isAssetPreApproved(asset);
   }
 }

--- a/src/identities/models/pre-approved.model.ts
+++ b/src/identities/models/pre-approved.model.ts
@@ -6,7 +6,7 @@ export class PreApprovedModel {
   @ApiProperty({
     description:
       'The Asset that is subject to pre-approval. NOTE: For 6.x chains, asset is represented by its ticker, but from 7.x, asset is represented by its unique Asset ID',
-    examples: ['TICKER', '0xa3616b82e8e1080aedc952ea28b9db8b'],
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   readonly asset: string;
 

--- a/src/metadata/dto/metadata-params.dto.ts
+++ b/src/metadata/dto/metadata-params.dto.ts
@@ -3,12 +3,12 @@
 import { MetadataType } from '@polymeshassociation/polymesh-sdk/types';
 import { IsEnum } from 'class-validator';
 
-import { IsTicker } from '~/common/decorators/validation';
+import { IsAsset } from '~/common/decorators/validation';
 import { IdParamsDto } from '~/common/dto/id-params.dto';
 
 export class MetadataParamsDto extends IdParamsDto {
-  @IsTicker()
-  readonly ticker: string;
+  @IsAsset()
+  readonly asset: string;
 
   @IsEnum(MetadataType)
   readonly type: MetadataType;

--- a/src/metadata/metadata.controller.spec.ts
+++ b/src/metadata/metadata.controller.spec.ts
@@ -27,12 +27,10 @@ describe('MetadataController', () => {
   const { txResult } = testValues;
   let controller: MetadataController;
   let mockService: DeepMocked<MetadataService>;
-  let ticker: string;
   let type: MetadataType;
   let id: BigNumber;
 
   beforeEach(async () => {
-    ticker = 'TICKER';
     type = MetadataType.Local;
     id = new BigNumber(1);
 
@@ -53,9 +51,9 @@ describe('MetadataController', () => {
   describe('getMetadata', () => {
     it('should return the list of all metadata for a given ticker', async () => {
       const mockMetadataEntry = createMockMetadataEntry();
-      when(mockService.findAll).calledWith(ticker).mockResolvedValue([mockMetadataEntry]);
+      when(mockService.findAll).calledWith(assetId).mockResolvedValue([mockMetadataEntry]);
 
-      const result = await controller.getMetadata({ ticker });
+      const result = await controller.getMetadata({ asset: assetId });
 
       expect(result).toEqual({
         results: [new MetadataEntryModel({ asset: assetId, type, id })],
@@ -84,10 +82,10 @@ describe('MetadataController', () => {
       mockMetadataEntry.value.mockResolvedValue(mockValue);
 
       when(mockService.findOne)
-        .calledWith({ ticker, type, id })
+        .calledWith({ asset: assetId, type, id })
         .mockResolvedValue(mockMetadataEntry);
 
-      const result = await controller.getSingleMetadata({ ticker, type, id });
+      const result = await controller.getSingleMetadata({ asset: assetId, type, id });
 
       expect(result).toEqual(
         new MetadataDetailsModel({
@@ -124,9 +122,9 @@ describe('MetadataController', () => {
         signer: 'Alice',
       };
 
-      when(mockService.create).calledWith(ticker, mockPayload).mockResolvedValue(testTxResult);
+      when(mockService.create).calledWith(assetId, mockPayload).mockResolvedValue(testTxResult);
 
-      const result = await controller.createMetadata({ ticker }, mockPayload);
+      const result = await controller.createMetadata({ asset: assetId }, mockPayload);
 
       expect(result).toEqual(
         expect.objectContaining({
@@ -156,10 +154,10 @@ describe('MetadataController', () => {
       };
 
       when(mockService.setValue)
-        .calledWith({ ticker, type, id }, mockPayload)
+        .calledWith({ asset: assetId, type, id }, mockPayload)
         .mockResolvedValue(testTxResult);
 
-      const result = await controller.setMetadata({ ticker, type, id }, mockPayload);
+      const result = await controller.setMetadata({ asset: assetId, type, id }, mockPayload);
 
       expect(result).toEqual(testTxResult);
     });
@@ -183,10 +181,10 @@ describe('MetadataController', () => {
       };
 
       when(mockService.clearValue)
-        .calledWith({ ticker, type, id }, mockBody)
+        .calledWith({ asset: assetId, type, id }, mockBody)
         .mockResolvedValue(testTxResult);
 
-      const result = await controller.clearMetadata({ ticker, type, id }, mockBody);
+      const result = await controller.clearMetadata({ asset: assetId, type, id }, mockBody);
 
       expect(result).toEqual(testTxResult);
     });
@@ -211,10 +209,10 @@ describe('MetadataController', () => {
       });
 
       when(mockService.removeKey)
-        .calledWith({ ticker, type, id }, mockBody)
+        .calledWith({ asset: assetId, type, id }, mockBody)
         .mockResolvedValue(testTxResult);
 
-      const result = await controller.removeLocalMetadata({ ticker, type, id }, mockBody);
+      const result = await controller.removeLocalMetadata({ asset: assetId, type, id }, mockBody);
 
       expect(result).toEqual(testTxResult);
     });

--- a/src/metadata/metadata.controller.ts
+++ b/src/metadata/metadata.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/swagger';
 import { MetadataEntry, MetadataType } from '@polymeshassociation/polymesh-sdk/types';
 
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import {
   ApiArrayResponse,
   ApiTransactionFailedResponse,
@@ -28,7 +28,7 @@ import { MetadataDetailsModel } from '~/metadata/models/metadata-details.model';
 import { MetadataEntryModel } from '~/metadata/models/metadata-entry.model';
 
 @ApiTags('asset', 'metadata')
-@Controller('assets/:ticker/metadata')
+@Controller('assets/:asset/metadata')
 export class MetadataController {
   constructor(private readonly metadataService: MetadataService) {}
 
@@ -37,8 +37,8 @@ export class MetadataController {
     description: 'This endpoint retrieves all the Metadata entries for a given Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose metadata are to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose metadata are to be fetched',
     type: 'string',
     example: 'TICKER',
   })
@@ -48,13 +48,14 @@ export class MetadataController {
   })
   @Get()
   public async getMetadata(
-    @Param() { ticker }: TickerParamsDto
+    @Param() { asset }: AssetParamsDto
   ): Promise<ResultsModel<MetadataEntryModel>> {
-    const result = await this.metadataService.findAll(ticker);
+    const result = await this.metadataService.findAll(asset);
 
     return new ResultsModel({
       results: result.map(
-        ({ asset: { id: asset }, id, type }) => new MetadataEntryModel({ asset, id, type })
+        ({ asset: { id: assetId }, id, type }) =>
+          new MetadataEntryModel({ asset: assetId, id, type })
       ),
     });
   }
@@ -65,8 +66,8 @@ export class MetadataController {
       'This endpoint retrieves the details of an Asset Metadata entry by its type and ID',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose metadata is to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose metadata is to be fetched',
     type: 'string',
     example: 'TICKER',
   })
@@ -104,8 +105,8 @@ export class MetadataController {
       'This endpoint creates a local metadata for the given Asset. The metadata value can be set by passing `value` parameter and specifying other optional `details` about the value',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset for which the metadata is to be created',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) for which the metadata is to be created',
     type: 'string',
     example: 'TICKER',
   })
@@ -127,10 +128,10 @@ export class MetadataController {
   })
   @Post('create')
   public async createMetadata(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: CreateMetadataDto
   ): Promise<TransactionResponseModel> {
-    const serviceResult = await this.metadataService.create(ticker, params);
+    const serviceResult = await this.metadataService.create(asset, params);
 
     const resolver: TransactionResolver<MetadataEntry> = ({ details, transactions, result }) => {
       const {
@@ -154,8 +155,8 @@ export class MetadataController {
       'This endpoint assigns a new value for the Metadata along with its expiry and lock status (when provided with `details`) of the Metadata value. Note that the value of a locked Metadata cannot be altered',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset for which the Metadata value is to be set',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) for which the Metadata value is to be set',
     type: 'string',
     example: 'TICKER',
   })
@@ -200,8 +201,8 @@ export class MetadataController {
       "This endpoint removes the existing value of the Asset's Metadata. Note that value for a metadata can only be remove only if it is not locked.",
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset for which the Metadata value is to be removed',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) for which the Metadata value is to be removed',
     type: 'string',
     example: 'TICKER',
   })
@@ -241,8 +242,8 @@ export class MetadataController {
       'This endpoint removes a local Asset Metadata key. Note, a local metadata key can only be removed if it is not locked',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset for which the Metadata is to be removed',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) for which the Metadata is to be removed',
     type: 'string',
     example: 'TICKER',
   })

--- a/src/metadata/metadata.service.spec.ts
+++ b/src/metadata/metadata.service.spec.ts
@@ -123,7 +123,7 @@ describe('MetadataService', () => {
       const mockMetadataEntry = createMockMetadataEntry();
       mockAsset.metadata.getOne.mockResolvedValue(mockMetadataEntry);
 
-      const result = await service.findOne({ ticker, type, id });
+      const result = await service.findOne({ asset: ticker, type, id });
 
       expect(result).toEqual(mockMetadataEntry);
     });
@@ -135,7 +135,7 @@ describe('MetadataService', () => {
 
         const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-        await expect(service.findOne({ ticker, type, id })).rejects.toThrowError();
+        await expect(service.findOne({ asset: ticker, type, id })).rejects.toThrowError();
 
         expect(handleSdkErrorSpy).toHaveBeenCalledWith(mockError);
       });
@@ -195,7 +195,7 @@ describe('MetadataService', () => {
 
       const findOneSpy = jest.spyOn(service, 'findOne');
       when(findOneSpy)
-        .calledWith({ ticker, type, id })
+        .calledWith({ asset: ticker, type, id })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockResolvedValue(mockMetadataEntry as any);
 
@@ -213,7 +213,7 @@ describe('MetadataService', () => {
         },
       };
 
-      const result = await service.setValue({ ticker, type, id }, body);
+      const result = await service.setValue({ asset: ticker, type, id }, body);
       expect(result).toEqual({
         result: mockMetadataEntry,
         transactions: [mockTransaction],
@@ -239,7 +239,7 @@ describe('MetadataService', () => {
 
       const findOneSpy = jest.spyOn(service, 'findOne');
       when(findOneSpy)
-        .calledWith({ ticker, type, id })
+        .calledWith({ asset: ticker, type, id })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockResolvedValue(mockMetadataEntry as any);
 
@@ -251,7 +251,7 @@ describe('MetadataService', () => {
         signer,
       };
 
-      const result = await service.clearValue({ ticker, type, id }, body);
+      const result = await service.clearValue({ asset: ticker, type, id }, body);
       expect(result).toEqual({
         transactions: [mockTransaction],
       });
@@ -276,7 +276,7 @@ describe('MetadataService', () => {
 
       const findOneSpy = jest.spyOn(service, 'findOne');
       when(findOneSpy)
-        .calledWith({ ticker, type, id })
+        .calledWith({ asset: ticker, type, id })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockResolvedValue(mockMetadataEntry as any);
 
@@ -288,7 +288,7 @@ describe('MetadataService', () => {
         signer,
       };
 
-      const result = await service.removeKey({ ticker, type, id }, body);
+      const result = await service.removeKey({ asset: ticker, type, id }, body);
       expect(result).toEqual({
         transactions: [mockTransaction],
       });

--- a/src/metadata/metadata.service.ts
+++ b/src/metadata/metadata.service.ts
@@ -27,26 +27,26 @@ export class MetadataService {
     return this.polymeshService.polymeshApi.assets.getGlobalMetadataKeys();
   }
 
-  public async findAll(ticker: string): Promise<MetadataEntry[]> {
-    const { metadata } = await this.assetsService.findOne(ticker);
+  public async findAll(asset: string): Promise<MetadataEntry[]> {
+    const { metadata } = await this.assetsService.findOne(asset);
 
     return metadata.get();
   }
 
-  public async findOne({ ticker, type, id }: MetadataParamsDto): Promise<MetadataEntry> {
-    const { metadata } = await this.assetsService.findOne(ticker);
+  public async findOne({ asset, type, id }: MetadataParamsDto): Promise<MetadataEntry> {
+    const { metadata } = await this.assetsService.findOne(asset);
 
     return await metadata.getOne({ type, id }).catch(error => {
       throw handleSdkError(error);
     });
   }
 
-  public async create(ticker: string, params: CreateMetadataDto): ServiceReturn<MetadataEntry> {
+  public async create(asset: string, params: CreateMetadataDto): ServiceReturn<MetadataEntry> {
     const { args, options } = extractTxOptions(params);
 
     const {
       metadata: { register },
-    } = await this.assetsService.findOne(ticker);
+    } = await this.assetsService.findOne(asset);
 
     return this.transactionsService.submit(register, args, options);
   }

--- a/src/metadata/models/metadata-entry.model.ts
+++ b/src/metadata/models/metadata-entry.model.ts
@@ -11,7 +11,7 @@ export class MetadataEntryModel {
     description:
       'The Asset for which this is the Metadata for. NOTE: For 6.x chains, asset is represented by its ticker, but from 7.x, asset is represented by its unique Asset ID',
     type: 'string',
-    examples: ['TICKER', '0xa3616b82e8e1080aedc952ea28b9db8b'],
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   readonly asset: string;
 

--- a/src/nfts/dto/nft-params.dto.ts
+++ b/src/nfts/dto/nft-params.dto.ts
@@ -3,11 +3,11 @@
 import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 
 import { ToBigNumber } from '~/common/decorators/transformation';
-import { IsBigNumber, IsTicker } from '~/common/decorators/validation';
+import { IsAsset, IsBigNumber } from '~/common/decorators/validation';
 
 export class NftParamsDto {
-  @IsTicker()
-  readonly ticker: string;
+  @IsAsset()
+  readonly asset: string;
 
   @IsBigNumber()
   @ToBigNumber()

--- a/src/nfts/nfts.controller.spec.ts
+++ b/src/nfts/nfts.controller.spec.ts
@@ -11,7 +11,7 @@ import { NftsService } from '~/nfts/nfts.service';
 import { processedTxResult, testValues } from '~/test-utils/consts';
 import { mockNftsServiceProvider } from '~/test-utils/service-mocks';
 
-const { signer, ticker, txResult } = testValues;
+const { signer, ticker, txResult, assetId } = testValues;
 
 describe('NftController', () => {
   let controller: NftsController;
@@ -38,7 +38,7 @@ describe('NftController', () => {
 
       mockNftsService.getCollectionKeys.mockResolvedValue(fakeResult);
 
-      const result = await controller.getCollectionKeys({ ticker });
+      const result = await controller.getCollectionKeys({ asset: assetId });
 
       expect(result).toEqual(fakeResult);
     });
@@ -50,7 +50,7 @@ describe('NftController', () => {
 
       mockNftsService.nftDetails.mockResolvedValue(fakeResult);
 
-      const result = await controller.getNftDetails({ ticker, id });
+      const result = await controller.getNftDetails({ asset: assetId, id });
 
       expect(result).toEqual(fakeResult);
     });
@@ -83,7 +83,7 @@ describe('NftController', () => {
       const fakeResult = processedTxResult as unknown as ServiceReturn<Nft>;
       mockNftsService.issueNft.mockResolvedValue(fakeResult);
 
-      const result = await controller.issueNft({ ticker }, input);
+      const result = await controller.issueNft({ asset: assetId }, input);
       expect(result).toEqual(fakeResult);
     });
   });
@@ -97,7 +97,7 @@ describe('NftController', () => {
       const fakeResult = processedTxResult as unknown as ServiceReturn<void>;
       mockNftsService.redeemNft.mockResolvedValue(fakeResult);
 
-      const result = await controller.redeem({ ticker, id }, input);
+      const result = await controller.redeem({ asset: assetId, id }, input);
       expect(result).toEqual(fakeResult);
     });
   });

--- a/src/nfts/nfts.controller.ts
+++ b/src/nfts/nfts.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiGoneResponse, ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import { ApiArrayResponse, ApiTransactionResponse } from '~/common/decorators/';
 import { TransactionQueueModel } from '~/common/models/transaction-queue.model';
 import { handleServiceResult, TransactionResponseModel } from '~/common/utils';
@@ -23,20 +23,21 @@ export class NftsController {
     description: 'This endpoint will provide the NFT collection keys for an NFT Collection',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the NFT Collection whose collection keys are to be fetched',
+    name: 'asset',
+    description:
+      'The Asset (Asset ID/Ticker) of the NFT Collection whose collection keys are to be fetched',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiArrayResponse(CollectionKeyModel, {
     description: 'List of required metadata values for each NFT in the collection',
     paginated: true,
   })
-  @Get(':ticker/collection-keys')
+  @Get(':asset/collection-keys')
   public async getCollectionKeys(
-    @Param() { ticker }: TickerParamsDto
+    @Param() { asset }: AssetParamsDto
   ): Promise<CollectionKeyModel[]> {
-    return this.nftService.getCollectionKeys(ticker);
+    return this.nftService.getCollectionKeys(asset);
   }
 
   @ApiOperation({
@@ -44,10 +45,10 @@ export class NftsController {
     description: 'This endpoint will return the metadata details of an NFT',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the NFT Collection',
+    name: 'asset',
+    description: 'The Asset (Asset ID/Ticker) of the NFT Collection',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiParam({
     name: 'id',
@@ -59,9 +60,9 @@ export class NftsController {
     type: NftModel,
     description: 'List of required metadata values for each NFT in the collection',
   })
-  @Get(':ticker/:id')
-  public async getNftDetails(@Param() { ticker, id }: NftParamsDto): Promise<NftModel> {
-    return this.nftService.nftDetails(ticker, id);
+  @Get(':asset/:id')
+  public async getNftDetails(@Param() { asset, id }: NftParamsDto): Promise<NftModel> {
+    return this.nftService.nftDetails(asset, id);
   }
 
   @ApiOperation({
@@ -89,21 +90,21 @@ export class NftsController {
     description: 'This endpoint allows for the issuance of NFTs',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the NFT Collection to issue an NFT for',
+    name: 'asset',
+    description: 'The Asset (Asset ID/Ticker) of the NFT Collection to issue an NFT for',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiTransactionResponse({
     description: 'Details about the transaction',
     type: TransactionQueueModel,
   })
-  @Post(':ticker/issue')
+  @Post(':asset/issue')
   public async issueNft(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Body() params: IssueNftDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.nftService.issueNft(ticker, params);
+    const result = await this.nftService.issueNft(asset, params);
 
     return handleServiceResult(result);
   }
@@ -113,10 +114,10 @@ export class NftsController {
     description: 'This endpoint allows for the redemption (aka burning) of NFTs',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the NFT Collection to redeem an NFT from',
+    name: 'asset',
+    description: 'The Asset (Asset ID/Ticker) of the NFT Collection to redeem an NFT from',
     type: 'string',
-    example: 'TICKER',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
   })
   @ApiParam({
     name: 'id',
@@ -128,12 +129,12 @@ export class NftsController {
     description: 'Details about the transaction',
     type: TransactionQueueModel,
   })
-  @Post(':ticker/:id/redeem')
+  @Post(':asset/:id/redeem')
   public async redeem(
-    @Param() { ticker, id }: NftParamsDto,
+    @Param() { asset, id }: NftParamsDto,
     @Body() params: RedeemNftDto
   ): Promise<TransactionResponseModel> {
-    const result = await this.nftService.redeemNft(ticker, id, params);
+    const result = await this.nftService.redeemNft(asset, id, params);
 
     return handleServiceResult(result);
   }

--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -157,7 +157,7 @@ describe('NotificationsService', () => {
       const scope = '0x01';
       const payload = {
         type: TransactionType.Single,
-        transactionTag: TxTags.asset.RegisterTicker,
+        transactionTag: TxTags.asset.RegisterUniqueTicker,
       };
       const mockIsExpired = jest.fn();
       mockSubscriptionsService.findOne.mockReturnValue({

--- a/src/notifications/notifications.util.spec.ts
+++ b/src/notifications/notifications.util.spec.ts
@@ -15,13 +15,13 @@ describe('signPayload', () => {
         payload: {
           status: TransactionStatus.Running,
           transactionHash: '0x01',
-          transactionTag: TxTags.asset.RegisterTicker,
+          transactionTag: TxTags.asset.RegisterUniqueTicker,
           type: TransactionType.Single,
         },
       },
       'someSecret'
     );
 
-    expect(result).toBe('iYFr08wYKxLP8eiFT7tOfkvid+0f3FT3h7wH81ELNsQ=');
+    expect(result).toBe('H967FW2eFJj1clXHP1HBfCjUGKm00EiiPbRVDkN0Gdc=');
   });
 });

--- a/src/offerings/offerings.controller.spec.ts
+++ b/src/offerings/offerings.controller.spec.ts
@@ -8,7 +8,10 @@ import { MockOfferingWithDetails } from '~/offerings/mocks/offering-with-details
 import { OfferingsController } from '~/offerings/offerings.controller';
 import { OfferingsService } from '~/offerings/offerings.service';
 import { createOfferingDetailsModel } from '~/offerings/offerings.util';
+import { testValues } from '~/test-utils/consts';
 import { MockOfferingsService } from '~/test-utils/service-mocks';
+
+const { assetId } = testValues;
 
 describe('OfferingsController', () => {
   let controller: OfferingsController;
@@ -34,10 +37,10 @@ describe('OfferingsController', () => {
     it('should return the list of Offerings for an Asset', async () => {
       const mockOfferings = [new MockOfferingWithDetails()];
 
-      mockOfferingsService.findAllByTicker.mockResolvedValue(mockOfferings);
+      mockOfferingsService.findAllByAsset.mockResolvedValue(mockOfferings);
 
       const result = await controller.getOfferings(
-        { ticker: 'TICKER' },
+        { asset: assetId },
         { timing: OfferingTimingStatus.Started }
       );
 
@@ -64,10 +67,10 @@ describe('OfferingsController', () => {
       count: new BigNumber(2),
     };
     it('should return a paginated list of Investments made in an Offering', async () => {
-      mockOfferingsService.findInvestmentsByTicker.mockResolvedValue(mockInvestments);
+      mockOfferingsService.findInvestmentsByAsset.mockResolvedValue(mockInvestments);
 
       const result = await controller.getInvestments(
-        { ticker: 'TICKER', id: new BigNumber(1) },
+        { asset: assetId, id: new BigNumber(1) },
         { start: new BigNumber(0), size: new BigNumber(10) }
       );
 
@@ -81,10 +84,10 @@ describe('OfferingsController', () => {
     });
 
     it('should return a Investments made in an Offering when no start param is provided', async () => {
-      mockOfferingsService.findInvestmentsByTicker.mockResolvedValue(mockInvestments);
+      mockOfferingsService.findInvestmentsByAsset.mockResolvedValue(mockInvestments);
 
       const result = await controller.getInvestments(
-        { ticker: 'TICKER', id: new BigNumber(1) },
+        { asset: assetId, id: new BigNumber(1) },
         { size: new BigNumber(10) }
       );
 

--- a/src/offerings/offerings.controller.ts
+++ b/src/offerings/offerings.controller.ts
@@ -7,9 +7,9 @@ import {
   OfferingTimingStatus,
 } from '@polymeshassociation/polymesh-sdk/types';
 
-import { TickerParamsDto } from '~/assets/dto/ticker-params.dto';
+import { AssetParamsDto } from '~/assets/dto/asset-params.dto';
 import { ApiArrayResponse } from '~/common/decorators/swagger';
-import { IsTicker } from '~/common/decorators/validation';
+import { IsAsset } from '~/common/decorators/validation';
 import { IdParamsDto } from '~/common/dto/id-params.dto';
 import { PaginatedParamsDto } from '~/common/dto/paginated-params.dto';
 import { PaginatedResultsModel } from '~/common/models/paginated-results.model';
@@ -21,12 +21,12 @@ import { OfferingsService } from '~/offerings/offerings.service';
 import { createOfferingDetailsModel } from '~/offerings/offerings.util';
 
 class OfferingParams extends IdParamsDto {
-  @IsTicker()
-  readonly ticker: string;
+  @IsAsset()
+  readonly asset: string;
 }
 
 @ApiTags('offerings')
-@Controller('assets/:ticker/offerings')
+@Controller('assets/:asset/offerings')
 export class OfferingsController {
   constructor(private readonly offeringsService: OfferingsService) {}
 
@@ -36,8 +36,8 @@ export class OfferingsController {
     description: 'This endpoint will provide the list of all Asset Offerings for an Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset whose Offerings are to be fetched',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID) whose Offerings are to be fetched',
     type: 'string',
     example: 'TICKER',
   })
@@ -65,10 +65,10 @@ export class OfferingsController {
   })
   @Get()
   public async getOfferings(
-    @Param() { ticker }: TickerParamsDto,
+    @Param() { asset }: AssetParamsDto,
     @Query() { timing, balance, sale }: OfferingStatusFilterDto
   ): Promise<ResultsModel<OfferingDetailsModel>> {
-    const offerings = await this.offeringsService.findAllByTicker(ticker, {
+    const offerings = await this.offeringsService.findAllByAsset(asset, {
       timing,
       balance,
       sale,
@@ -84,8 +84,8 @@ export class OfferingsController {
       'This endpoint will return a list of Investments made in an Offering for a given Asset',
   })
   @ApiParam({
-    name: 'ticker',
-    description: 'The ticker of the Asset',
+    name: 'asset',
+    description: 'The Asset (Ticker/Asset ID)',
     type: 'string',
     example: 'TICKER',
   })
@@ -115,15 +115,15 @@ export class OfferingsController {
   })
   @Get(':id/investments')
   public async getInvestments(
-    @Param() { ticker, id }: OfferingParams,
+    @Param() { asset, id }: OfferingParams,
     @Query() { size, start }: PaginatedParamsDto
   ): Promise<PaginatedResultsModel<InvestmentModel>> {
     const {
       data,
       count: total,
       next,
-    } = await this.offeringsService.findInvestmentsByTicker(
-      ticker,
+    } = await this.offeringsService.findInvestmentsByAsset(
+      asset,
       id,
       size,
       new BigNumber(start || 0)

--- a/src/offerings/offerings.service.spec.ts
+++ b/src/offerings/offerings.service.spec.ts
@@ -44,7 +44,7 @@ describe('OfferingsService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('findAllByTicker', () => {
+  describe('findAllByAsset', () => {
     it('should return the list of Offerings for an Asset', async () => {
       const mockOfferings = [new MockOfferingWithDetails()];
 
@@ -52,7 +52,7 @@ describe('OfferingsService', () => {
       mockAsset.offerings.get.mockResolvedValue(mockOfferings);
       mockAssetsService.findFungible.mockResolvedValue(mockAsset);
 
-      const result = await service.findAllByTicker('TICKER', {
+      const result = await service.findAllByAsset('TICKER', {
         timing: OfferingTimingStatus.Started,
       });
 
@@ -60,13 +60,13 @@ describe('OfferingsService', () => {
     });
   });
 
-  describe('findInvestmentsByTicker', () => {
+  describe('findInvestmentsByAsset', () => {
     it('should return a list of investments', async () => {
       const findSpy = jest.spyOn(service, 'findOne');
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       findSpy.mockResolvedValue(mockOfferingWithDetails as any);
 
-      const result = await service.findInvestmentsByTicker(
+      const result = await service.findInvestmentsByAsset(
         'TICKER',
         new BigNumber(1),
         new BigNumber(0)
@@ -83,13 +83,13 @@ describe('OfferingsService', () => {
   describe('findOne', () => {
     describe('if the offering is not found', () => {
       it('should throw a AppNotFoundError', async () => {
-        const findSpy = jest.spyOn(service, 'findAllByTicker');
+        const findSpy = jest.spyOn(service, 'findAllByAsset');
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         findSpy.mockResolvedValue([mockOfferingWithDetails] as any);
 
         let error;
         try {
-          await service.findInvestmentsByTicker('TICKER', new BigNumber(99), new BigNumber(0));
+          await service.findInvestmentsByAsset('TICKER', new BigNumber(99), new BigNumber(0));
         } catch (err) {
           error = err;
         }
@@ -98,7 +98,7 @@ describe('OfferingsService', () => {
     });
     describe('otherwise', () => {
       it('should return the offering', async () => {
-        const findSpy = jest.spyOn(service, 'findAllByTicker');
+        const findSpy = jest.spyOn(service, 'findAllByAsset');
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         findSpy.mockResolvedValue([mockOfferingWithDetails] as any);
 

--- a/src/offerings/offerings.service.ts
+++ b/src/offerings/offerings.service.ts
@@ -14,7 +14,7 @@ import { InvestmentModel } from '~/offerings/models/investment.model';
 export class OfferingsService {
   constructor(private readonly assetsService: AssetsService) {}
 
-  public async findAllByTicker(
+  public async findAllByAsset(
     ticker: string,
     stoStatus?: Partial<OfferingStatus>
   ): Promise<OfferingWithDetails[]> {
@@ -23,7 +23,7 @@ export class OfferingsService {
   }
 
   public async findOne(ticker: string, id: BigNumber): Promise<OfferingWithDetails> {
-    const offerings = await this.findAllByTicker(ticker);
+    const offerings = await this.findAllByAsset(ticker);
     const offering = offerings.find(({ offering: { id: offeringId } }) => offeringId.eq(id));
     if (!offering) {
       throw new AppNotFoundError(id.toString(), `Asset "${ticker}" Offering`);
@@ -31,7 +31,7 @@ export class OfferingsService {
     return offering;
   }
 
-  public async findInvestmentsByTicker(
+  public async findInvestmentsByAsset(
     ticker: string,
     id: BigNumber,
     size: BigNumber,

--- a/src/portfolios/dto/get-transactions.dto.ts
+++ b/src/portfolios/dto/get-transactions.dto.ts
@@ -3,7 +3,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
 
-import { IsTicker } from '~/common/decorators/validation';
+import { IsAsset } from '~/common/decorators/validation';
 
 export class GetTransactionsDto {
   @ApiPropertyOptional({
@@ -19,6 +19,6 @@ export class GetTransactionsDto {
     example: '123',
   })
   @IsOptional()
-  @IsTicker()
-  readonly ticker?: string;
+  @IsAsset()
+  readonly asset?: string;
 }

--- a/src/portfolios/dto/portfolio-movement.dto.ts
+++ b/src/portfolios/dto/portfolio-movement.dto.ts
@@ -5,15 +5,15 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { IsByteLength, IsOptional, IsString, ValidateIf } from 'class-validator';
 
 import { ToBigNumber } from '~/common/decorators/transformation';
-import { IsBigNumber, IsTicker } from '~/common/decorators/validation';
+import { IsAsset, IsBigNumber } from '~/common/decorators/validation';
 
 export class PortfolioMovementDto {
   @ApiProperty({
-    description: 'Ticker of Asset to move',
+    description: 'Asset to move',
     example: 'TICKER',
   })
-  @IsTicker()
-  readonly ticker: string;
+  @IsAsset()
+  readonly asset: string;
 
   @ApiPropertyOptional({
     description: 'Amount of a Fungible Asset to move',

--- a/src/portfolios/porfolios.controller.spec.ts
+++ b/src/portfolios/porfolios.controller.spec.ts
@@ -16,7 +16,7 @@ import { processedTxResult, testValues } from '~/test-utils/consts';
 import { createMockResultSet, MockHistoricSettlement, MockPortfolio } from '~/test-utils/mocks';
 import { MockPortfoliosService } from '~/test-utils/service-mocks';
 
-const { did, signer, txResult } = testValues;
+const { did, signer, txResult, assetId } = testValues;
 
 describe('PortfoliosController', () => {
   let controller: PortfoliosController;
@@ -62,7 +62,7 @@ describe('PortfoliosController', () => {
         signer: '0x6000',
         to: new BigNumber(2),
         from: new BigNumber(0),
-        items: [{ to: '3', ticker: 'TICKER', amount: new BigNumber(100) }],
+        items: [{ to: '3', asset: assetId, amount: new BigNumber(100) }],
       };
 
       const result = await controller.moveAssets({ did: '0x6000' }, params);

--- a/src/portfolios/portfolios.controller.ts
+++ b/src/portfolios/portfolios.controller.ts
@@ -334,9 +334,9 @@ export class PortfoliosController {
   @Get('/identities/:did/portfolios/:id/transactions')
   async getTransactionHistory(
     @Param() { did, id }: PortfolioDto,
-    @Query() { account, ticker }: GetTransactionsDto
+    @Query() { account, asset }: GetTransactionsDto
   ): Promise<ResultsModel<HistoricSettlementModel>> {
-    const data = await this.portfoliosService.getTransactions(did, id, account, ticker);
+    const data = await this.portfoliosService.getTransactions(did, id, account, asset);
 
     const results = data.map(settlement => new HistoricSettlementModel(settlement));
 

--- a/src/portfolios/portfolios.service.spec.ts
+++ b/src/portfolios/portfolios.service.spec.ts
@@ -29,7 +29,7 @@ import {
 } from '~/test-utils/service-mocks';
 import * as transactionsUtilModule from '~/transactions/transactions.util';
 
-const { signer, did } = testValues;
+const { signer, did, assetId } = testValues;
 
 jest.mock('@polymeshassociation/polymesh-sdk/utils', () => ({
   ...jest.requireActual('@polymeshassociation/polymesh-sdk/utils'),
@@ -177,7 +177,7 @@ describe('PortfoliosService', () => {
         from: new BigNumber(0),
         items: [
           {
-            ticker: 'TICKER',
+            asset: assetId,
             amount: new BigNumber(123),
           },
         ],
@@ -195,7 +195,7 @@ describe('PortfoliosService', () => {
           items: [
             {
               amount: new BigNumber(123),
-              asset: 'TICKER',
+              asset: assetId,
               memo: undefined,
             },
           ],

--- a/src/portfolios/portfolios.service.ts
+++ b/src/portfolios/portfolios.service.ts
@@ -66,7 +66,7 @@ export class PortfoliosService {
 
     const formattedArgs = {
       to: toPortfolioId(to),
-      items: items.map(({ ticker: asset, amount, memo, nfts }) => {
+      items: items.map(({ asset, amount, memo, nfts }) => {
         return {
           asset,
           amount,

--- a/src/settlements/dto/asset-leg.dto.ts
+++ b/src/settlements/dto/asset-leg.dto.ts
@@ -3,17 +3,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum } from 'class-validator';
 
-import { IsTicker } from '~/common/decorators/validation';
 import { LegType } from '~/common/types';
 
-export class AssetLegDto {
-  @ApiProperty({
-    description: 'Ticker of the Asset',
-    example: 'TICKER',
-  })
-  @IsTicker()
-  readonly asset: string;
-
+export class AssetLegTypeDto {
   @ApiProperty({
     description: 'Indicator to know if the transfer is on chain or off chain',
     enum: LegType,

--- a/src/settlements/dto/create-instruction.dto.ts
+++ b/src/settlements/dto/create-instruction.dto.ts
@@ -10,11 +10,11 @@ import { ToBigNumber } from '~/common/decorators/transformation';
 import { IsBigNumber, IsDid } from '~/common/decorators/validation';
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 import { LegType } from '~/common/types';
-import { AssetLegDto } from '~/settlements/dto/asset-leg.dto';
+import { AssetLegTypeDto } from '~/settlements/dto/asset-leg.dto';
 import { LegDto } from '~/settlements/dto/leg.dto';
 import { OffChainLegDto } from '~/settlements/dto/offchain-leg.dto';
 
-@ApiExtraModels(LegDto, OffChainLegDto, AssetLegDto)
+@ApiExtraModels(LegDto, OffChainLegDto, AssetLegTypeDto)
 export class CreateInstructionDto extends TransactionBaseDto {
   @ApiPropertyOneOf({
     description: 'Array of legs which can be either LegDto or OffChainLegDto',
@@ -22,7 +22,7 @@ export class CreateInstructionDto extends TransactionBaseDto {
     isArray: true,
   })
   @ValidateNested({ each: true })
-  @Type(() => AssetLegDto, {
+  @Type(() => AssetLegTypeDto, {
     keepDiscriminatorProperty: true,
     discriminator: {
       property: 'type',

--- a/src/settlements/dto/leg-validation-params.dto.ts
+++ b/src/settlements/dto/leg-validation-params.dto.ts
@@ -5,7 +5,7 @@ import { BigNumber } from '@polymeshassociation/polymesh-sdk';
 import { ValidateIf } from 'class-validator';
 
 import { ToBigNumber } from '~/common/decorators/transformation';
-import { IsBigNumber, IsDid, IsTicker } from '~/common/decorators/validation';
+import { IsAsset, IsBigNumber, IsDid } from '~/common/decorators/validation';
 
 export class LegValidationParamsDto {
   @ApiPropertyOptional({
@@ -66,10 +66,10 @@ export class LegValidationParamsDto {
   readonly toPortfolio: BigNumber;
 
   @ApiProperty({
-    description: 'Ticker of the Asset to be transferred',
+    description: 'The Asset (Asset ID/Ticker) to be transferred',
     type: 'string',
-    example: 'TICKER',
+    example: '0x12345678',
   })
-  @IsTicker()
+  @IsAsset()
   readonly asset: string;
 }

--- a/src/settlements/dto/leg.dto.ts
+++ b/src/settlements/dto/leg.dto.ts
@@ -7,13 +7,13 @@ import { Type } from 'class-transformer';
 import { IsEnum, ValidateIf, ValidateNested } from 'class-validator';
 
 import { ToBigNumber } from '~/common/decorators/transformation';
-import { IsBigNumber } from '~/common/decorators/validation';
+import { IsAsset, IsBigNumber } from '~/common/decorators/validation';
 import { AppValidationError } from '~/common/errors';
 import { LegType } from '~/common/types';
 import { PortfolioDto } from '~/portfolios/dto/portfolio.dto';
-import { AssetLegDto } from '~/settlements/dto/asset-leg.dto';
+import { AssetLegTypeDto } from '~/settlements/dto/asset-leg.dto';
 
-export class LegDto extends AssetLegDto {
+export class LegDto extends AssetLegTypeDto {
   @ApiPropertyOptional({
     description: 'Amount of the fungible Asset to be transferred',
     type: 'string',
@@ -57,6 +57,13 @@ export class LegDto extends AssetLegDto {
   @ValidateNested()
   @Type(() => PortfolioDto)
   readonly to: PortfolioDto;
+
+  @ApiProperty({
+    description: 'Asset associated with the leg',
+    example: '0xa3616b82e8e1080aedc952ea28b9db8b',
+  })
+  @IsAsset()
+  readonly asset: string;
 
   @ApiProperty({ enum: LegType, default: LegType.onChain })
   @IsEnum(LegType)

--- a/src/settlements/dto/offchain-leg.dto.ts
+++ b/src/settlements/dto/offchain-leg.dto.ts
@@ -6,11 +6,11 @@ import { InstructionOffChainLeg } from '@polymeshassociation/polymesh-sdk/types'
 import { IsEnum } from 'class-validator';
 
 import { ToBigNumber } from '~/common/decorators/transformation';
-import { IsBigNumber, IsDid } from '~/common/decorators/validation';
+import { IsBigNumber, IsDid, IsTicker } from '~/common/decorators/validation';
 import { LegType } from '~/common/types';
-import { AssetLegDto } from '~/settlements/dto/asset-leg.dto';
+import { AssetLegTypeDto } from '~/settlements/dto/asset-leg.dto';
 
-export class OffChainLegDto extends AssetLegDto {
+export class OffChainLegDto extends AssetLegTypeDto {
   @ApiProperty({
     description: 'DID of the sender',
     type: 'string',
@@ -39,6 +39,13 @@ export class OffChainLegDto extends AssetLegDto {
   @ApiProperty({ enum: LegType, default: LegType.offChain })
   @IsEnum(LegType)
   readonly type = LegType.offChain;
+
+  @ApiProperty({
+    description: 'Ticker of the off chain Asset',
+    example: 'OFF_CHAIN',
+  })
+  @IsTicker()
+  readonly asset: string;
 
   public toLeg(): InstructionOffChainLeg {
     const { from, to, asset, offChainAmount } = this;

--- a/src/test-utils/consts.ts
+++ b/src/test-utils/consts.ts
@@ -118,7 +118,7 @@ export const extrinsic = {
   extrinsicIdx: new BigNumber(1),
   address: 'someAccount',
   nonce: new BigNumber(123456),
-  txTag: TxTags.asset.RegisterTicker,
+  txTag: TxTags.asset.RegisterUniqueTicker,
   params: [
     {
       name: 'ticker',

--- a/src/test-utils/mocks.ts
+++ b/src/test-utils/mocks.ts
@@ -342,7 +342,7 @@ export class MockPortfolio {
 
 export class MockCheckpoint {
   id = new BigNumber(1);
-  ticker = 'TICKER';
+  assetId = testValues.assetId;
   balance = jest.fn();
   allBalances = jest.fn();
   createdAt = jest.fn();
@@ -351,7 +351,7 @@ export class MockCheckpoint {
 
 export class MockCheckpointSchedule {
   id = new BigNumber(1);
-  ticker = 'TICKER';
+  assetId = testValues.assetId;
   pendingPoints = [new Date('10/14/1987')];
   expiryDate = new Date('10/14/2000');
   getCheckpoints = jest.fn();
@@ -432,13 +432,13 @@ class MockPolymeshTransactionBase {
   onStatusChange = jest.fn();
 }
 export class MockPolymeshTransaction extends MockPolymeshTransactionBase {
-  tag: TxTag = TxTags.asset.RegisterTicker;
+  tag: TxTag = TxTags.asset.RegisterUniqueTicker;
 }
 
 export class MockPolymeshTransactionBatch extends MockPolymeshTransactionBase {
   transactions: { tag: TxTag }[] = [
     {
-      tag: TxTags.asset.RegisterTicker,
+      tag: TxTags.asset.RegisterUniqueTicker,
     },
     {
       tag: TxTags.asset.CreateAsset,

--- a/src/test-utils/service-mocks.ts
+++ b/src/test-utils/service-mocks.ts
@@ -29,7 +29,7 @@ export class MockAssetService {
   findDocuments = jest.fn();
   setDocuments = jest.fn();
   findAllByOwner = jest.fn();
-  registerTicker = jest.fn();
+  RegisterUniqueTicker = jest.fn();
   createAsset = jest.fn();
   issue = jest.fn();
   transferOwnership = jest.fn();
@@ -148,7 +148,7 @@ export class MockIdentitiesService {
   registerDid = jest.fn();
   rotatePrimaryKey = jest.fn();
   attestPrimaryKeyRotation = jest.fn();
-  isTickerPreApproved = jest.fn();
+  isAssetPreApproved = jest.fn();
   getPreApprovedAssets = jest.fn();
 }
 
@@ -195,14 +195,14 @@ export class MockPortfoliosService {
 }
 
 export class MockOfferingsService {
-  findInvestmentsByTicker = jest.fn();
-  findAllByTicker = jest.fn();
+  findInvestmentsByAsset = jest.fn();
+  findAllByAsset = jest.fn();
 }
 
 export class MockCorporateActionsService {
-  findDefaultConfigByTicker = jest.fn();
-  updateDefaultConfigByTicker = jest.fn();
-  findDistributionsByTicker = jest.fn();
+  findDefaultConfigByAsset = jest.fn();
+  updateDefaultConfigByAsset = jest.fn();
+  findDistributionsByAsset = jest.fn();
   findDistribution = jest.fn();
   createDividendDistribution = jest.fn();
   remove = jest.fn();
@@ -214,14 +214,14 @@ export class MockCorporateActionsService {
 }
 
 export class MockCheckpointsService {
-  findAllByTicker = jest.fn();
-  findSchedulesByTicker = jest.fn();
+  findAllByAsset = jest.fn();
+  findSchedulesByAsset = jest.fn();
   findScheduleById = jest.fn();
-  createByTicker = jest.fn();
-  createScheduleByTicker = jest.fn();
+  createByAsset = jest.fn();
+  createScheduleByAsset = jest.fn();
   getAssetBalance = jest.fn();
   getHolders = jest.fn();
-  deleteScheduleByTicker = jest.fn();
+  deleteScheduleByAsset = jest.fn();
   findOne = jest.fn();
   findCheckpointsByScheduleId = jest.fn();
   getComplexityForAsset = jest.fn();

--- a/src/ticker-reservations/ticker-reservations.service.spec.ts
+++ b/src/ticker-reservations/ticker-reservations.service.spec.ts
@@ -78,7 +78,7 @@ describe('TickerReservationsService', () => {
         blockHash: '0x1',
         txHash: '0x2',
         blockNumber: new BigNumber(1),
-        tag: TxTags.asset.RegisterTicker,
+        tag: TxTags.asset.RegisterUniqueTicker,
       };
       const mockResult = new MockTickerReservation();
 
@@ -150,7 +150,7 @@ describe('TickerReservationsService', () => {
         blockHash: '0x1',
         txHash: '0x2',
         blockNumber: new BigNumber(1),
-        tag: TxTags.asset.RegisterTicker,
+        tag: TxTags.asset.RegisterUniqueTicker,
       };
 
       const findOneSpy = jest.spyOn(service, 'findOne');

--- a/src/transactions/transactions.service.spec.ts
+++ b/src/transactions/transactions.service.spec.ts
@@ -147,7 +147,7 @@ describe('TransactionsService', () => {
           blockHash: undefined,
           blockNumber: undefined,
           transactionHash: undefined,
-          transactionTag: TxTags.asset.RegisterTicker,
+          transactionTag: TxTags.asset.RegisterUniqueTicker,
           type: TransactionType.Single,
         },
       ]);
@@ -171,7 +171,7 @@ describe('TransactionsService', () => {
           blockHash: undefined,
           blockNumber: undefined,
           transactionHash: undefined,
-          transactionTags: [TxTags.asset.RegisterTicker, TxTags.asset.CreateAsset],
+          transactionTags: [TxTags.asset.RegisterUniqueTicker, TxTags.asset.CreateAsset],
           type: TransactionType.Batch,
         },
       ]);
@@ -306,7 +306,7 @@ describe('TransactionsService', () => {
 
       const expectedPayload = {
         type: TransactionType.Single,
-        transactionTag: TxTags.asset.RegisterTicker,
+        transactionTag: TxTags.asset.RegisterUniqueTicker,
         status: TransactionStatus.Unapproved,
       };
       expect(result).toEqual({
@@ -395,7 +395,7 @@ describe('TransactionsService', () => {
         nonce: 0,
         payload: {
           type: TransactionType.Batch,
-          transactionTags: [TxTags.asset.RegisterTicker, TxTags.asset.CreateAsset],
+          transactionTags: [TxTags.asset.RegisterUniqueTicker, TxTags.asset.CreateAsset],
           status: TransactionStatus.Unapproved,
         },
       });
@@ -415,7 +415,7 @@ describe('TransactionsService', () => {
         scope: eventScope,
         payload: {
           type: TransactionType.Batch,
-          transactionTags: [TxTags.asset.RegisterTicker, TxTags.asset.CreateAsset],
+          transactionTags: [TxTags.asset.RegisterUniqueTicker, TxTags.asset.CreateAsset],
           status: TransactionStatus.Failed,
           transactionHash,
           blockHash,
@@ -470,7 +470,7 @@ describe('TransactionsService', () => {
         nonce: 0,
         payload: {
           type: TransactionType.Batch,
-          transactionTags: [TxTags.asset.RegisterTicker, TxTags.asset.CreateAsset],
+          transactionTags: [TxTags.asset.RegisterUniqueTicker, TxTags.asset.CreateAsset],
           status: TransactionStatus.Unapproved,
         },
       });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -36,7 +36,7 @@ describe('AppController (e2e)', () => {
     await Promise.all([app.close(), polymeshService.close()]);
   });
 
-  describe('/tokens/:ticker (GET)', () => {
+  describe('/assets/:asset (GET)', () => {
     describe('if the token exists', () => {
       it('should return token details', () => {
         return request(app.getHttpServer()).get('/tokens/JERE02').expect(HttpStatus.OK).expect({
@@ -52,7 +52,7 @@ describe('AppController (e2e)', () => {
     describe('if the ticker is too long', () => {
       it('should return a Bad Request error', () => {
         return request(app.getHttpServer())
-          .get('/tokens/JERE023465565435433566')
+          .get('/assets/JERE023465565435433566')
           .expect(HttpStatus.BAD_REQUEST)
           .expect({
             statusCode: 400,
@@ -64,7 +64,7 @@ describe('AppController (e2e)', () => {
     describe('otherwise', () => {
       it('should return a Not Found error', () => {
         return request(app.getHttpServer())
-          .get('/tokens/JERE9999')
+          .get('/assets/JERE9999')
           .expect(HttpStatus.NOT_FOUND)
           .expect({
             statusCode: HttpStatus.NOT_FOUND,
@@ -75,7 +75,7 @@ describe('AppController (e2e)', () => {
     });
   });
 
-  describe('/identities/:did/tokens (GET)', () => {
+  describe('/identities/:did/assets (GET)', () => {
     describe('if the did is not a 66 digit hex value', () => {
       it('should return a Bad Request error', () => {
         return request(app.getHttpServer())
@@ -96,7 +96,7 @@ describe('AppController (e2e)', () => {
       it("should return a list of the Identity's tokens", () => {
         return request(app.getHttpServer())
           .get(
-            '/identities/0x0600000000000000000000000000000000000000000000000000000000000000/tokens'
+            '/identities/0x0600000000000000000000000000000000000000000000000000000000000000/assets'
           )
           .expect(HttpStatus.OK)
           .expect({
@@ -179,7 +179,7 @@ describe('AppController (e2e)', () => {
           .get('/instructions/911')
           .expect(HttpStatus.OK)
           .expect({
-            status: InstructionStatus.Executed,
+            status: InstructionStatus.Success,
             eventIdentifier: {
               blockNumber: '2719172',
               blockDate: '2021-06-26T01:47:45.000Z',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,10 +1954,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.3.0"
 
-"@polymeshassociation/polymesh-sdk@26.0.0-alpha.2":
-  version "26.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-26.0.0-alpha.2.tgz#6ede875b7b661204f3c4cd1caac65297f19db356"
-  integrity sha512-xu1YEX5MDLpJSmeO0jkp3dzrdndKbVKZYho0jl4GppoQ5P4rkPPqE+1U5HBoUNib/iLFdeA23e4lvX4JDZdiEQ==
+"@polymeshassociation/polymesh-sdk@26.0.0-beta.1":
+  version "26.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-26.0.0-beta.1.tgz#930c87fd6eeb5ce0610f3088f11b9d3ebdaf0eff"
+  integrity sha512-4SXB4q78EOdl8/5GJFl1WScoCLSDVs2Db8Vv+HDLR3EJqMX598WFafH9Air4/+lBEQmxGJZtCSgdclu0XMYzoA==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "11.2.1"


### PR DESCRIPTION
### JIRA Link 

DA-1301

### Changelog / Description 

Adds support for Asset IDs
- All the asset related endpoints (starting with `assets/` or associated
with `assets` tag) now also accept asset ID as permissible value along with ticker for
the corresponding path param from 7.x chain.
- The `ticker` property of `CheckpointScheduleModel` has been renamed to `asset`.
- The query param `ticker` has been renamed to `asset` for the endpoint
GET `portfolios/identities/:did/portfolios/:id/transactions`.
- The property `ticker` has been renamed to `asset` in `PortfolioMovementDto`.
This affects the endpoint POST `portfolios/identities/:did/portfolios/move-assets`.
- The endpoint POST `settlements/instructions/create` now accepts asset ID as well
for on chain legs, as possible value for `asset` body params.
- The endpoint GET `settlements/leg-validations` now accepts asset ID as well,
as possible value for `asset` body param from 7.x chain.
- The `asset` property of `CorporateActionModel`, `PreApprovedModel`,
`MetadataEntryModel` now return asset ID values from 7.x chain.

### Checklist - 

- [x] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [x] Unit Test (if possible) ?
- [x] Updated the Readme.md (if required) ?
