### PR TITLE
fix: 🐛 corepack permission issues

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v*
-  release:
-    type: [published]
 
 jobs:
   push_to_registry:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,18 @@ RUN apk add --no-cache \
 
 WORKDIR /app/builder
 RUN chown -R node: /app
+RUN corepack enable
 
 USER node
 
 COPY --chown=node:node . .
 
-RUN corepack enable && \
-    yarn install \
-    --ignore-scripts \
+ENV YARN_ENABLE_SCRIPTS=false
+
+RUN yarn install \
     --immutable \
-    --no-progress && \
+    --inline-builds \
+    --mode=skip-build && \
     yarn build && \
     yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")') && \
     rm -r /home/node/.cache/


### PR DESCRIPTION
### Changelog / Description 

- Run corepack enable before dropping privileges so Yarn can create its shims without hitting permission errors.
- Keep the build stages running as the node user once that setup is complete.
- Set YARN_ENABLE_SCRIPTS=false to replace the old --ignore-scripts flag removed in Yarn 4.
- Switch yarn install to use Yarn 4–compatible flags (--immutable, --inline-builds, --mode=skip-build) 

