### PR TITLE
fix: 🐛 Add missing support for NFT collection in UUID format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-rest-api",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Provides a REST like interface for interacting with the Polymesh blockchain",
   "author": "Polymesh Association",
   "private": true,

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -71,9 +71,21 @@ describe('AssetsService', () => {
     it('should return the Asset for a valid ticker', async () => {
       const mockAsset = new MockAsset();
 
-      mockPolymeshApi.assets.getAsset.mockResolvedValue(mockAsset);
+      when(mockPolymeshApi.assets.getAsset)
+        .calledWith({ ticker: 'TICKER' })
+        .mockResolvedValue(mockAsset);
 
       const result = await service.findOne('TICKER');
+
+      expect(result).toEqual(mockAsset);
+    });
+
+    it('should return the Asset for a valid Asset ID', async () => {
+      const mockAsset = new MockAsset();
+
+      when(mockPolymeshApi.assets.getAsset).calledWith({ assetId }).mockResolvedValue(mockAsset);
+
+      const result = await service.findOne(assetId);
 
       expect(result).toEqual(mockAsset);
     });

--- a/src/nfts/models/nft.model.ts
+++ b/src/nfts/models/nft.model.ts
@@ -16,9 +16,9 @@ export class NftModel {
   readonly id: BigNumber;
 
   @ApiProperty({
-    description: 'The collection ticker of which the NFT belongs to',
+    description: 'The collection (Ticker/Asset ID) of which the NFT belongs to',
   })
-  readonly ticker: string;
+  readonly collection: string;
 
   @ApiProperty({
     description: 'The metadata associated to the NFT',

--- a/src/nfts/nfts.service.spec.ts
+++ b/src/nfts/nfts.service.spec.ts
@@ -8,6 +8,7 @@ import {
   NftCollection,
   TxTags,
 } from '@polymeshassociation/polymesh-sdk/types';
+import { when } from 'jest-when';
 
 import { NftsService } from '~/nfts/nfts.service';
 import { POLYMESH_API } from '~/polymesh/polymesh.consts';
@@ -55,20 +56,22 @@ describe('NftService', () => {
   describe('findCollection', () => {
     it('should return the collection for a valid ticker', async () => {
       const collection = createMock<NftCollection>();
-      mockPolymeshApi.assets.getNftCollection.mockResolvedValue(collection);
+      when(mockPolymeshApi.assets.getNftCollection)
+        .calledWith({ ticker })
+        .mockResolvedValue(collection);
 
       const result = await service.findCollection(ticker);
 
       expect(result).toEqual(collection);
     });
-  });
 
-  describe('findCollection', () => {
-    it('should return the collection for a valid ticker', async () => {
+    it('should return the collection for a valid collection ID', async () => {
       const collection = createMock<NftCollection>();
-      mockPolymeshApi.assets.getNftCollection.mockResolvedValue(collection);
+      when(mockPolymeshApi.assets.getNftCollection)
+        .calledWith({ assetId })
+        .mockResolvedValue(collection);
 
-      const result = await service.findCollection(ticker);
+      const result = await service.findCollection(assetId);
 
       expect(result).toEqual(collection);
     });
@@ -88,13 +91,13 @@ describe('NftService', () => {
   });
 
   describe('findNft', () => {
-    it('should return the NFT for a valid ticker and id', async () => {
+    it('should return the NFT for a valid collection and id', async () => {
       const collection = createMock<NftCollection>();
       const nft = createMock<Nft>();
       mockPolymeshApi.assets.getNftCollection.mockResolvedValue(collection);
       collection.getNft.mockResolvedValue(nft);
 
-      const result = await service.findNft(ticker, id);
+      const result = await service.findNft(assetId, id);
 
       expect(result).toEqual(nft);
     });
@@ -110,7 +113,7 @@ describe('NftService', () => {
 
       const handleSdkErrorSpy = jest.spyOn(transactionsUtilModule, 'handleSdkError');
 
-      await expect(() => service.findNft(ticker, id)).rejects.toThrowError();
+      await expect(() => service.findNft(assetId, id)).rejects.toThrowError();
 
       expect(handleSdkErrorSpy).toHaveBeenCalledWith(mockError);
     });
@@ -128,10 +131,10 @@ describe('NftService', () => {
       const findNftSpy = jest.spyOn(service, 'findNft');
       findNftSpy.mockResolvedValue(nft);
 
-      const result = await service.nftDetails(ticker, id);
+      const result = await service.nftDetails(assetId, id);
       expect(result).toEqual({
         id,
-        ticker,
+        collection: assetId,
         imageUri,
         tokenUri,
         metadata: [],
@@ -158,7 +161,7 @@ describe('NftService', () => {
 
       collection.collectionKeys.mockResolvedValue(mockMetadata);
 
-      const result = await service.getCollectionKeys(ticker);
+      const result = await service.getCollectionKeys(assetId);
 
       expect(result).toEqual(
         expect.arrayContaining([
@@ -223,7 +226,7 @@ describe('NftService', () => {
         transactions: [mockTransaction],
       });
 
-      const result = await service.issueNft(ticker, input);
+      const result = await service.issueNft(assetId, input);
 
       expect(result).toEqual({
         result: mockNft,
@@ -254,7 +257,7 @@ describe('NftService', () => {
         transactions: [mockTransaction],
       });
 
-      const result = await service.redeemNft(ticker, id, input);
+      const result = await service.redeemNft(assetId, id, input);
 
       expect(result).toEqual({
         result: undefined,


### PR DESCRIPTION
### JIRA Link 

Insert JIRA url here  

### Changelog / Description 

While getting nft collection from SDK, REST API service was always expecting ticker to be passed. This PR fixes the logic there. 

BREAKING CHANGE: 🧨 `ticker` field in `NftModel` has been renamed to `collection`

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
