### PR TITLE
feat: 🎸 support customClaim withouth scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@polymeshassociation/fireblocks-signing-manager": "^2.5.0",
     "@polymeshassociation/hashicorp-vault-signing-manager": "^3.4.0",
     "@polymeshassociation/local-signing-manager": "^3.3.0",
-    "@polymeshassociation/polymesh-sdk": "^26.1.0",
+    "@polymeshassociation/polymesh-sdk": "^26.2.0-alpha.1",
     "@polymeshassociation/signing-manager-types": "^3.2.0",
     "class-transformer": "0.5.1",
     "class-validator": "^0.14.0",

--- a/src/claims/dto/claim.dto.spec.ts
+++ b/src/claims/dto/claim.dto.spec.ts
@@ -102,6 +102,13 @@ describe('claimsDto', () => {
           customClaimTypeId: new BigNumber('1'),
         },
       ],
+      [
+        'Custom claim with `customClaimTypeId` and no `scope`',
+        {
+          type: ClaimType.Custom,
+          customClaimTypeId: new BigNumber('1'),
+        },
+      ],
     ];
     test.each(cases)('%s', async (_, input) => {
       await target.transform(input, metadata).catch(err => {
@@ -174,6 +181,15 @@ describe('claimsDto', () => {
         [
           'trustedClaimIssuers.0.each value in trustedFor must be one of the following values: Accredited, Affiliate, BuyLockup, SellLockup, CustomerDueDiligence, KnowYourCustomer, Jurisdiction, Exempted, Blocked, Custom',
         ],
+      ],
+      [
+        'Custom with empty `scope`',
+        {
+          type: ClaimType.Custom,
+          scope: {},
+          customClaimTypeId: new BigNumber('1'),
+        },
+        ['scope.type must be one of the following values: Identity, Ticker, Asset, Custom'],
       ],
     ];
     test.each(cases)('%s', async (_, input, expected) => {

--- a/src/claims/dto/claim.dto.ts
+++ b/src/claims/dto/claim.dto.ts
@@ -26,7 +26,9 @@ export class ClaimDto {
       'The scope of the Claim. Required for most types except for `CustomerDueDiligence`, `InvestorUniquenessV2` and `NoData`',
     type: ScopeDto,
   })
-  @ValidateIf(claim => !isCddClaim(claim))
+  @ValidateIf(
+    claim => !isCddClaim(claim) && !(claim.type === ClaimType.Custom && claim.scope === undefined)
+  )
   @ValidateNested()
   @Type(() => ScopeDto)
   @IsNotEmptyObject()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,10 +1954,10 @@
   dependencies:
     "@polymeshassociation/signing-manager-types" "^3.3.0"
 
-"@polymeshassociation/polymesh-sdk@^26.1.0":
-  version "26.1.0"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-26.1.0.tgz#88584cf89af98fd7eb722ec8d6ce3c2b5d557240"
-  integrity sha512-0I6/CwAFxE67Rb8JenEiHnzZObTou4dKpnR4esQZpiRh+DLnzrplk1OMihfccsTFISVYGGf2OdYiNGasGuaMSw==
+"@polymeshassociation/polymesh-sdk@^26.2.0-alpha.1":
+  version "26.2.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-sdk/-/polymesh-sdk-26.2.0-alpha.1.tgz#227ed72deea0f7137c5d584d85a4b235d380f65c"
+  integrity sha512-zUpDRNZGKagQ38N1avGoo54tCX89lShcqTY2Ez5OCN7F3CA7eKDPhRoO+3DQmXIPmHrHu22BB19Z5M+hfeAVlQ==
   dependencies:
     "@apollo/client" "^3.8.1"
     "@polkadot/api" "11.2.1"


### PR DESCRIPTION
### JIRA Link 

https://polymesh.atlassian.net/browse/DA-1208

### Changelog / Description 

- updates sdk to 26.2.0-alpha.1
- update logic to allow for CustomClaim to be without scope defined
- uses latest SDK to allow to retrieve CustomClaim scopes for did if middleware is enabled

### Checklist - 

- [x] New Feature ?
- [x] Unit Test (if possible) ?
