### PR TITLE
fix: 🐛 do not run resolver in dryRun

### DIFF
--- a/src/common/utils/functions.ts
+++ b/src/common/utils/functions.ts
@@ -86,6 +86,14 @@ export const handleServiceResult = <T>(
     if (result.resultType === ResultType.MultiSigProposal) {
       return multiSigProposalResolver(result);
     } else {
+      // Skip resolver in dry run mode
+      if (result.isDryRun) {
+        return new TransactionQueueModel({
+          transactions: result.transactions,
+          details: result.details,
+        });
+      }
+
       return resolver(result);
     }
   }

--- a/src/transactions/transactions.util.ts
+++ b/src/transactions/transactions.util.ts
@@ -48,6 +48,7 @@ export interface MultiSigProposalResult {
   resultType: ResultType.MultiSigProposal;
   transactions: (TransactionModel | BatchTransactionModel)[];
   details: TransactionDetails;
+  isDryRun?: boolean;
 }
 
 export type DirectTransactionResult<T> = {
@@ -55,6 +56,7 @@ export type DirectTransactionResult<T> = {
   resultType: ResultType.Direct;
   transactions: (TransactionModel | BatchTransactionModel)[];
   details: TransactionDetails;
+  isDryRun?: boolean;
 };
 
 export type TransactionResult<T> = DirectTransactionResult<T> | MultiSigProposalResult;
@@ -132,6 +134,7 @@ export async function processTransaction<
           result: { toHuman: () => ({ multiSigAddress, id: '-1' }) } as unknown as MultiSigProposal,
           resultType: ResultType.MultiSigProposal,
           transactions: [],
+          isDryRun: true,
         };
       } else {
         return {
@@ -139,6 +142,7 @@ export async function processTransaction<
           result: {} as TransformedReturnType,
           resultType: ResultType.Direct,
           transactions: [],
+          isDryRun: true,
         };
       }
     }


### PR DESCRIPTION
### JIRA Link 

https://polymesh.atlassian.net/browse/DA-1561

### Changelog / Description 

- fixes an issue when in dryRun controller method tries to run the resolver and causes a 500 error due to the entity not created

### Checklist - 

- [ ] New Feature ?
- [ ] Updated swagger annotation (if API structure is changed) ?
- [ ] Unit Test (if possible) ?
- [ ] Updated the Readme.md (if required) ?
