### PR TITLE
Fix validations

### DIFF
--- a/src/accounts/models/asset-permissions.model.ts
+++ b/src/accounts/models/asset-permissions.model.ts
@@ -9,7 +9,7 @@ export class AssetPermissionsModel extends PermissionTypeModel {
     description: 'List of included/excluded Assets',
     type: 'string',
     isArray: true,
-    example: ['TICKER123456'],
+    example: ['3616b82e-8e10-80ae-dc95-2ea28b9db8b3'],
   })
   readonly values: string[];
 

--- a/src/assets/dto/create-asset.dto.ts
+++ b/src/assets/dto/create-asset.dto.ts
@@ -59,6 +59,7 @@ export class CreateAssetDto extends TransactionBaseDto {
     isArray: true,
     type: SecurityIdentifierDto,
   })
+  @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => SecurityIdentifierDto)
   readonly securityIdentifiers?: SecurityIdentifierDto[];

--- a/src/claims/decorators/validation.ts
+++ b/src/claims/decorators/validation.ts
@@ -75,7 +75,7 @@ export function IsValidScopeValue(property: string, validationOptions?: Validati
           const scopeType = (args.object as any)[scopeTypeField];
           switch (scopeType) {
             case ScopeType.Asset:
-              return 'value must be a valid Asset ID either in hex or UUID format';
+              return 'value must be a valid Asset ID (either in hex or UUID format) or a valid ticker (all uppercase and no longer than 12 characters)';
             case ScopeType.Ticker:
               return `value must be all uppercase and no longer than 12 characters for type: ${scopeType}`;
             case ScopeType.Identity:

--- a/src/claims/decorators/validation.ts
+++ b/src/claims/decorators/validation.ts
@@ -6,19 +6,17 @@ import { ScopeType } from '@polymeshassociation/polymesh-sdk/types';
 import {
   IsHexadecimal,
   isHexadecimal,
-  isUppercase,
   Length,
   length,
   Matches,
   matches,
-  maxLength,
   registerDecorator,
   ValidationArguments,
   ValidationOptions,
 } from 'class-validator';
 import { isString } from 'lodash';
 
-import { MAX_TICKER_LENGTH } from '~/assets/assets.consts';
+import { isAssetId, isTicker } from '~/common/decorators';
 import { CDD_ID_LENGTH, DID_LENGTH } from '~/identities/identities.consts';
 
 export function IsCddId() {
@@ -54,8 +52,10 @@ export function IsValidScopeValue(property: string, validationOptions?: Validati
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const scopeType = (args.object as any)[scopeTypeField];
           switch (scopeType) {
+            case ScopeType.Asset:
+              return isString(value) && (isAssetId(value) || isTicker(value));
             case ScopeType.Ticker:
-              return maxLength(value, MAX_TICKER_LENGTH) && isUppercase(value);
+              return isString(value) && isTicker(value);
             case ScopeType.Identity:
               return (
                 isHexadecimal(value) &&
@@ -74,6 +74,8 @@ export function IsValidScopeValue(property: string, validationOptions?: Validati
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const scopeType = (args.object as any)[scopeTypeField];
           switch (scopeType) {
+            case ScopeType.Asset:
+              return 'value must be a valid Asset ID either in hex or UUID format';
             case ScopeType.Ticker:
               return `value must be all uppercase and no longer than 12 characters for type: ${scopeType}`;
             case ScopeType.Identity:

--- a/src/common/decorators/validation.ts
+++ b/src/common/decorators/validation.ts
@@ -7,9 +7,11 @@ import { isHexUuid, isUuid } from '@polymeshassociation/polymesh-sdk/utils';
 import {
   IsHexadecimal,
   IsUppercase,
+  isUppercase,
   Length,
   Matches,
   MaxLength,
+  maxLength,
   registerDecorator,
   ValidationArguments,
   ValidationOptions,
@@ -47,6 +49,10 @@ export const isAssetId = (id: string): boolean => {
   return isHexUuid(id) || isUuid(id);
 };
 
+export const isTicker = (ticker: string): boolean => {
+  return maxLength(ticker, MAX_TICKER_LENGTH) && isUppercase(ticker);
+};
+
 export function IsAsset(validationOptions?: ValidationOptions) {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return function (object: Object, propertyName: string) {
@@ -57,9 +63,7 @@ export function IsAsset(validationOptions?: ValidationOptions) {
       options: validationOptions,
       validator: {
         validate(value: string) {
-          return (
-            isAssetId(value) || (value.length <= MAX_TICKER_LENGTH && value === value.toUpperCase())
-          );
+          return isAssetId(value) || isTicker(value);
         },
         defaultMessage(args: ValidationArguments) {
           return `${args.property} must be either a Ticker (${MAX_TICKER_LENGTH} characters uppercase string) or an Asset ID (${ASSET_ID_LENGTH} characters long hex string)`;

--- a/src/compliance/dto/condition.dto.ts
+++ b/src/compliance/dto/condition.dto.ts
@@ -7,7 +7,14 @@ import {
   isSingleClaimCondition,
 } from '@polymeshassociation/polymesh-sdk/utils';
 import { Type } from 'class-transformer';
-import { IsEnum, IsNotEmpty, IsNotEmptyObject, ValidateIf, ValidateNested } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNotEmptyObject,
+  IsOptional,
+  ValidateIf,
+  ValidateNested,
+} from 'class-validator';
 
 import { ClaimDto } from '~/claims/dto/claim.dto';
 import { IsDid } from '~/common/decorators/validation';
@@ -38,6 +45,7 @@ export class ConditionDto {
   })
   @ValidateNested({ each: true })
   @Type(() => TrustedClaimIssuerDto)
+  @IsOptional()
   readonly trustedClaimIssuers?: TrustedClaimIssuerDto[];
 
   @ApiPropertyOptional({

--- a/src/compliance/dto/set-requirements.dto.ts
+++ b/src/compliance/dto/set-requirements.dto.ts
@@ -30,8 +30,8 @@ export class SetRequirementsDto extends TransactionBaseDto {
             {
               type: 'Jurisdiction',
               scope: {
-                type: 'Ticker',
-                value: 'TICKER',
+                type: 'Asset',
+                value: '3616b82e-8e10-80ae-dc95-2ea28b9db8b3',
               },
               code: CountryCode.Us,
             },
@@ -51,8 +51,8 @@ export class SetRequirementsDto extends TransactionBaseDto {
           claim: {
             type: 'Accredited',
             scope: {
-              type: 'Ticker',
-              value: 'TICKER',
+              type: 'Asset',
+              value: '3616b82e-8e10-80ae-dc95-2ea28b9db8b3',
             },
           },
         },

--- a/src/identities/dto/asset-permissions.dto.ts
+++ b/src/identities/dto/asset-permissions.dto.ts
@@ -12,7 +12,7 @@ export class AssetPermissionsDto extends PermissionTypeDto {
     description: 'List of assets to be included or excluded in the permissions',
     type: 'string',
     isArray: true,
-    example: ['TICKER123456'],
+    example: ['3616b82e-8e10-80ae-dc95-2ea28b9db8b3'],
   })
   @IsArray()
   @IsAsset({ each: true })

--- a/src/nfts/dto/create-nft-collection.dto.ts
+++ b/src/nfts/dto/create-nft-collection.dto.ts
@@ -40,6 +40,7 @@ export class CreateNftCollectionDto extends TransactionBaseDto {
     isArray: true,
     type: SecurityIdentifierDto,
   })
+  @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => SecurityIdentifierDto)
   readonly securityIdentifiers?: SecurityIdentifierDto[];

--- a/src/portfolios/dto/portfolio-movement.dto.ts
+++ b/src/portfolios/dto/portfolio-movement.dto.ts
@@ -10,7 +10,7 @@ import { IsAsset, IsBigNumber } from '~/common/decorators/validation';
 export class PortfolioMovementDto {
   @ApiProperty({
     description: 'Asset to move',
-    example: 'TICKER',
+    example: '3616b82e-8e10-80ae-dc95-2ea28b9db8b3',
   })
   @IsAsset()
   readonly asset: string;

--- a/src/settlements/dto/create-venue.dto.ts
+++ b/src/settlements/dto/create-venue.dto.ts
@@ -1,8 +1,7 @@
 /* istanbul ignore file */
-
 import { ApiProperty } from '@nestjs/swagger';
 import { VenueType } from '@polymeshassociation/polymesh-sdk/types';
-import { IsEnum, IsString } from 'class-validator';
+import { IsArray, IsEnum, IsOptional, IsString } from 'class-validator';
 
 import { TransactionBaseDto } from '~/common/dto/transaction-base-dto';
 
@@ -29,6 +28,8 @@ export class CreateVenueDto extends TransactionBaseDto {
     isArray: true,
     example: ['5GwwYnwCYcJ1Rkop35y7SDHAzbxrCkNUDD4YuCUJRPPXbvyV'],
   })
+  @IsOptional()
+  @IsArray()
   @IsString({ each: true })
   readonly signers?: string[];
 }

--- a/src/settlements/dto/leg-validation-params.dto.ts
+++ b/src/settlements/dto/leg-validation-params.dto.ts
@@ -68,7 +68,7 @@ export class LegValidationParamsDto {
   @ApiProperty({
     description: 'The Asset (Asset ID/Ticker) to be transferred',
     type: 'string',
-    example: '0x12345678',
+    example: '3616b82e-8e10-80ae-dc95-2ea28b9db8b3',
   })
   @IsAsset()
   readonly asset: string;


### PR DESCRIPTION
### JIRA Link 

DA-1399

### Changelog / Description 

-  Add missing `IsOptional` to `CreateVenueDto.signers`. Without the `IsOptional` annotation, creating a venue without signers was not posssible. Adding it, allows the functionality to work as expected
- Fix validations for `ScopeType.Asset` in `ScopeDto` . `ScopeDto` was allowing all values of asset ID to pass when `type` was set to `ScopeType.Asset`. This adds in check for it to be a valid Asset ID
- Update swagger examples to display asset IDs
- Add missing `IsOptional` to `securityIdentifiers` in `CreateAssetDto` and `CreateNftCollectionDto`

### Checklist - 

- [ ] New Feature ?
- [x] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
